### PR TITLE
TST: cover the NaT-sentinel and non-tz-rule branches of the nonexistent shift (GH#66697)

### DIFF
--- a/pandas/tests/indexes/datetimes/methods/test_tz_localize.py
+++ b/pandas/tests/indexes/datetimes/methods/test_tz_localize.py
@@ -503,14 +503,24 @@ class TestTZLocalize:
         with pytest.raises(OutOfBoundsDatetime, match="overflows past"):
             dti.tz_localize("US/Eastern", nonexistent=Timedelta.max)
 
-    def test_dti_tz_localize_nonexistent_shift_utc_overflow(self):
+    @pytest.mark.parametrize(
+        "tz, start_ts",
+        [
+            # US/Eastern has a DST rule past the last cached transition and
+            #  America/Sao_Paulo does not, so the two reach the offset that
+            #  applies by different routes
+            ("US/Eastern", "2011-03-13 02:30"),
+            ("America/Sao_Paulo", "2018-11-04 00:30"),
+        ],
+    )
+    def test_dti_tz_localize_nonexistent_shift_utc_overflow(self, tz, start_ts):
         # GH#66697
-        ts = Timestamp("2011-03-13 02:30").as_unit("ns")
+        ts = Timestamp(start_ts).as_unit("ns")
         dti = DatetimeIndex([ts, ts])
         shift = Timestamp.max - ts - Timedelta(hours=1)
 
         with pytest.raises(OutOfBoundsDatetime, match="overflows past"):
-            dti.tz_localize("US/Eastern", nonexistent=shift)
+            dti.tz_localize(tz, nonexistent=shift)
 
 
 def test_dti_tz_localize_nonexistent_shift_past_last_transition():
@@ -526,6 +536,18 @@ def test_dti_tz_localize_nonexistent_shift_past_last_transition():
     expected = DatetimeIndex([dti[0] + shift]).tz_localize(tz)
     tm.assert_index_equal(result, expected)
     tm.assert_index_equal(result, dti.tz_localize(tz, nonexistent=shift))
+
+
+def test_dti_tz_localize_nonexistent_timedelta_shift_onto_nat_sentinel():
+    # GH#66697 shifting a nonexistent time to a wall time whose UTC instant is
+    #  exactly the NaT sentinel, one below Timestamp.min, used to come back as a
+    #  missing value.  Asia/Tokyo's +9 offset is what makes the two line up.
+    dti = DatetimeIndex([Timestamp("1948-05-02 00:30")]).as_unit("ns")
+    jst = 9 * 3600 * 10**9
+    shift = Timedelta(Timestamp.min._value - 1 + jst - dti.asi8[0], "ns")
+
+    with pytest.raises(OutOfBoundsDatetime, match="underflows past"):
+        dti.tz_localize("Asia/Tokyo", nonexistent=shift)
 
 
 def _make_tzfile_ending_in_spring_forward(filename):


### PR DESCRIPTION
Test-only follow-up to GH-66718, which guarded the nonexistent-shift block in `tz_localize_to_utc`. Two gaps it left:

- The sentinel branch it added was untested. `test_dti_tz_localize_nonexistent_timedelta_shift_onto_nat_sentinel` covers the Asia/Tokyo case where the shifted wall time's UTC instant is exactly the `NaT` sentinel — on the pre-GH-66718 code that comes back as a missing value rather than raising.
- `test_dti_tz_localize_nonexistent_shift_utc_overflow` only exercised `US/Eastern`, whose DST rule extends past the last cached transition, so the shift reaches the applicable offset through the `has_tz_rule` fastpath. Parametrized it over `America/Sao_Paulo`, which has no such rule and goes through the bisect path instead. That case also raises on pre-GH-66718 code, via an incidental `check_overflows` when the result is boxed, so it is branch coverage rather than a regression test.

xref GH-66697.