### PR TITLE
BUG: preserve NaN position in Series.unstack(sort=False)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -798,6 +798,7 @@ Reshaping
 - Bug in :meth:`DataFrame.stack` raising a bare ``AssertionError`` or an ``IndexError`` when ``level`` contained duplicate entries, including duplicates produced by resolving level names or negative level numbers; it now raises an informative ``ValueError`` (:issue:`66588`)
 - Bug in :meth:`DataFrame.unstack` and :meth:`Series.unstack` with ``sort=False`` placing values under the wrong row labels, or collapsing distinct index combinations into a single row (:issue:`62816`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
+- Bug in :meth:`Series.unstack` with ``sort=False`` always placing a ``NaN`` column first without reordering the corresponding values (:issue:`66672`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)
 - In :func:`pivot_table`, when ``values`` is empty, the aggregation will be computed on a Series of all NA values (:issue:`46475`)
 -

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -399,7 +399,10 @@ class _Unstacker:
             if not self.has_nan:
                 return self.removed_level._rename(name=self.removed_name)
 
-            lev = self.removed_level.insert(0, item=self.removed_level._na_value)
+            nan_index = 0 if self.sort else self.unique_nan_index
+            lev = self.removed_level.insert(
+                nan_index, item=self.removed_level._na_value
+            )
             return lev.rename(self.removed_name)
 
         stride = len(self.removed_level) + self.has_nan

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1425,6 +1425,30 @@ def test_unstack_sort_false_nan(levels2, expected_columns):
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize(
+    "levels2",
+    [
+        [np.nan, 8.0, 7.0],
+        [8.0, np.nan, 7.0],
+        [8.0, 7.0, np.nan],
+    ],
+    ids=["nan=first", "nan=second", "nan=last"],
+)
+def test_unstack_sort_false_nan_series(levels2):
+    # GH#66672
+    index = MultiIndex.from_product([["r"], levels2], names=["x", "z"])
+    ser = Series([1.0, 2.0, 3.0], index=index)
+
+    result = ser.unstack(level="z", sort=False)
+
+    expected = DataFrame(
+        [[1.0, 2.0, 3.0]],
+        index=Index(["r"], name="x"),
+        columns=Index(levels2, name="z"),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_unstack_sort_false_unsorted_with_gaps():
     # Unsorted MI with missing combinations, unstacking non-last level
     # with sort=False. Exercises the identity=False, mask_all=False,


### PR DESCRIPTION
- [x] closes #66672
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions (not applicable; no new API).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

For NumPy-backed Series, `unstack(sort=False)` kept values in first-appearance order but always inserted the `NaN` column label at position 0. Use the tracked first-appearance position for `NaN` when sorting is disabled, while preserving the existing sorted behavior.

Regression coverage checks `NaN` in the first, middle, and last positions. AI assistance was used to develop this pull request; the changes were reviewed and adjusted against `AGENTS.md` and the pandas contribution guidelines.

Tests:

- `python -m pytest pandas/tests/frame/test_stack_unstack.py -q` (1041 passed, 2 skipped)
- `pre-commit run --files pandas/core/reshape/reshape.py pandas/tests/frame/test_stack_unstack.py doc/source/whatsnew/v3.1.0.rst`
