### PR TITLE
BUG: parallel read_csv could leave the file mapped when it raised (GH-66259)

### DIFF
--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -891,12 +891,6 @@ def _read_csv_chunks(
         "low_memory": False,
     }
 
-    # mmap the file once and pass zero-copy memoryview slices to each thread
-    # instead of having each thread open/seek/read its own copy.  mmap dups
-    # the file descriptor, so the file object can be closed right away.
-    with open(filepath, "rb") as fh:
-        mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
-
     # Each thread reuses one parser to drain the queue, so no worker stalls
     # the gather on a straggler and no chunk pays parser construction.
     chunk_queue: queue.SimpleQueue = queue.SimpleQueue()
@@ -973,6 +967,13 @@ def _read_csv_chunks(
     columns: list[Hashable] = []
     total = 0
     readers_closing = False
+
+    # mmap the file once and pass zero-copy memoryview slices to each thread
+    # instead of having each thread open/seek/read its own copy.  mmap dups
+    # the file descriptor, so the file object can be closed right away.  Map it
+    # last, so that every path out of here runs the close below.  GH#66259
+    with open(filepath, "rb") as fh:
+        mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
     try:
         with (
             memoryview(mm) as mv,
@@ -1063,9 +1064,10 @@ def _read_csv_chunks(
                     reader.close()
                 except Exception:
                     pass
-        # suppress: a worker exception's traceback may still hold a memoryview
-        # export, in which case close() raises BufferError.  The mapping is
-        # unmapped once that traceback is garbage-collected.
+        # The closes above drop the chunk slices the readers hold, so the
+        # mapping is normally unmapped right here.  suppress: a traceback that
+        # still pins a slice would make close() raise BufferError and mask the
+        # exception on its way out; the mapping then goes when it is collected.
         with contextlib.suppress(BufferError):
             mm.close()
 

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import csv
 import io
+import mmap
 import os
 from typing import TYPE_CHECKING
 import warnings
@@ -1483,6 +1484,35 @@ def test_parallel_worker_exception_still_warns(tmp_path, monkeypatch):
     assert [str(warning.message) for warning in recorded] == [
         _converter_dtype_warning("col1")
     ]
+
+
+@pytest.mark.skipif(WASM, reason="WASM stays serial, so no worker raises")
+def test_parallel_worker_exception_unmaps_the_file(tmp_path, monkeypatch):
+    # A worker exception must not leave the file mapped until its traceback is
+    # collected: the workers hold memoryview slices of the mapping, so they are
+    # closed before it is (GH#66259).
+    raw = b"col1,col2\n" + b"".join(f"{i},{i * 2}\n".encode() for i in range(1000))
+    path = tmp_path / "boom.csv"
+    path.write_bytes(raw)
+
+    mapped: list[mmap.mmap] = []
+
+    class TrackingMmap(mmap.mmap):
+        def __init__(self, *args, **kwargs) -> None:
+            mapped.append(self)
+
+    monkeypatch.setattr(mmap, "mmap", TrackingMmap)
+
+    def boom(value):
+        if value == "1400":
+            raise RuntimeError("boom")
+        return value
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _read_forced_parallel(path, monkeypatch, converters={"col2": boom})
+
+    assert len(mapped) == 1
+    assert mapped[0].closed
 
 
 @pytest.mark.skipif(WASM, reason="WASM stays serial, so there is no attempt to decline")


### PR DESCRIPTION
Last of the parallel `read_csv` divergences in GH-66259 (bug 6 there; bugs 2 and 3 are on separate branches).

`_read_csv_chunks` mmapped the file ~70 lines above the `try`/`finally` that closes the mapping, and `pandas_dtype(dtype_arg)` sits in that gap. A raise there left the file mapped for good — worse than the deferred unmap the issue describes. Mapping it last puts every exit path through the close.

The `BufferError`-and-defer symptom the issue reports is already gone, fixed incidentally by GH-66275: the workers hold memoryview slices of the mapping via `TextReader._buffer_ref`, and the `reader.close()` loop that PR added to the `finally` drops them before `mm.close()` runs. I confirmed that both ways — no `BufferError` across the parser suite or a battery of error-path reads under a tracing `mmap` subclass, and the `BufferError` returns immediately if that close loop is disabled. So the second half of this PR is a regression test pinning the ordering, which fails on `assert mapped[0].closed` without it.

No whatsnew entry: parallel `read_csv` (GH-64347) is unreleased.