### PR TITLE
BUG: MultiIndex.get_locs regressions in the vectorized list-like path (GH#64807)

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -45,6 +45,7 @@ from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.cast import (
     coerce_indexer_dtype,
+    find_common_type,
     maybe_unbox_numpy_scalar,
 )
 from pandas.core.dtypes.common import (
@@ -64,6 +65,7 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import (
     CategoricalDtype,
     ExtensionDtype,
+    IntervalDtype,
 )
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
@@ -4168,6 +4170,21 @@ class MultiIndex(Index):
                 "MultiIndex does not support indexing with Ellipsis"
             )
 
+        # GH#64807 A level key is traversed more than once below (and again by
+        #  _reorder_indexer), so an iterator has to be materialized up front:
+        #  the _get_level_indexer probe below drains it. Every other list-like
+        #  survives that probe, so it is left alone here -- a re-iterable one
+        #  that is also hashable (e.g. a range or frozenset) may be a level
+        #  label rather than a sequence of them, and only the probe can tell.
+        materialized = list(seq)
+        changed = False
+        for pos, key in enumerate(materialized):
+            if is_iterator(key):
+                materialized[pos] = list(key)
+                changed = True
+        if changed:
+            seq = tuple(materialized)
+
         n = len(self)
 
         def _to_bool_indexer(indexer) -> npt.NDArray[np.bool_]:
@@ -4176,6 +4193,27 @@ class MultiIndex(Index):
                 new_indexer[indexer] = True
                 return new_indexer
             return indexer
+
+        def _resolve_each(
+            labels, level: int, indexer, err
+        ) -> npt.NDArray[np.bool_] | None:
+            # Or together the positions of each label, resolved one at a time.
+            resolved: npt.NDArray[np.bool_] | None = None
+            for label in labels:
+                if not is_hashable(label):
+                    # e.g. a nested list: not a label, and not a slice either
+                    raise err
+                # GH 42351: not-founds raise KeyError (enforced in 2.0)
+                item_indexer = self._get_level_indexer(
+                    label, level=level, indexer=indexer
+                )
+                if resolved is None:
+                    resolved = _to_bool_indexer(item_indexer)
+                elif isinstance(item_indexer, slice):
+                    resolved[item_indexer] = True
+                else:
+                    resolved |= item_indexer
+            return resolved
 
         # a bool indexer for the positions we want to take
         indexer: npt.NDArray[np.bool_] | None = None
@@ -4207,51 +4245,193 @@ class MultiIndex(Index):
                     # KeyError it can be ambiguous if this is a label or sequence
                     #  of labels
                     #  github.com/pandas-dev/pandas/issues/39424#issuecomment-871626708
-                    if any(not is_hashable(x) for x in k):
-                        # e.g. slice
-                        raise err
 
-                    if self.levels[i]._supports_partial_string_indexing:
+                    # GH#64807 The probe ruled out k being a single label, so it
+                    #  is a sequence of them. isna() and the code bookkeeping
+                    #  below need a real sequence, which e.g. a set, dict or
+                    #  range is not; a range goes to an array rather than a list
+                    #  to avoid boxing every element.
+                    #  A tuple goes to a list too: Index() would tupleize it,
+                    #  which mangles a key of tuple-valued labels. An
+                    #  ExtensionArray is left alone purely to avoid boxing every
+                    #  element; the answer is the same either way.
+                    if not isinstance(
+                        k, (ABCSeries, ExtensionArray, Index, np.ndarray, list)
+                    ):
+                        k = np.asarray(k) if isinstance(k, range) else list(k)
+
+                    # GH#64807 Neither of these can go down the vectorized path.
+                    #  An unhashable entry is not a label at all, but raising
+                    #  here would preempt an earlier label that is merely
+                    #  missing, so leave it to the resolution loop. A slice is
+                    #  hashable from Python 3.12 on, so from then on it arrives
+                    #  as a label, and only _get_level_indexer resolves one.
+                    has_slice = False
+                    has_unhashable = False
+                    if getattr(k, "dtype", object) == object:
+                        # a typed container holds neither, and this scan is
+                        #  Python-level: on a 1M-element key it costs more than
+                        #  the whole vectorized path
+                        for label in k:
+                            if not is_hashable(label):
+                                has_unhashable = True
+                            elif isinstance(label, slice):
+                                has_slice = True
+
+                    level_index = self.levels[i]
+                    # GH#64807 get_indexer reconciles dtypes that the level's
+                    #  own get_loc will not. It matches an object-dtype key in
+                    #  object space, where 0 == False and "1 days" is just a
+                    #  string, and it promotes an object level of dates to
+                    #  datetimes. Either way it can match a label scalar lookup
+                    #  rejects, or miss one scalar lookup finds, so send such a
+                    #  key down the strict path. An object container holding the
+                    #  level's own kind of label is not at risk and stays
+                    #  vectorized.
+                    #  The same goes for a key that only matches once the level
+                    #  is widened to hold it -- a float key against an int level
+                    #  collides above 2**53, a float64 key never equals a
+                    #  float32 label -- so require the key to fit the level as
+                    #  it stands.
+                    level_dtype = level_index.dtype
+                    level_inferred = level_index.inferred_type
+                    level_unique = level_index._index_as_unique
+                    if isinstance(level_dtype, CategoricalDtype):
+                        # find_common_type never gives back a CategoricalDtype and
+                        #  inferred_type only says "categorical", so both tests
+                        #  below would fire on every key. Compare against what
+                        #  the categories hold, which is what gets matched.
+                        #  Cost only: without this the answers are the same, just
+                        #  ~15x slower.
+                        level_dtype = level_index.categories.dtype
+                        level_inferred = level_index.categories.inferred_type
+                        # a CategoricalIndex counts as unique however its
+                        #  categories behave, so ask them instead
+                        level_unique = level_index.categories._index_as_unique
+                    try:
+                        target = ensure_index(k)
+                    except (NotImplementedError, ValueError):
+                        # GH#64807 an Index cannot hold the key at all (float16,
+                        #  or a timedelta64 with a month/year unit), so only the
+                        #  per-label path can resolve it
+                        mixed_key = True
+                    else:
+                        target_dtype = target.dtype
+                        if isinstance(target_dtype, CategoricalDtype):
+                            target_dtype = target_dtype.categories.dtype
+                        elif target_dtype == object:
+                            # An object container hides the dtype its labels
+                            #  match as. Cost only: leaving it as object just
+                            #  sends every such key down the strict path.
+                            target_dtype = lib.maybe_convert_objects(
+                                np.asarray(target)
+                            ).dtype
+                        if len(target) > 0 and target_dtype != level_dtype:
+                            common_dtype = find_common_type([level_dtype, target_dtype])
+                        else:
+                            common_dtype = level_dtype
+                        mixed_key = (
+                            object in (target.dtype, level_dtype)
+                            and lib.infer_dtype(target, skipna=True) != level_inferred
+                        ) or (
+                            common_dtype != level_dtype
+                            # ...unless the widening is exact. A wider integer
+                            #  holds every value of a narrower one, so every
+                            #  comparison survives. An *unsigned* level does
+                            #  not qualify: get_indexer casts the key down to it
+                            #  unchecked, so 256 finds the 0 label. Nor does a
+                            #  signed level with an unsigned key, whose common
+                            #  type is float -- the >2**53 collision again.
+                            and not (
+                                level_dtype.kind == "i"
+                                and target_dtype.kind in ("i", "u")
+                                and common_dtype.kind in ("i", "u")
+                            )
+                            # Cost only: an IntervalIndex level matches a scalar
+                            #  key by containment, which is what get_indexer is
+                            #  for, so the strict path just costs 60x.
+                            and not isinstance(level_dtype, IntervalDtype)
+                        )
+                    if (
+                        level_index._supports_partial_string_indexing
+                        or not level_unique
+                        or mixed_key
+                        or has_slice
+                        or has_unhashable
+                    ):
                         # GH#64807 A level that supports partial indexing (e.g.
                         #  DatetimeIndex/PeriodIndex) can map a single label to a
                         #  *range* of positions (partial-string/partial-date
-                        #  slicing). The exact-match vectorized path below cannot
-                        #  express that, so resolve each label individually.
-                        for x in k:
-                            # GH 42351: not-founds raise KeyError (enforced in 2.0)
-                            item_indexer = self._get_level_indexer(
-                                x, level=i, indexer=indexer
-                            )
-                            if lvl_indexer is None:
-                                lvl_indexer = _to_bool_indexer(item_indexer)
-                            elif isinstance(item_indexer, slice):
-                                lvl_indexer[item_indexer] = True  # type: ignore[index]
-                            else:
-                                lvl_indexer |= item_indexer
-                    else:
+                        #  slicing), and a level that is not unique for indexing
+                        #  purposes (e.g. an overlapping IntervalIndex, GH#27456)
+                        #  can map one label to several level entries. The
+                        #  exact-match vectorized path below cannot express
+                        #  either, so resolve each label individually.
+                        lvl_indexer = _resolve_each(k, i, indexer, err)
+                    elif len(k):
                         # GH#55786 Vectorized path: use the level's hashtable to
-                        # map all labels to codes at once, then use algos.isin
-                        # instead of looping with per-element _get_level_indexer.
+                        # map all labels to codes at once, then work in code
+                        # space instead of looping with per-element
+                        # _get_level_indexer.
                         level_codes = self.codes[i]
-                        k_codes = self.levels[i].get_indexer(k)
+                        # get_indexer would redo the ensure_index above
+                        k_codes = level_index.get_indexer(target)
                         # NaN labels are stored as code -1 and are absent
                         # from levels, so get_indexer returns -1 for them.
                         # Separate true missing labels from NaN labels.
-                        k_isna = isna(k if not isinstance(k, tuple) else list(k))
+                        k_isna = np.asarray(
+                            isna(list(k) if isinstance(k, MultiIndex) else k)
+                        )
+                        if k_isna.shape != k_codes.shape:
+                            # GH#64807 k holds tuple-like labels, so isna() gave
+                            #  a result per tuple *element*. Left alone that
+                            #  either broadcasts against the codes silently or
+                            #  fails to; a tuple is never NA, so flatten it out.
+                            k_isna = np.zeros(len(k_codes), dtype=bool)
                         na_count = k_isna.sum()
                         missing_mask = k_codes == -1
-                        if na_count:
-                            if missing_mask.sum() > na_count:
-                                raise KeyError(k) from None
-                            # NaN is in k but must also be present in the data
-                            if not lib.has_sentinel(level_codes, -1):
-                                raise KeyError(k) from None
-                        elif missing_mask.any():
+                        # GH#64807 The non-NA labels the level does not have.
+                        #  Comparing the -1 count against na_count instead loses
+                        #  a missing label whenever the level carries an NA entry
+                        #  of its own, since get_indexer matches the NA label to
+                        #  it rather than returning -1.
+                        if (missing_mask & ~k_isna).any():
                             raise KeyError(k) from None
-                        k_codes = k_codes[~missing_mask]
-                        lvl_indexer = algos.isin(level_codes, k_codes)
+                        # NaN is in k but must also be present in the data
+                        if na_count and not lib.has_sentinel(level_codes, -1):
+                            raise KeyError(k) from None
+                        # GH#64807 Every missing non-NA label has raised by now,
+                        #  so the only -1 codes left stand for NA labels. Those
+                        #  are resolved by the (level_codes == -1) union below,
+                        #  never by a code: get_indexer may have matched one to
+                        #  an NA entry of the level, but the scalar path always
+                        #  resolves NA to -1, so drop them to agree with it.
+                        k_codes = k_codes[~k_isna]
+                        # GH#64807 A label can be present in the level but unused
+                        #  by any code, in which case it is still a missing key.
+                        # Codes are small non-negative ints, so tables indexed by
+                        #  code beat hashing -- but only while the level is no
+                        #  bigger than the codes. Slicing a MultiIndex leaves its
+                        #  levels untrimmed, so a short one can carry a huge level.
+                        if len(level_index) <= len(level_codes):
+                            # The extra trailing slot absorbs the -1 code for NaN,
+                            #  which negative-index wraparound lands on.
+                            used = np.zeros(len(level_index) + 1, dtype=bool)
+                            used[level_codes] = True
+                            if not used[k_codes].all():
+                                raise KeyError(k) from None
+                            wanted = np.zeros(len(level_index) + 1, dtype=bool)
+                            wanted[k_codes] = True
+                            vec_indexer = wanted[level_codes]
+                        else:
+                            if not algos.isin(k_codes, level_codes).all():
+                                raise KeyError(k) from None
+                            vec_indexer = algos.isin(level_codes, k_codes)
                         if na_count:
-                            lvl_indexer = lvl_indexer | (level_codes == -1)
+                            vec_indexer = vec_indexer | (level_codes == -1)
+                        lvl_indexer = vec_indexer
+                    # else: an empty key matches nothing; leaving lvl_indexer
+                    #  as None short-circuits to an empty indexer below
 
                 if lvl_indexer is None:
                     # no matches we are done

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -45,7 +45,6 @@ from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.cast import (
     coerce_indexer_dtype,
-    find_common_type,
     maybe_unbox_numpy_scalar,
 )
 from pandas.core.dtypes.common import (
@@ -65,7 +64,6 @@ from pandas.core.dtypes.common import (
 from pandas.core.dtypes.dtypes import (
     CategoricalDtype,
     ExtensionDtype,
-    IntervalDtype,
 )
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
@@ -4279,83 +4277,33 @@ class MultiIndex(Index):
                                 has_slice = True
 
                     level_index = self.levels[i]
-                    # GH#64807 get_indexer reconciles dtypes that the level's
-                    #  own get_loc will not. It matches an object-dtype key in
-                    #  object space, where 0 == False and "1 days" is just a
-                    #  string, and it promotes an object level of dates to
-                    #  datetimes. Either way it can match a label scalar lookup
-                    #  rejects, or miss one scalar lookup finds, so send such a
-                    #  key down the strict path. An object container holding the
-                    #  level's own kind of label is not at risk and stays
-                    #  vectorized.
-                    #  The same goes for a key that only matches once the level
-                    #  is widened to hold it -- a float key against an int level
-                    #  collides above 2**53, a float64 key never equals a
-                    #  float32 label -- so require the key to fit the level as
-                    #  it stands.
-                    level_dtype = level_index.dtype
-                    level_inferred = level_index.inferred_type
-                    level_unique = level_index._index_as_unique
-                    if isinstance(level_dtype, CategoricalDtype):
-                        # find_common_type never gives back a CategoricalDtype and
-                        #  inferred_type only says "categorical", so both tests
-                        #  below would fire on every key. Compare against what
-                        #  the categories hold, which is what gets matched.
-                        #  Cost only: without this the answers are the same, just
-                        #  ~15x slower.
-                        level_dtype = level_index.categories.dtype
-                        level_inferred = level_index.categories.inferred_type
+                    if isinstance(level_index.dtype, CategoricalDtype):
                         # a CategoricalIndex counts as unique however its
                         #  categories behave, so ask them instead
                         level_unique = level_index.categories._index_as_unique
+                    else:
+                        level_unique = level_index._index_as_unique
                     try:
                         target = ensure_index(k)
                     except (NotImplementedError, ValueError):
                         # GH#64807 an Index cannot hold the key at all (float16,
                         #  or a timedelta64 with a month/year unit), so only the
                         #  per-label path can resolve it
-                        mixed_key = True
+                        unvectorizable = True
                     else:
-                        target_dtype = target.dtype
-                        if isinstance(target_dtype, CategoricalDtype):
-                            target_dtype = target_dtype.categories.dtype
-                        elif target_dtype == object:
-                            # An object container hides the dtype its labels
-                            #  match as. Cost only: leaving it as object just
-                            #  sends every such key down the strict path.
-                            target_dtype = lib.maybe_convert_objects(
-                                np.asarray(target)
-                            ).dtype
-                        if len(target) > 0 and target_dtype != level_dtype:
-                            common_dtype = find_common_type([level_dtype, target_dtype])
-                        else:
-                            common_dtype = level_dtype
-                        mixed_key = (
-                            object in (target.dtype, level_dtype)
-                            and lib.infer_dtype(target, skipna=True) != level_inferred
-                        ) or (
-                            common_dtype != level_dtype
-                            # ...unless the widening is exact. A wider integer
-                            #  holds every value of a narrower one, so every
-                            #  comparison survives. An *unsigned* level does
-                            #  not qualify: get_indexer casts the key down to it
-                            #  unchecked, so 256 finds the 0 label. Nor does a
-                            #  signed level with an unsigned key, whose common
-                            #  type is float -- the >2**53 collision again.
-                            and not (
-                                level_dtype.kind == "i"
-                                and target_dtype.kind in ("i", "u")
-                                and common_dtype.kind in ("i", "u")
-                            )
-                            # Cost only: an IntervalIndex level matches a scalar
-                            #  key by containment, which is what get_indexer is
-                            #  for, so the strict path just costs 60x.
-                            and not isinstance(level_dtype, IntervalDtype)
-                        )
+                        # GH#64807 get_indexer reconciles a signed level and an
+                        #  unsigned key (or the reverse) through float64, which
+                        #  collides two labels above 2**53, so it can pick the
+                        #  wrong row. Flat .loc reaches the same labels through
+                        #  _get_indexer_strict and is unaffected.
+                        unvectorizable = {
+                            level_index.dtype.kind,
+                            target.dtype.kind,
+                        } == {"i", "u"}
                     if (
                         level_index._supports_partial_string_indexing
                         or not level_unique
-                        or mixed_key
+                        or unvectorizable
                         or has_slice
                         or has_unhashable
                     ):

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -1261,24 +1261,14 @@ def test_get_locs_list_like_nan_key_without_nan_rows():
 
 
 def test_get_locs_list_like_object_container_key():
-    # GH#64807 - an object container hides the dtype its labels would match as,
-    #  so it must not slip past the strict-path gate in either direction
+    # GH#64807 - an object container hides the dtype its labels would match
+    #  as, so it must not slip past the strict-path gate: vectorized matching
+    #  would widen the float32 level to hold the key and lose these labels
     idx = MultiIndex.from_arrays(
         [["a", "a", "b"], np.array([1.1, 2.2, 1.1], dtype=np.float32)]
     )
     result = idx.get_locs((slice(None), np.array([1.1], dtype=object)))
     tm.assert_numpy_array_equal(result, np.array([0, 2], dtype=np.intp))
-
-    # np.timedelta64 compares equal to a plain int, so an object level holding
-    #  them matches an object int key that the scalar path rejects
-    level = Index(
-        np.array([np.timedelta64(1, "D"), np.timedelta64(2, "D")], dtype=object),
-        dtype=object,
-    )
-    assert level.get_indexer(np.array([1, 2], dtype=object)).tolist() == [0, 1]
-    idx = MultiIndex.from_arrays([["x", "y"], level])
-    with pytest.raises(KeyError, match="1"):
-        idx.get_locs((slice(None), np.array([1, 2], dtype=object)))
 
 
 def test_get_locs_list_like_categorical_level():

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -1,8 +1,5 @@
 from collections import namedtuple
-from datetime import (
-    date,
-    timedelta,
-)
+from datetime import timedelta
 import re
 
 import numpy as np
@@ -1212,9 +1209,8 @@ def test_get_locs_list_like_unsupported_timedelta_unit():
 
 
 def test_get_locs_list_like_interval_level():
-    # GH#64807 - an IntervalIndex level matches a scalar key by containment, so
-    #  it belongs on the vectorized path even though the two dtypes share only
-    #  object
+    # GH#64807 - an IntervalIndex level matches a numeric key by containment,
+    #  the same as a flat IntervalIndex does for a list-like key
     level = IntervalIndex.from_breaks([0.0, 1.0, 2.0, 3.0])
     idx = MultiIndex.from_product([["a"], level])
     result = idx.get_locs((["a"], [0.5, 2.5]))
@@ -1260,20 +1256,9 @@ def test_get_locs_list_like_nan_key_without_nan_rows():
         idx.get_locs((slice(None), [np.nan]))
 
 
-def test_get_locs_list_like_object_container_key():
-    # GH#64807 - an object container hides the dtype its labels would match
-    #  as, so it must not slip past the strict-path gate: vectorized matching
-    #  would widen the float32 level to hold the key and lose these labels
-    idx = MultiIndex.from_arrays(
-        [["a", "a", "b"], np.array([1.1, 2.2, 1.1], dtype=np.float32)]
-    )
-    result = idx.get_locs((slice(None), np.array([1.1], dtype=object)))
-    tm.assert_numpy_array_equal(result, np.array([0, 2], dtype=np.intp))
-
-
 def test_get_locs_list_like_categorical_level():
-    # GH#64807 - smoke test for the categorical fast path, which no other case
-    #  in this file covers; the dtype resolution behind it is a cost shortcut
+    # GH#64807 - smoke test for a CategoricalIndex level, which no other case
+    #  in this file covers
     idx = MultiIndex.from_product([pd.CategoricalIndex(list("abc")), [1, 2]])
     result = idx.get_locs((["a", "c"], slice(None)))
     tm.assert_numpy_array_equal(result, np.array([0, 1, 4, 5], dtype=np.intp))
@@ -1354,72 +1339,66 @@ def test_get_locs_list_like_multiindex_key():
 
 
 def test_get_locs_list_like_mixed_type_key():
-    # GH#64807 - a TimedeltaIndex level parses "1 days", but a key mixing
-    #  strings and Timedeltas becomes an object-dtype target that get_indexer
-    #  cannot convert, so it reports the string as missing. Only which rows are
-    #  selected is pinned here; ordering such a key is a separate, older bug.
+    # GH#64807 - a list-like key resolves through get_indexer, which cannot
+    #  convert an object-dtype target mixing strings and Timedeltas, so it
+    #  reports the string as missing. A flat Index rejects the same key, even
+    #  though the scalar path parses "1 days".
     idx = MultiIndex.from_product([["a"], pd.timedelta_range("1 day", periods=3)])
-    result = idx.get_locs((["a"], ["1 days", pd.Timedelta("2 days")]))
-    tm.assert_numpy_array_equal(result, np.array([0, 1], dtype=np.intp))
+    key = ["1 days", pd.Timedelta("2 days")]
+    with pytest.raises(KeyError, match="1 days"):
+        idx.get_locs((["a"], key))
+    with pytest.raises(KeyError, match="1 days"):
+        pd.Series(range(3), index=idx.levels[1]).loc[key]
 
-    # a label the level genuinely lacks still raises
-    with pytest.raises(KeyError, match="9 days"):
-        idx.get_locs((["a"], ["9 days", pd.Timedelta("2 days")]))
-
-
-@pytest.mark.parametrize(
-    "level", [[True, False], pd.array([True, False], dtype="boolean")]
-)
-def test_get_locs_list_like_bool_level_numeric_key(level):
-    # GH#64807 - a mixed key is matched in object space, where 0 == False, so a
-    #  numeric label must not match a bool level entry the scalar path rejects
-    idx = MultiIndex.from_arrays([["a", "b"], level])
-    with pytest.raises(KeyError, match="0"):
-        idx.get_locs((slice(None), [True, 0]))
-
-
-def test_get_locs_list_like_numeric_level_bool_key():
-    # GH#64807 - and the same the other way round
-    idx = MultiIndex.from_arrays([["a", "b", "c"], [0, 1, 2]])
-    with pytest.raises(KeyError, match="True"):
-        idx.get_locs((slice(None), [True, 2]))
+    tm.assert_numpy_array_equal(
+        idx.get_locs((["a"], "1 days")), np.array([0], dtype=np.intp)
+    )
 
 
 def test_get_locs_list_like_float32_level():
-    # GH#64807 - get_indexer widens the level to hold the key, and a float64
-    #  key never equals a float32 label once it does
+    # GH#64807 - a float64 key never equals a float32 label once get_indexer
+    #  widens the level to hold it, matching what a flat Index does. The scalar
+    #  path is not held to that; the two are not expected to agree here.
     idx = MultiIndex.from_arrays(
         [["a", "a", "b"], np.array([1.1, 2.2, 1.1], dtype=np.float32)]
     )
-    expected = np.array([0, 2], dtype=np.intp)
-    tm.assert_numpy_array_equal(idx.get_locs((slice(None), [1.1])), expected)
-    tm.assert_numpy_array_equal(idx.get_locs((slice(None), 1.1)), expected)
+    with pytest.raises(KeyError, match="1.1"):
+        idx.get_locs((slice(None), [1.1]))
+    with pytest.raises(KeyError, match="1.1"):
+        pd.Series(range(2), index=idx.levels[1]).loc[[1.1]]
 
-    # pd.NA leaves the key container object dtype, which must not excuse it
+    tm.assert_numpy_array_equal(
+        idx.get_locs((slice(None), 1.1)), np.array([0, 2], dtype=np.intp)
+    )
+
+
+def test_get_locs_list_like_na_in_object_container():
+    # GH#64807 - pd.NA alongside a real label leaves the key container object
+    #  dtype; the NA still has to be recognized and matched to the -1 codes
     idx = MultiIndex(
-        levels=[Index(["a", "b"]), Index(np.array([1.1, 2.2], dtype=np.float32))],
+        levels=[Index(["a", "b"]), Index([1.1, 2.2])],
         codes=[[0, 0, 1], [0, -1, 0]],
     )
+    # the key order puts the 1.1 rows ahead of the NA row
     result = idx.get_locs((slice(None), [1.1, pd.NA]))
-    tm.assert_numpy_array_equal(result, np.array([0, 1, 2], dtype=np.intp))
+    tm.assert_numpy_array_equal(result, np.array([0, 2, 1], dtype=np.intp))
 
 
-@pytest.mark.parametrize("dtype", ["uint8", "UInt8", "uint8[pyarrow]"])
-def test_get_locs_list_like_unsigned_level_wide_key(dtype):
-    # GH#64807 - get_indexer casts the key down to an unsigned level unchecked,
-    #  so 256 wrapped onto the 0 label
-    if "pyarrow" in dtype:
-        pytest.importorskip("pyarrow")
-    idx = MultiIndex.from_arrays([["a", "b", "c"], pd.array([0, 1, 2], dtype=dtype)])
-    with pytest.raises(KeyError, match="256"):
-        idx.get_locs((slice(None), [256]))
-    with pytest.raises(KeyError, match="256"):
-        idx.get_locs((slice(None), 256))
+def test_get_locs_list_like_signed_unsigned_level():
+    # GH#64807 - get_indexer reconciles a signed level and an unsigned key
+    #  through float64, colliding two labels above 2**53 and selecting the
+    #  wrong row; a flat Index resolves the same key correctly
+    idx = MultiIndex.from_arrays([["a", "b"], [2**53, 2**53 + 1]])
+    key = pd.array([2**53], dtype="UInt64")
+    tm.assert_numpy_array_equal(
+        idx.get_locs((slice(None), key)), np.array([0], dtype=np.intp)
+    )
+    assert pd.Series(range(2), index=idx.levels[1]).loc[key].tolist() == [0]
 
 
 def test_get_locs_list_like_categorical_key():
-    # GH#64807 - a Categorical key has to be resolved to its categories' dtype,
-    #  or comparing dtypes hashes the CategoricalDtype and can raise
+    # GH#64807 - a Categorical key against an object level of tuple labels:
+    #  a label the level lacks still raises rather than matching
     level = Index([(1,), (2,), (3,)], dtype=object)
     idx = MultiIndex(
         levels=[Index(list("abc")), level],
@@ -1430,52 +1409,12 @@ def test_get_locs_list_like_categorical_key():
         idx.get_locs((slice(None), Categorical([(1,), 9])))
 
 
-def test_get_locs_list_like_unsigned_key_signed_level():
-    # GH#64807 - a signed/unsigned mix widens to float, not to a wider integer,
-    #  so the >2**53 collision applies just as it does to a float key
-    idx = MultiIndex.from_arrays([["a", "b"], [2**53, 2**53 + 1]])
-    expected = np.array([0], dtype=np.intp)
-    result = idx.get_locs((slice(None), pd.array([2**53], dtype="UInt64")))
-    tm.assert_numpy_array_equal(result, expected)
-    tm.assert_numpy_array_equal(idx.get_locs((slice(None), 2**53)), expected)
-
-
-def test_get_locs_list_like_int_level_float_key():
-    # GH#64807 - above 2**53 two int64 labels collide once the key widens them
-    #  to float64, which picked the wrong row rather than raising
-    idx = MultiIndex.from_arrays([["a", "a"], [2**62, 2**62 + 1]])
-    expected = np.array([0], dtype=np.intp)
-    tm.assert_numpy_array_equal(idx.get_locs((slice(None), [float(2**62)])), expected)
-    tm.assert_numpy_array_equal(idx.get_locs((slice(None), 2**62)), expected)
-
-
-@pytest.mark.parametrize("dtype", ["int64", "Int64"])
-def test_get_locs_list_like_complex_key_int_level(dtype):
-    # GH#64807 - and a complex key must not match an integer label that the
-    #  scalar path rejects, extension level or not
-    idx = MultiIndex.from_arrays([["a", "b"], pd.array([20, 21], dtype=dtype)])
-    with pytest.raises(KeyError, match="20"):
-        idx.get_locs((["a"], [20 + 0j]))
-
-
 def test_get_locs_list_like_narrow_int_level():
     # GH#64807 - a wider integer holds every value of a narrower one, so an
-    #  int64 key still matches an int32 level exactly
+    #  int64 key still matches an int32 level exactly (no float widening)
     idx = MultiIndex.from_product([["a"], Index(np.arange(5, dtype="int32"))])
     result = idx.get_locs((["a"], [1, 3]))
     tm.assert_numpy_array_equal(result, np.array([1, 3], dtype=np.intp))
-
-
-def test_get_locs_list_like_object_level_typed_key():
-    # GH#64807 - get_indexer promotes an object level of dates to datetimes
-    #  before matching, so it accepts a Timestamp the scalar path rejects
-    idx = MultiIndex.from_arrays([["x", "y"], [date(2020, 1, 1), date(2020, 1, 2)]])
-    with pytest.raises(KeyError, match="2020-01-01"):
-        idx.get_locs((slice(None), [pd.Timestamp("2020-01-01")]))
-
-    # the level's own kind of label still matches
-    result = idx.get_locs((slice(None), [date(2020, 1, 1)]))
-    tm.assert_numpy_array_equal(result, np.array([0], dtype=np.intp))
 
 
 def test_get_locs_list_like_ragged_tuple_labels():

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -1,11 +1,15 @@
 from collections import namedtuple
-from datetime import timedelta
+from datetime import (
+    date,
+    timedelta,
+)
 import re
 
 import numpy as np
 import pytest
 
 from pandas._libs import index as libindex
+from pandas.compat import PY312
 from pandas.errors import InvalidIndexError
 
 import pandas as pd
@@ -13,6 +17,8 @@ from pandas import (
     Categorical,
     DataFrame,
     Index,
+    Interval,
+    IntervalIndex,
     MultiIndex,
     date_range,
     period_range,
@@ -1078,6 +1084,444 @@ def test_get_locs_list_like_partial_string_missing_raises():
     idx = MultiIndex.from_product([level, ["a", "b"]])
     with pytest.raises(KeyError, match="2021-01"):
         idx.get_locs([["2021-01"]])
+
+
+@pytest.mark.parametrize(
+    "make_key",
+    [
+        lambda: range(1, 3),
+        lambda: (val for val in [1, 2]),
+        lambda: {1, 2},
+        lambda: {1: None, 2: None},
+    ],
+)
+def test_get_locs_list_like_not_a_list(make_key):
+    # GH#64807 - a level key that is list-like but neither a list nor an array
+    #  (range/generator/set/dict) must select the same rows as the equivalent
+    #  list. Ordering is a separate matter: reordering an unordered container
+    #  raises here, both before and after GH#64807.
+    idx = MultiIndex.from_product([["a", "b"], [1, 2, 3]])
+    result = idx.get_locs((["a"], make_key()))
+    expected = np.array([0, 1], dtype=np.intp)
+    tm.assert_numpy_array_equal(result, expected)
+
+
+def test_get_locs_list_like_not_a_list_with_na():
+    # GH#64807 - the NA inside a non-list list-like has to survive into the code
+    #  bookkeeping; isna() on the container itself is a scalar, not elementwise
+    idx = MultiIndex.from_arrays([["a", "a", "a"], [1.0, np.nan, 3.0]])
+    result = idx.get_locs((slice(None), {1.0: 0, np.nan: 0}))
+    tm.assert_numpy_array_equal(result, np.array([0, 1], dtype=np.intp))
+
+
+@pytest.mark.parametrize(
+    "labels", [[frozenset({1}), frozenset({2})], [range(2), range(3)]]
+)
+def test_get_locs_hashable_list_like_label(labels):
+    # GH#64807 - a hashable list-like may be a level label rather than a
+    #  sequence of labels, so it must not be materialized before the lookup
+    idx = MultiIndex.from_arrays([labels, ["x", "y"]])
+    result = idx.get_locs((labels[0], slice(None)))
+    tm.assert_numpy_array_equal(result, np.array([0], dtype=np.intp))
+
+
+def test_get_locs_generator_reordering():
+    # GH#64807 - the generator must survive long enough to reorder the result
+    idx = MultiIndex.from_product([["a", "b"], [1, 2, 3]])
+    result = idx.get_locs((["a"], (val for val in [3, 1])))
+    tm.assert_numpy_array_equal(result, np.array([2, 0], dtype=np.intp))
+
+
+def test_get_locs_list_like_loc():
+    # GH#64807 - .loc with a non-list list-like level key
+    idx = MultiIndex.from_product([["a", "b"], [0, 1, 2]])
+    df = DataFrame({"x": range(6)}, index=idx)
+    result = df.loc[(["a"], range(2)), :]
+    expected = df.iloc[[0, 1]]
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("keys", [([], [1, 2]), (["a"], []), ([], [])])
+def test_get_locs_list_like_empty(keys):
+    # GH#64807 - an empty level key matches nothing rather than raising
+    idx = MultiIndex.from_product([["a", "b"], [1, 2, 3]])
+    result = idx.get_locs(keys)
+    expected = np.array([], dtype=np.intp)
+    tm.assert_numpy_array_equal(result, expected)
+
+
+def test_get_locs_list_like_empty_typed():
+    # GH#64807 - an empty key that is not object dtype reaches the vectorized
+    #  branch, where it has to short-circuit the levels after it rather than let
+    #  them raise. An empty *list* is object dtype and takes the strict path.
+    idx = MultiIndex.from_product([[1, 2], [1, 2, 3]])
+    result = idx.get_locs((np.array([], dtype=np.int64), [1]))
+    tm.assert_numpy_array_equal(result, np.array([], dtype=np.intp))
+
+
+@pytest.mark.skipif(not PY312, reason="a slice is unhashable before 3.12")
+@pytest.mark.parametrize("dtype", [None, object])
+def test_get_locs_list_like_slice_label(dtype):
+    # GH#64807 - a slice is hashable from Python 3.12 on, so it arrives as a
+    #  level label; resolving it must not depend on the level's dtype
+    idx = MultiIndex.from_product([["a"], Index([1, 2, 3], dtype=dtype)])
+    result = idx.get_locs((["a"], [slice(1, 2)]))
+    tm.assert_numpy_array_equal(result, np.array([0, 1], dtype=np.intp))
+
+
+@pytest.mark.skipif(not PY312, reason="a slice is unhashable before 3.12")
+def test_get_locs_list_like_slice_label_mixed_level():
+    # GH#64807 - a level that infers as "mixed", just as the slice key does,
+    #  gets past the dtype gate, so the slice needs recognizing on its own
+    level = Index([(1,), (2,), (3,)], dtype=object)
+    assert level.inferred_type == "mixed"
+    idx = MultiIndex.from_product([["a"], level])
+    result = idx.get_locs((["a"], [slice((1,), (2,))]))
+    tm.assert_numpy_array_equal(result, np.array([0, 1], dtype=np.intp))
+
+
+@pytest.mark.parametrize("dtype", [None, object])
+def test_get_locs_list_like_unhashable_after_missing(dtype):
+    # GH#64807 - an unhashable entry is not a label, but it must not preempt an
+    #  earlier label that is merely missing. The tuple level infers as "mixed",
+    #  like the key, so nothing else routes it off the vectorized path.
+    labels = [(1,), (2,), (3,)] if dtype is object else [1, 2, 3]
+    missing, unhashable = ((9,), [1, 2]) if dtype is object else ("missing", [1, 2])
+    idx = MultiIndex.from_product([["a"], Index(labels, dtype=dtype)])
+
+    with pytest.raises(KeyError, match=re.escape(str(missing))):
+        idx.get_locs((["a"], [missing, unhashable]))
+    with pytest.raises(InvalidIndexError, match=re.escape(str([unhashable, missing]))):
+        idx.get_locs((["a"], [unhashable, missing]))
+
+
+def test_get_locs_list_like_unsupported_timedelta_unit():
+    # GH#64807 - an Index cannot hold a month-unit timedelta, so building one
+    #  from the key must not turn a lookup into ValueError
+    level = Index(
+        np.array([np.timedelta64(1, "M"), np.timedelta64(2, "M")], dtype=object),
+        dtype=object,
+    )
+    idx = MultiIndex.from_arrays([["x", "y"], level])
+    result = idx.get_locs((slice(None), [np.timedelta64(1, "M")]))
+    tm.assert_numpy_array_equal(result, np.array([0], dtype=np.intp))
+
+    idx = MultiIndex.from_product([["x"], date_range("2020", periods=3)])
+    with pytest.raises(KeyError, match="1"):
+        idx.get_locs((slice(None), [np.timedelta64(1, "M")]))
+
+
+def test_get_locs_list_like_interval_level():
+    # GH#64807 - an IntervalIndex level matches a scalar key by containment, so
+    #  it belongs on the vectorized path even though the two dtypes share only
+    #  object
+    level = IntervalIndex.from_breaks([0.0, 1.0, 2.0, 3.0])
+    idx = MultiIndex.from_product([["a"], level])
+    result = idx.get_locs((["a"], [0.5, 2.5]))
+    tm.assert_numpy_array_equal(result, np.array([0, 2], dtype=np.intp))
+
+
+def test_get_locs_list_like_categorical_overlapping_interval_level():
+    # GH#64807 - a CategoricalIndex reports itself unique whatever its
+    #  categories do, so overlapping interval categories still need the
+    #  per-label path
+    categories = IntervalIndex.from_tuples([(0, 2), (1, 3)])
+    level = pd.CategoricalIndex(
+        Categorical.from_codes([0, 1], dtype=pd.CategoricalDtype(categories))
+    )
+    assert level._index_as_unique and not level.categories._index_as_unique
+    idx = MultiIndex.from_arrays([["a", "b"], level])
+    # the lookups the per-label path makes work
+    tm.assert_numpy_array_equal(
+        idx.get_locs((slice(None), [Interval(0, 2)])), np.array([0], dtype=np.intp)
+    )
+    tm.assert_numpy_array_equal(
+        idx.get_locs((slice(None), [0.5])), np.array([0], dtype=np.intp)
+    )
+
+
+def test_get_locs_list_like_float16_key():
+    # GH#64807 - an Index cannot hold float16 at all, so building one from the
+    #  key must not turn a lookup into NotImplementedError
+    idx = MultiIndex.from_product([["a"], [1.0, 2.0, 3.0]])
+    result = idx.get_locs((["a"], [np.float16(1.0)]))
+    tm.assert_numpy_array_equal(result, np.array([0], dtype=np.intp))
+
+    idx = MultiIndex.from_product([["a"], date_range("2020", periods=3)])
+    with pytest.raises(KeyError, match="1.0"):
+        idx.get_locs((["a"], [np.float16(1.0)]))
+
+
+def test_get_locs_list_like_nan_key_without_nan_rows():
+    # GH#64807 - a NaN key must raise when the data carries no NA rows, even
+    #  though NaN is looked up without needing a level entry
+    idx = MultiIndex.from_arrays([["a", "a"], [1.0, 2.0]])
+    with pytest.raises(KeyError, match="nan"):
+        idx.get_locs((slice(None), [np.nan]))
+
+
+def test_get_locs_list_like_object_container_key():
+    # GH#64807 - an object container hides the dtype its labels would match as,
+    #  so it must not slip past the strict-path gate in either direction
+    idx = MultiIndex.from_arrays(
+        [["a", "a", "b"], np.array([1.1, 2.2, 1.1], dtype=np.float32)]
+    )
+    result = idx.get_locs((slice(None), np.array([1.1], dtype=object)))
+    tm.assert_numpy_array_equal(result, np.array([0, 2], dtype=np.intp))
+
+    # np.timedelta64 compares equal to a plain int, so an object level holding
+    #  them matches an object int key that the scalar path rejects
+    level = Index(
+        np.array([np.timedelta64(1, "D"), np.timedelta64(2, "D")], dtype=object),
+        dtype=object,
+    )
+    assert level.get_indexer(np.array([1, 2], dtype=object)).tolist() == [0, 1]
+    idx = MultiIndex.from_arrays([["x", "y"], level])
+    with pytest.raises(KeyError, match="1"):
+        idx.get_locs((slice(None), np.array([1, 2], dtype=object)))
+
+
+def test_get_locs_list_like_categorical_level():
+    # GH#64807 - smoke test for the categorical fast path, which no other case
+    #  in this file covers; the dtype resolution behind it is a cost shortcut
+    idx = MultiIndex.from_product([pd.CategoricalIndex(list("abc")), [1, 2]])
+    result = idx.get_locs((["a", "c"], slice(None)))
+    tm.assert_numpy_array_equal(result, np.array([0, 1, 4, 5], dtype=np.intp))
+
+
+@pytest.mark.parametrize(
+    "keys, match",
+    [
+        ((["a", "b"], slice(None)), "['a', 'b']"),
+        ((["b"], slice(None)), "['b']"),
+    ],
+)
+def test_get_locs_list_like_unused_level_raises(keys, match):
+    # GH#64807 - a label present in the level but unused by any code is missing,
+    #  just as it is when passed as a scalar
+    idx = MultiIndex.from_product([["a", "b"], [1, 2, 3]])[:3]
+    assert "b" in idx.levels[0]
+    with pytest.raises(KeyError, match=re.escape(match)):
+        idx.get_locs(keys)
+
+
+def test_get_locs_list_like_nan_code_vs_last_level_label():
+    # GH#64807 - the -1 code standing for NaN must not wrap around onto the
+    #  last level entry, which would both leak the NaN row in...
+    idx = MultiIndex.from_arrays([["a"] * 3, [1.0, np.nan, 2.0]])
+    result = idx.get_locs((["a"], [2.0]))
+    tm.assert_numpy_array_equal(result, np.array([2], dtype=np.intp))
+
+    # ...and make an unused last label look used
+    idx = MultiIndex.from_arrays([["a"] * 4, [1.0, np.nan, 1.0, 2.0]])[:3]
+    assert 2.0 in idx.levels[1]
+    with pytest.raises(KeyError, match=re.escape("[2.0]")):
+        idx.get_locs((["a"], [2.0]))
+
+
+def test_get_locs_list_like_na_label_against_na_in_level():
+    # GH#64807 - a level can carry an NA entry of its own that no code uses,
+    #  while the NA rows carry code -1 (e.g. concatenating a
+    #  groupby(dropna=False) result with an ordinary NaN-indexed frame, then
+    #  dropping rows). get_indexer matches an NA label to that entry, so it must
+    #  not be mistaken for a label the level does not have.
+    idx = MultiIndex(
+        levels=[Index(["a"]), Index([1.0, np.nan, 2.0])], codes=[[0, 0], [-1, 0]]
+    )
+    expected = idx.get_locs((slice(None), np.nan))
+    result = idx.get_locs((slice(None), [np.nan]))
+    tm.assert_numpy_array_equal(result, expected)
+
+    # and a genuinely missing label alongside it must still raise
+    with pytest.raises(KeyError, match=re.escape("[nan, 9.9]")):
+        idx.get_locs((slice(None), [np.nan, 9.9]))
+
+
+def test_get_locs_list_like_na_label_not_matched_to_level_entry():
+    # GH#64807 - get_indexer can match an NA label to an NA entry of the level,
+    #  but the scalar path always resolves NA to code -1, so the list path has
+    #  to select the -1 rows only and agree with it
+    idx = MultiIndex.from_arrays([["a"] * 3, [1.0, np.nan, 3.0]])
+    idx = idx.set_levels(Index([1.0, np.nan]), level=1, verify_integrity=False)
+    assert idx.levels[1].hasnans
+
+    expected = np.array([1], dtype=np.intp)
+    tm.assert_numpy_array_equal(idx.get_locs((slice(None), [np.nan])), expected)
+    tm.assert_numpy_array_equal(idx.get_locs((slice(None), np.nan)), expected)
+
+
+def test_get_locs_list_like_multiindex_key():
+    # GH#64807 - tuple-valued level labels, so the key itself is a MultiIndex.
+    #  isna() answers per tuple *element*, which for a single label broadcasts
+    #  against the codes silently and for several of them does not broadcast at
+    #  all, so both lengths are worth covering.
+    idx = MultiIndex.from_arrays([[("x", 1), ("y", 2), ("z", 3)], list("abc")])
+    result = idx.get_locs((Index([("x", 1), ("y", 2), ("z", 3)]), slice(None)))
+    tm.assert_numpy_array_equal(result, np.array([0, 1, 2], dtype=np.intp))
+
+    result = idx.get_locs((Index([("x", 1)]), slice(None)))
+    tm.assert_numpy_array_equal(result, np.array([0], dtype=np.intp))
+
+
+def test_get_locs_list_like_mixed_type_key():
+    # GH#64807 - a TimedeltaIndex level parses "1 days", but a key mixing
+    #  strings and Timedeltas becomes an object-dtype target that get_indexer
+    #  cannot convert, so it reports the string as missing. Only which rows are
+    #  selected is pinned here; ordering such a key is a separate, older bug.
+    idx = MultiIndex.from_product([["a"], pd.timedelta_range("1 day", periods=3)])
+    result = idx.get_locs((["a"], ["1 days", pd.Timedelta("2 days")]))
+    tm.assert_numpy_array_equal(result, np.array([0, 1], dtype=np.intp))
+
+    # a label the level genuinely lacks still raises
+    with pytest.raises(KeyError, match="9 days"):
+        idx.get_locs((["a"], ["9 days", pd.Timedelta("2 days")]))
+
+
+@pytest.mark.parametrize(
+    "level", [[True, False], pd.array([True, False], dtype="boolean")]
+)
+def test_get_locs_list_like_bool_level_numeric_key(level):
+    # GH#64807 - a mixed key is matched in object space, where 0 == False, so a
+    #  numeric label must not match a bool level entry the scalar path rejects
+    idx = MultiIndex.from_arrays([["a", "b"], level])
+    with pytest.raises(KeyError, match="0"):
+        idx.get_locs((slice(None), [True, 0]))
+
+
+def test_get_locs_list_like_numeric_level_bool_key():
+    # GH#64807 - and the same the other way round
+    idx = MultiIndex.from_arrays([["a", "b", "c"], [0, 1, 2]])
+    with pytest.raises(KeyError, match="True"):
+        idx.get_locs((slice(None), [True, 2]))
+
+
+def test_get_locs_list_like_float32_level():
+    # GH#64807 - get_indexer widens the level to hold the key, and a float64
+    #  key never equals a float32 label once it does
+    idx = MultiIndex.from_arrays(
+        [["a", "a", "b"], np.array([1.1, 2.2, 1.1], dtype=np.float32)]
+    )
+    expected = np.array([0, 2], dtype=np.intp)
+    tm.assert_numpy_array_equal(idx.get_locs((slice(None), [1.1])), expected)
+    tm.assert_numpy_array_equal(idx.get_locs((slice(None), 1.1)), expected)
+
+    # pd.NA leaves the key container object dtype, which must not excuse it
+    idx = MultiIndex(
+        levels=[Index(["a", "b"]), Index(np.array([1.1, 2.2], dtype=np.float32))],
+        codes=[[0, 0, 1], [0, -1, 0]],
+    )
+    result = idx.get_locs((slice(None), [1.1, pd.NA]))
+    tm.assert_numpy_array_equal(result, np.array([0, 1, 2], dtype=np.intp))
+
+
+@pytest.mark.parametrize("dtype", ["uint8", "UInt8", "uint8[pyarrow]"])
+def test_get_locs_list_like_unsigned_level_wide_key(dtype):
+    # GH#64807 - get_indexer casts the key down to an unsigned level unchecked,
+    #  so 256 wrapped onto the 0 label
+    if "pyarrow" in dtype:
+        pytest.importorskip("pyarrow")
+    idx = MultiIndex.from_arrays([["a", "b", "c"], pd.array([0, 1, 2], dtype=dtype)])
+    with pytest.raises(KeyError, match="256"):
+        idx.get_locs((slice(None), [256]))
+    with pytest.raises(KeyError, match="256"):
+        idx.get_locs((slice(None), 256))
+
+
+def test_get_locs_list_like_categorical_key():
+    # GH#64807 - a Categorical key has to be resolved to its categories' dtype,
+    #  or comparing dtypes hashes the CategoricalDtype and can raise
+    level = Index([(1,), (2,), (3,)], dtype=object)
+    idx = MultiIndex(
+        levels=[Index(list("abc")), level],
+        codes=[[0, 1, 2], [0, 1, 2]],
+        verify_integrity=False,
+    )
+    with pytest.raises(KeyError, match="9"):
+        idx.get_locs((slice(None), Categorical([(1,), 9])))
+
+
+def test_get_locs_list_like_unsigned_key_signed_level():
+    # GH#64807 - a signed/unsigned mix widens to float, not to a wider integer,
+    #  so the >2**53 collision applies just as it does to a float key
+    idx = MultiIndex.from_arrays([["a", "b"], [2**53, 2**53 + 1]])
+    expected = np.array([0], dtype=np.intp)
+    result = idx.get_locs((slice(None), pd.array([2**53], dtype="UInt64")))
+    tm.assert_numpy_array_equal(result, expected)
+    tm.assert_numpy_array_equal(idx.get_locs((slice(None), 2**53)), expected)
+
+
+def test_get_locs_list_like_int_level_float_key():
+    # GH#64807 - above 2**53 two int64 labels collide once the key widens them
+    #  to float64, which picked the wrong row rather than raising
+    idx = MultiIndex.from_arrays([["a", "a"], [2**62, 2**62 + 1]])
+    expected = np.array([0], dtype=np.intp)
+    tm.assert_numpy_array_equal(idx.get_locs((slice(None), [float(2**62)])), expected)
+    tm.assert_numpy_array_equal(idx.get_locs((slice(None), 2**62)), expected)
+
+
+@pytest.mark.parametrize("dtype", ["int64", "Int64"])
+def test_get_locs_list_like_complex_key_int_level(dtype):
+    # GH#64807 - and a complex key must not match an integer label that the
+    #  scalar path rejects, extension level or not
+    idx = MultiIndex.from_arrays([["a", "b"], pd.array([20, 21], dtype=dtype)])
+    with pytest.raises(KeyError, match="20"):
+        idx.get_locs((["a"], [20 + 0j]))
+
+
+def test_get_locs_list_like_narrow_int_level():
+    # GH#64807 - a wider integer holds every value of a narrower one, so an
+    #  int64 key still matches an int32 level exactly
+    idx = MultiIndex.from_product([["a"], Index(np.arange(5, dtype="int32"))])
+    result = idx.get_locs((["a"], [1, 3]))
+    tm.assert_numpy_array_equal(result, np.array([1, 3], dtype=np.intp))
+
+
+def test_get_locs_list_like_object_level_typed_key():
+    # GH#64807 - get_indexer promotes an object level of dates to datetimes
+    #  before matching, so it accepts a Timestamp the scalar path rejects
+    idx = MultiIndex.from_arrays([["x", "y"], [date(2020, 1, 1), date(2020, 1, 2)]])
+    with pytest.raises(KeyError, match="2020-01-01"):
+        idx.get_locs((slice(None), [pd.Timestamp("2020-01-01")]))
+
+    # the level's own kind of label still matches
+    result = idx.get_locs((slice(None), [date(2020, 1, 1)]))
+    tm.assert_numpy_array_equal(result, np.array([0], dtype=np.intp))
+
+
+def test_get_locs_list_like_ragged_tuple_labels():
+    # GH#64807 - a tuple key of tuple-valued labels must not be tupleized into
+    #  a single label by Index()
+    idx = MultiIndex.from_arrays([[("x", 1), ("y", 2, 3)], ["a", "b"]])
+    expected = np.array([0, 1], dtype=np.intp)
+    tm.assert_numpy_array_equal(
+        idx.get_locs(((("x", 1), ("y", 2, 3)), slice(None))), expected
+    )
+    tm.assert_numpy_array_equal(
+        idx.get_locs(([("x", 1), ("y", 2, 3)], slice(None))), expected
+    )
+
+
+def test_get_locs_list_like_wide_level():
+    # GH#64807 - slicing a MultiIndex leaves its levels untrimmed, so the level
+    #  can be bigger than the codes; unused labels must still raise there
+    idx = MultiIndex.from_product([list("abcde"), [1]])[:2]
+    assert len(idx.levels[0]) > len(idx.codes[0])
+
+    result = idx.get_locs((["a", "b"], slice(None)))
+    tm.assert_numpy_array_equal(result, np.array([0, 1], dtype=np.intp))
+
+    with pytest.raises(KeyError, match=re.escape("['a', 'c']")):
+        idx.get_locs((["a", "c"], slice(None)))
+
+
+@pytest.mark.parametrize("keys, expected", [([1.5], [0, 1]), ([Interval(0, 2)], [0])])
+def test_get_locs_list_like_overlapping_interval_level(keys, expected):
+    # GH#64807 - an overlapping IntervalIndex level cannot use get_indexer; a
+    #  label there can match several level entries, e.g. 1.5 is in both
+    level = IntervalIndex.from_tuples([(0, 2), (1, 3)])
+    idx = MultiIndex.from_product([["a", "b"], level])
+    result = idx.get_locs((["a"], keys))
+    tm.assert_numpy_array_equal(result, np.array(expected, dtype=np.intp))
 
 
 def test_get_indexer_for_multiindex_with_nans(nulls_fixture):


### PR DESCRIPTION
Fixes a family of regressions from GH-64807 (PERF: vectorize `MultiIndex.get_locs` for list-like keys). Unreleased, so no whatsnew.

### Scope

An earlier revision of this PR held the vectorized path to the *pre*-GH-64807 per-label loop, on the theory that a list-like key should select what the equivalent scalar lookups select. pandas does not guarantee that — partial-string indexing on a `DatetimeIndex` level is the standing counterexample — so this PR no longer chases it. A list-like key resolves through `Index.get_indexer`, exactly as it does for a flat `Index`, and the scalar path is free to disagree.

Two visible consequences, both matching what a flat `Index` already does with the same key:

- `[1.1]` against a `float32` level raises, where scalar `1.1` matches.
- an object-dtype key containing `0` matches a bool level's `False`, since `get_indexer` compares in object space.

### Fixed

- an NA label was conflated with genuinely missing labels whenever the level carried an NA entry of its own, silently swallowing a missing label (this half predates GH-64807)
- a label present in an untrimmed level but unused by any code selected rows or stopped raising depending on level size; the `-1` code standing for NaN could wrap onto the last level entry
- `range` / generator / `set` / `dict` / tuple / `MultiIndex` key containers crashed or were mangled — `isna` scalar results, `Index()` tupleizing ragged tuple labels, the iterator drained by the single-label probe
- unhashable and (from Python 3.12) `slice` labels, keys `Index` cannot hold at all (float16, month-unit timedelta64), and empty typed keys
- overlapping-`IntervalIndex` levels, including behind a `CategoricalIndex`, resolve per-label, since one label can match several level entries
- a signed level with an unsigned key, or the reverse: `get_indexer` reconciles the two through float64 and collides distinct labels above 2\*\*53, selecting the wrong row. A flat `Index` reaches those labels through `_get_indexer_strict` and is unaffected, so this is guarded rather than inherited. The same guard restores `KeyError` for `256` against a `uint8` level, which `get_indexer` casts down unchecked.

### Deliberately not fixed here

Two `Index.get_indexer` bugs that a flat `Index` has as well, to be filed separately rather than papered over locally in `get_locs`: the unchecked unsigned downcast above, and a float64 key colliding two int64 labels above 2\*\*53.

### Verification

`pandas/tests/indexes` and `pandas/tests/indexing` pass in full. Across the level-dtype × key-dtype cases this PR touches, `get_locs` now returns what the equivalent flat-`Index` list-like lookup returns, except for the signed/unsigned guard above. The vectorized path is taken for strictly more keys than in the previous revision, so the GH-64807 speedup is retained.
