### PR TITLE
BUG: stata mixed-tz object dates and version-error enumeration (GH#64556, GH#63082)

### DIFF
--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -87,6 +87,12 @@ if TYPE_CHECKING:
         WriteBuffer,
     )
 
+# The format versions each header reader accepts. _version_error enumerates
+#  both, so keep them in sync -- GH#63082 dropped four of these from the
+#  message while the readers went on accepting them.
+_old_format_versions: Final = [102, 103, 104, 105, 108, 110, 111, 113, 114, 115]
+_new_format_versions: Final = [117, 118, 119]
+
 # Error shown when a version number was parsed but is not supported.
 # Wording intentionally mentions “either not a valid Stata dataset or
 # an unsupported version” to avoid confusing users when input is not a
@@ -94,9 +100,10 @@ if TYPE_CHECKING:
 _version_error = (
     "This is either not a valid Stata dataset or a Stata dataset from a "
     "version pandas does not support (detected: {version}). pandas "
-    "supports importing versions 105, 108, 111 (Stata 7SE), 113 (Stata "
-    "8/9), 114 (Stata 10/11), 115 (Stata 12), 117 (Stata 13), 118 (Stata "
-    "14/15/16), and 119 (Stata 15/16, over 32,767 variables)."
+    "supports importing versions 102, 103, 104, 105, 108, 110 (Stata 7), "
+    "111 (Stata 7SE), 113 (Stata 8/9), 114 (Stata 10/11), 115 (Stata 12), "
+    "117 (Stata 13), 118 (Stata 14/15/16), and 119 (Stata 15/16, over "
+    "32,767 variables)."
 )
 
 
@@ -281,9 +288,16 @@ def _datetime_to_stata_elapsed_vec(dates: Series, fmt: str) -> Series:
                 v = np.vectorize(f)
                 d["delta"] = v(delta) // 1_000  # convert back to ms
             if year:
-                date_index = DatetimeIndex(dates)
-                d["year"] = date_index.year
-                d["month"] = date_index.month
+                try:
+                    date_index = DatetimeIndex(dates)
+                except ValueError:
+                    # GH#64556 entries not sharing a single tzinfo cannot be
+                    #  cast to datetime64, but we only need each object's fields
+                    d["year"] = [date.year for date in dates]
+                    d["month"] = [date.month for date in dates]
+                else:
+                    d["year"] = date_index.year
+                    d["month"] = date_index.month
             if days:
 
                 def g(x: datetime) -> int:
@@ -1189,7 +1203,7 @@ class StataReader(StataParser, abc.Iterator):
         # The first part of the header is common to 117 - 119.
         self._path_or_buf.read(27)  # stata_dta><header><release>
         self._format_version = int(self._path_or_buf.read(3))
-        if self._format_version not in [117, 118, 119]:
+        if self._format_version not in _new_format_versions:
             raise ValueError(_version_error.format(version=self._format_version))
         self._set_encoding()
         self._path_or_buf.read(21)  # </release><byteorder>
@@ -1350,18 +1364,7 @@ class StataReader(StataParser, abc.Iterator):
 
     def _read_old_header(self, first_char: bytes) -> None:
         self._format_version = int(first_char[0])
-        if self._format_version not in [
-            102,
-            103,
-            104,
-            105,
-            108,
-            110,
-            111,
-            113,
-            114,
-            115,
-        ]:
+        if self._format_version not in _old_format_versions:
             raise ValueError(_version_error.format(version=self._format_version))
         self._set_encoding()
         # Note 102 format will have a zero in this header position, so support

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -34,6 +34,10 @@ from pandas.io.stata import (
     StataWriter,
     StataWriterUTF8,
     ValueLabelTypeMismatch,
+    _datetime_to_stata_elapsed_vec,
+    _new_format_versions,
+    _old_format_versions,
+    _version_error,
     read_stata,
 )
 
@@ -2645,6 +2649,70 @@ def test_stata_v117_prefix_with_unsupported_version_raises_version_error():
         match=r"either not a valid Stata dataset.*\(detected:\s*999\)",
     ):
         read_stata(buf)
