### PR TITLE
BUG: parallel read_csv kept NA tokens literal where serial masked them (GH#66259)

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -399,6 +399,12 @@ cdef class TextReader:
         # gives every worker the same sink so a warning is raised once rather
         # than once per chunk (GH#66259).
         public object warning_sink
+        # Set once a column has been emitted with its NA tokens left as
+        # literal strings despite na_filter being on (the uint64-conflict
+        # branch of _convert_tokens, GH#14983).  Whether that branch is taken
+        # depends on which rows the parser saw, so the parallel reader checks
+        # this and falls back to a serial read (GH#66259).
+        public bint na_left_literal
         uint64_t parser_start  # this is modified after __init__
         const char *encoding_errors
         object _encoding_errors
@@ -580,6 +586,7 @@ cdef class TextReader:
         self._pa_target = None
         self.trim_after_read = True
         self.warning_sink = None
+        self.na_left_literal = False
 
         if float_precision in ("round_trip", "legacy", "high", None):
             self.parser.double_converter = precise_xstrtod_wrapper
@@ -1291,6 +1298,8 @@ cdef class TextReader:
                         col_res, na_count = self._string_convert(
                             i, start, end, 0, na_hashset,
                             allow_pyarrow=col_dtype is None)
+                        if na_filter:
+                            self.na_left_literal = True
                 except OverflowError:
                     try:
                         col_res, na_count = _try_pylong(self.parser, i, start,
@@ -1299,6 +1308,8 @@ cdef class TextReader:
                         col_res, na_count = self._string_convert(
                             i, start, end, 0, na_hashset,
                             allow_pyarrow=col_dtype is None)
+                        if na_filter:
+                            self.na_left_literal = True
 
                 if col_res is not None:
                     break

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -980,6 +980,18 @@ def _read_csv_chunks(
         ):
             for fut in [pool.submit(_worker) for _ in range(n_workers)]:
                 fut.result()
+
+            # A column of only NA tokens and ints too large for int64 converts
+            # to no numeric dtype, and is then emitted with its NA tokens left
+            # as literal strings (GH#14983).  Which chunks hit that depends on
+            # how the file was split, and the resulting dtype is str either
+            # way, so the reconciliation below cannot see the difference -- the
+            # values would just silently disagree with a serial read.  GH#66259
+            if any(
+                reader._engine._reader.na_left_literal for reader in workers_readers
+            ):
+                return None
+
             # Freeing parser buffers costs a few ms of madvise; run it on the
             # pool, overlapped with the gather copies below.
             close_futures = [pool.submit(reader.close) for reader in workers_readers]

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -1179,6 +1179,7 @@ def test_parallel_uint64_na_conflict_matches_serial(tmp_path, monkeypatch, kwarg
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.skipif(WASM, reason="WASM stays serial, so the spy sees no call")
 def test_parallel_uint64_na_conflict_na_filter_false(tmp_path, monkeypatch):
     # With na_filter=False the literal NA tokens are what a serial read gives
     # too, so such a file keeps using the parallel path.  GH#66259

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -1152,6 +1152,57 @@ def test_parallel_low_memory_false_matches_serial(tmp_path, monkeypatch, low_mem
     assert result["col"].isna().sum() == 3000
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {},
+        {"na_values": ["MISSING"]},
+        {"na_values": {"col": ["MISSING"]}},
+        {"dtype_backend": "numpy_nullable"},
+    ],
+)
+def test_parallel_uint64_na_conflict_matches_serial(tmp_path, monkeypatch, kwargs):
+    # A chunk holding only NA tokens and uint64-range ints converts to no
+    # numeric dtype and is emitted with its NA tokens left as literal strings
+    # (gh-14983).  A chunk that also sees ordinary text takes the object branch
+    # and masks them instead, and both results are str dtype, so the gather's
+    # dtype reconciliation cannot tell them apart - the parallel path must step
+    # aside rather than return values a serial read never produces (GH#66259).
+    token = "MISSING" if kwargs.get("na_values") else "nan"
+    body = f"{token}\n9223372036854775808\n" * 3000
+    path = tmp_path / "uint64_default_lm.csv"
+    path.write_text("col\n" + "text\n" * 500 + body, encoding="utf-8")
+
+    result = _read_forced_parallel(path, monkeypatch, **kwargs)
+    with option_context("mode.max_threads", 1):
+        expected = read_csv(path, **kwargs)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_parallel_uint64_na_conflict_na_filter_false(tmp_path, monkeypatch):
+    # With na_filter=False the literal NA tokens are what a serial read gives
+    # too, so such a file keeps using the parallel path.  GH#66259
+    body = "nan\n9223372036854775808\n" * 3000
+    path = tmp_path / "uint64_no_filter.csv"
+    path.write_text("col\n" + "text\n" * 500 + body, encoding="utf-8")
+
+    fell_back = []
+    orig = _readers._read_csv_parallel
+
+    def spy(*args, **kwargs):
+        result = orig(*args, **kwargs)
+        fell_back.append(result is None)
+        return result
+
+    monkeypatch.setattr(_readers, "_read_csv_parallel", spy)
+
+    result = _read_forced_parallel(path, monkeypatch, na_filter=False)
+    assert fell_back == [False]
+    with option_context("mode.max_threads", 1):
+        expected = read_csv(path, na_filter=False)
+    tm.assert_frame_equal(result, expected)
+
+
 def test_parallel_quoted_newline_in_header_matches_serial(tmp_path, monkeypatch):
     # A quoted embedded newline in the header shifts data_start mid-header;
     # without a guard, chunk 0 starts inside the header and silently injects


### PR DESCRIPTION
Bug 3 of GH-66259. No closing keyword: bug 2 is in flight on a separate branch, and bugs 4 and 6 still need a verdict (see the note at the bottom).

A column holding only NA tokens and ints too large for int64 converts to no numeric dtype, and the C parser then emits it with `na_filter` disabled, leaving the NA tokens as literal strings (GH-14983). A chunk that also sees ordinary text takes the object branch and masks them instead.

Which chunks land where depends on how the file was split, so the parallel path silently disagreed with a serial read of the *same* file — and since both branches yield `str`, the gather's per-column dtype reconciliation could not tell them apart. On a 67 MB file at default settings:

```python
par = pd.read_csv("f3.csv")
with pd.option_context("mode.max_threads", 1):
    ser = pd.read_csv("f3.csv")

ser["c0"].isna().sum()   # 104858
par["c0"].isna().sum()   #  66667   <- 38191 NA tokens kept as the literal string "nan"
```

No exception, just wrong values.

The issue suggested this one might only be fixable with a doc note, since serial `low_memory=True` already gives context-dependent NA here. But the divergence has a detectable signature: a column only reaches that emission path via the uint64 conflict or the `_try_pylong` overflow fallback. So `TextReader` now records when a column was emitted that way *despite* `na_filter` being on, and the parallel reader falls back to a serial read when any worker set it — the same step-aside the path already takes when chunk dtypes disagree. The GH-14983 behaviour itself is untouched; the flag only observes it.

Normal reads never set the flag, so this costs nothing outside the rare files that trip it.

Tests cover default NA tokens, `na_values` as a list and as a dict, and `dtype_backend="numpy_nullable"`, plus an `na_filter=False` case asserting such a file *stays* on the parallel path (there the literal tokens are what serial gives too). All four divergence cases fail without the guard.

---

Two notes on the remaining items in GH-66259, neither confirmed:

- **Bug 6** (deferred mmap unmap) did not reproduce on `main`. I probed `mm.close()` via an `mmap.mmap` subclass across three worker-exception paths — a converter raising deep in the file, `dtype={"c0": "Int64"}` overflow, and `dtype_backend="pyarrow"` — and got a clean unmap every time, no `BufferError`. The `finally` that closes worker readers, added in GH-66275, may have fixed it incidentally. I did not build at that commit's parent to confirm the attribution.
- **Bug 4** (error type for incompatible explicit `dtype`) also looks largely closed out: with the `low_memory=False` gate merged, serial at default `low_memory=True` chunks internally too, and both paths raised the same error type in the cases I tried.