### PR TITLE
BUG: parallel read_csv raised on huge ints with dtype_backend="pyarrow" (GH#66259)

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -59,6 +59,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     pandas_dtype,
 )
+from pandas.core.dtypes.dtypes import ArrowDtype
 from pandas.core.dtypes.inference import is_file_like
 
 from pandas import Series
@@ -354,11 +355,14 @@ def _read(
             assert isinstance(_filepath, str)  # guaranteed by _can_parallelize_csv
             try:
                 result = _read_csv_parallel(_filepath, kwds, _n_workers)
-            except (ParserError, UnicodeDecodeError):
+            except (ParserError, UnicodeDecodeError, OverflowError):
                 # e.g. a chunk boundary landed inside a quoted field containing
-                # an embedded newline.  The serial path below handles anything
-                # the parallel path cannot.  Other exceptions propagate: they
-                # signal a parallel-path bug, not ineligible input.
+                # an embedded newline, or a chunk of only huge ints converted
+                # where the mixed whole-file column would have stayed a string
+                # (GH#66259).  The serial path below handles anything the
+                # parallel path cannot -- and raises in turn if it too fails.
+                # Other exceptions propagate: they signal a parallel-path bug,
+                # not ineligible input.
                 result = None
             if result is not None:
                 return result
@@ -734,7 +738,7 @@ def _read_csv_parallel(
     warning_sink: list[tuple[str, type[Warning]]] = []
     try:
         result = _read_csv_chunks(filepath, kwds, n_workers, warning_sink)
-    except (ParserError, UnicodeDecodeError):
+    except (ParserError, UnicodeDecodeError, OverflowError):
         # The caller answers these with a serial read of the whole file.
         raise
     except Exception:
@@ -815,9 +819,19 @@ def _read_csv_chunks(
         preamble = fd.read(data_start)
         first_line = fd.readline()
 
+    # Only the column names and the row count are kept, so the sample is parsed
+    # as strings: a value that converts on its own line but not for the whole
+    # column (an int above 2**63 under dtype_backend="pyarrow", say) would
+    # otherwise raise here for a file the serial path reads fine.  GH#66259
     name_buf = io.BytesIO(preamble + first_line)
+    name_kwds = {
+        **base_kwds,
+        "dtype": str,
+        "converters": None,
+        "dtype_backend": lib.no_default,
+    }
     try:
-        name_reader = TextFileReader(name_buf, **base_kwds)
+        name_reader = TextFileReader(name_buf, **name_kwds)
     except EmptyDataError:
         # The one data line we sliced off is blank (e.g. header=None on a file
         # whose first physical line is empty), so the name-inference read sees
@@ -1005,11 +1019,15 @@ def _read_csv_chunks(
             # Per-chunk dtype inference can disagree with whole-file inference
             # (a lone non-numeric row makes only its own chunk object).  Mixed
             # signed-int/float chunks gather to the float64 serial would give;
-            # anything else must be re-read serially.
+            # anything else must be re-read serially.  ArrowDtype is excluded
+            # because pyarrow widens int to double with a *checked* cast, which
+            # raises above 2**53 where the serial whole-file read just infers
+            # double.  GH#66259
             for name in col_list:
                 chunk_dtypes = {chunk_dict[name].dtype for chunk_dict in chunk_dicts}
                 if len(chunk_dtypes) > 1 and not all(
-                    dt.kind in "if" for dt in chunk_dtypes
+                    dt.kind in "if" and not isinstance(dt, ArrowDtype)
+                    for dt in chunk_dtypes
                 ):
                     return None
 

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -1563,3 +1563,66 @@ def test_multibyte_sep_or_quotechar_warns_once(tmp_path, monkeypatch, kwargs):
     assert len(recorded) == 1
     assert recorded[0].category is ParserWarning
     assert "Falling back to the 'python' engine" in str(recorded[0].message)
+
+
+# 2**63 - 1 gathers through pyarrow's checked int-to-double cast; 2**64 does not
+# even fit an integer chunk, so it fails earlier, in a worker's own conversion
+@pytest.mark.parametrize(
+    ("big", "outcome"),
+    [("9223372036854775807", "declined"), ("18446744073709551616", "raised")],
+)
+@pytest.mark.skipif(WASM, reason="WASM stays serial, so the chunks never disagree")
+def test_parallel_pyarrow_huge_int_chunk_matches_serial(
+    tmp_path, monkeypatch, big, outcome
+):
+    # A chunk holding only huge integers converts as an integer column, while
+    # the whole-file serial read sees the trailing float too and infers double
+    # (or leaves the column a string).  The parallel path used to propagate the
+    # resulting ArrowInvalid / OverflowError instead of re-reading serially
+    # (GH#66259).
+    pytest.importorskip("pyarrow")
+    raw = b"col1\n" + f"{big}\n".encode() * 500 + b"1.5\n"
+    path = tmp_path / "huge_int.csv"
+    path.write_bytes(raw)
+    outcomes = _track_parallel(monkeypatch)
+
+    result = _read_forced_parallel(path, monkeypatch, dtype_backend="pyarrow")
+
+    expected = read_csv(io.BytesIO(raw), dtype_backend="pyarrow")
+    assert outcomes == [outcome]
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.skipif(WASM, reason="WASM stays serial, so nothing infers per chunk")
+def test_parallel_pyarrow_huge_int_column_stays_parallel(tmp_path, monkeypatch):
+    # The guard above must not cost the parallel path columns it handles fine:
+    # with no float row every chunk agrees on int64 and nothing falls back
+    # (GH#66259).
+    pytest.importorskip("pyarrow")
+    raw = b"col1\n" + b"9223372036854775807\n" * 500
+    path = tmp_path / "huge_int_only.csv"
+    path.write_bytes(raw)
+    outcomes = _track_parallel(monkeypatch)
+
+    result = _read_forced_parallel(path, monkeypatch, dtype_backend="pyarrow")
+
+    expected = read_csv(io.BytesIO(raw), dtype_backend="pyarrow")
+    assert outcomes == ["used"]
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.skipif(WASM, reason="WASM stays serial, so no sample line is parsed")
+def test_parallel_huge_int_first_line_matches_serial(tmp_path, monkeypatch):
+    # The name-inference read parses one data line only to learn the column
+    # names, so a value that converts on its own but not for the whole column
+    # must not raise there (GH#66259).
+    pytest.importorskip("pyarrow")
+    raw = b"col1\n18446744073709551616\n" + b"".join(
+        f"{i}.5\n".encode() for i in range(500)
+    )
+    path = tmp_path / "huge_first.csv"
+    path.write_bytes(raw)
+
+    result = _read_forced_parallel(path, monkeypatch, dtype_backend="pyarrow")
+
+    tm.assert_frame_equal(result, read_csv(io.BytesIO(raw), dtype_backend="pyarrow"))


### PR DESCRIPTION
Addresses bug 2 of GH-66259 (bugs 4 and 6 there are still open, so no closing keyword).

`read_csv(dtype_backend="pyarrow")` raised on a large local file where the serial (`mode.max_threads=1`) read of the same file succeeds. The issue scoped this to `low_memory=False`, but it is still live under the default `low_memory` now that GH-66686 gates the former: a file under ~1M rows does not chunk serially, so only the parallel path splits it.

Two independent mechanisms, both pyarrow-only:

- **`ArrowInvalid` at the gather.** Chunk dtypes `{int64[pyarrow], double[pyarrow]}` passed the mixed int/float guard, whose premise is that the int-to-float widening is an unchecked cast. That holds for numpy and masked dtypes but not pyarrow, whose `concat` does a *checked* cast that raises above 2**53. `ArrowDtype` is now excluded from that guard, so the column falls back to a serial re-read.
- **`OverflowError` in the name-inference read.** That read parses one sampled data line only to learn the column names, but ran it through the user's `dtype_backend`, so a line holding an int above 2**63 raised for a file the serial path reads fine. It now parses the sample as strings with conversion disabled, mirroring the raw-header read just below it.

A worker whose chunk happens to be entirely huge ints can still overflow that conversion, so `OverflowError` joins `ParserError`/`UnicodeDecodeError` as a serial-fallback signal. That is safe by construction: the serial read is the reference result, and it raises in turn if it too fails.

The guard costs no parallelism where the gather is sound — numpy and `numpy_nullable` mixed int/float columns still go parallel, as does a pure huge-int pyarrow column (asserted in a test).

A sweep over magnitude x backend x outlier position x chunk count goes from 36 serial/parallel divergences to 0 over 432 cases.

Note for a follow-up issue, not fixed here: `read_csv(dtype_backend="pyarrow")` on a column of ints above 2**64 raises `OverflowError` *serially* too. Parallel chunking only made it reachable for files whose column as a whole would have stayed a string.