+
+
+def test_version_error_lists_every_supported_version():
+    # GH#63082 the message dropped the four oldest formats that are still read;
+    #  derive from the readers' own lists so the two cannot drift again
+    msg = _version_error.format(version=999)
+    for version in _old_format_versions + _new_format_versions:
+        assert str(version) in msg
+
+
+object_date_depr_msg = (
+    "Converting object-dtype columns of datetimes to datetime64 "
+    "when writing to stata is deprecated"
+)
+
+
+@pytest.mark.parametrize(
+    "fmt, expected, roundtrip",
+    [
+        ("tm", [720, 737], ["2020-01-01", "2021-06-01"]),
+        ("tq", [240, 245], ["2020-01-01", "2021-04-01"]),
+        ("th", [120, 122], ["2020-01-01", "2021-01-01"]),
+        ("ty", [2020, 2021], ["2020-01-01", "2021-01-01"]),
+    ],
+)
+def test_to_stata_object_dates_heterogeneous_tz(temp_file, fmt, expected, roundtrip):
+    # GH#64556 year/month came from DatetimeIndex(dates), which rejects an
+    #  object array whose entries do not share a single tzinfo
+    tz = dt.timezone(dt.timedelta(hours=-5))
+    ser = Series(
+        [datetime(2020, 1, 1, tzinfo=dt.UTC), datetime(2021, 6, 15, tzinfo=tz)],
+        dtype=object,
+    )
+    with tm.assert_produces_warning(Pandas4Warning, match=object_date_depr_msg):
+        result = _datetime_to_stata_elapsed_vec(ser, fmt)
+    # "ty" carries through the "year" name of the intermediate frame column
+    tm.assert_series_equal(
+        result, Series(expected, dtype=np.float64), check_names=False
+    )
+
+    df = DataFrame({"d": ser})
+    with tm.assert_produces_warning(Pandas4Warning, match=object_date_depr_msg):
+        df.to_stata(temp_file, convert_dates={"d": fmt}, write_index=False)
+    written_and_read_again = read_stata(temp_file)
+    tm.assert_frame_equal(
+        written_and_read_again, DataFrame({"d": Series(roundtrip, dtype="M8[s]")})
+    )
+
+
+def test_to_stata_object_dates_naive_and_aware_with_nat(temp_file):
+    # GH#64556 a naive/aware mix, with or without NaT, likewise has no single
+    #  tzinfo and so takes the same fallback
+    tz = dt.timezone(dt.timedelta(hours=-5))
+    ser = Series(
+        [datetime(2020, 1, 1), None, datetime(2021, 6, 15, tzinfo=tz)], dtype=object
+    )
+    df = DataFrame({"d": ser})
+    with tm.assert_produces_warning(Pandas4Warning, match=object_date_depr_msg):
+        df.to_stata(temp_file, convert_dates={"d": "tm"}, write_index=False)
+    written_and_read_again = read_stata(temp_file)
+    expected = DataFrame(
+        {"d": Series(["2020-01-01", None, "2021-06-01"], dtype="M8[s]")}
+    )
+    tm.assert_frame_equal(written_and_read_again, expected)
 
 
 def test_read_stata_far_future_dates(datapath):


### PR DESCRIPTION
Two audit follow-ups in `pandas/io/stata.py`. No closing keyword: GH-64555 is already closed by GH-64556, and GH-63082 had no linked issue.

**`to_stata` on object-dtype dates with mixed `tzinfo`.** GH-64556 replaced a per-element `dates.apply(lambda x: 100 * x.year + x.month)` with `DatetimeIndex(dates)` as a perf optimization. `DatetimeIndex` rejects an object array whose entries do not all share one `tzinfo`, so this regressed:

```python
ser = Series([datetime(2020, 1, 1, tzinfo=timezone.utc),
              datetime(2021, 6, 15, tzinfo=timezone(timedelta(hours=-5)))], dtype=object)
DataFrame({"d": ser}).to_stata(path, convert_dates={"d": "tm"})
# ValueError: Tz-aware datetime.datetime cannot be converted to datetime64 unless utc=True
```

Affects the `"tm"`, `"tq"`, `"th"` and `"ty"` formats, and a naive/aware mix (with or without `NaT`) the same way. Fixed by falling back to per-element field extraction when the cast fails, which reproduces the pre-GH-64556 values exactly while keeping the vectorized fast path for the common single-tz case.

**`read_stata` unsupported-version message.** GH-63082 reworded `_version_error` and dropped versions 102, 103, 104 and 110 from its enumeration, even though `_read_old_header` still accepts all four — so a user with an unreadable file was told those formats are unsupported when they are not. Restored them, and hoisted both readers' accepted-version lists into `_old_format_versions` / `_new_format_versions` so the message and the readers are checked against the same source. The test iterates those constants, so adding a format without updating the message now fails.

Neither regression appears in a released pandas — checked by content against the `v3.0.0` and `v3.0.5` tags rather than by SHA ancestry, since backports carry different SHAs — so there are no whatsnew entries.