### PR TITLE
ENH: add excel_sep_hint parameter to to_csv

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2281,7 +2281,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         excel_sep_hint : bool, default False
             If True, prepend a separator hint to help Microsoft Excel detect
             the delimiter.
-
         engine_kwargs : dict, optional
             Arbitrary keyword arguments passed to excel engine.
         autofilter : bool, default False

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2277,10 +2277,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             details, and for more examples on storage options refer `here
             <https://pandas.pydata.org/docs/user_guide/io.html?
             highlight=storage_options#reading-writing-remote-files>`_.
-            
-        excel_sep_hint : bool, default False
-            If True, prepend a separator hint to help Microsoft Excel detect
-            the delimiter.
+
         engine_kwargs : dict, optional
             Arbitrary keyword arguments passed to excel engine.
         autofilter : bool, default False
@@ -4048,6 +4045,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             details, and for more examples on storage options refer `here
             <https://pandas.pydata.org/docs/user_guide/io.html?
             highlight=storage_options#reading-writing-remote-files>`_.
+
+        excel_sep_hint : bool, default False
+            If True, prepend a separator hint to help Microsoft Excel detect
+            the delimiter.
 
         Returns
         -------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3879,6 +3879,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ...,
         errors: OpenFileErrors = ...,
         storage_options: StorageOptions = ...,
+        excel_sep_hint: bool = ...,
     ) -> str: ...
 
     @overload
@@ -3906,6 +3907,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ...,
         errors: OpenFileErrors = ...,
         storage_options: StorageOptions = ...,
+        excel_sep_hint: bool = ...,
     ) -> None: ...
 
     @final
@@ -3933,6 +3935,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ".",
         errors: OpenFileErrors = "strict",
         storage_options: StorageOptions | None = None,
+        excel_sep_hint: bool = False,
     ) -> str | None:
         r"""
         Write object to a comma-separated values (csv) file.
@@ -4123,6 +4126,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             doublequote=doublequote,
             escapechar=escapechar,
             storage_options=storage_options,
+            excel_sep_hint=excel_sep_hint,
         )
 
     # ----------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -2277,6 +2277,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             details, and for more examples on storage options refer `here
             <https://pandas.pydata.org/docs/user_guide/io.html?
             highlight=storage_options#reading-writing-remote-files>`_.
+            
+        excel_sep_hint : bool, default False
+            If True, prepend a separator hint to help Microsoft Excel detect
+            the delimiter.
 
         engine_kwargs : dict, optional
             Arbitrary keyword arguments passed to excel engine.

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -261,6 +261,8 @@ class CSVFormatter:
             # Note: self.encoding is irrelevant here
             # error: Argument "quoting" to "writer" has incompatible type "int";
             # expected "Literal[0, 1, 2, 3]"
+            if self.excel_sep_hint:
+                handles.handle.write(f"sep={self.sep}{self.lineterminator}")
             self.writer = csvlib.writer(
                 handles.handle,
                 lineterminator=self.lineterminator,
@@ -274,8 +276,6 @@ class CSVFormatter:
             self._save()
 
     def _save(self) -> None:
-        if self.excel_sep_hint:
-            self.writer.writerow([f"sep={self.sep}"])
         if self._need_to_save_header:
             self._save_header()
         self._save_body()

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -274,11 +274,11 @@ class CSVFormatter:
             self._save()
 
     def _save(self) -> None:
-    if self.excel_sep_hint:
-        self.writer.writerow([f"sep={self.sep}"])
-    if self._need_to_save_header:
-        self._save_header()
-    self._save_body()
+        if self.excel_sep_hint:
+            self.writer.writerow([f"sep={self.sep}"])
+        if self._need_to_save_header:
+            self._save_header()
+        self._save_body()
 
     def _save_header(self) -> None:
         if not self.has_mi_columns or self._has_aliases:

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -75,6 +75,7 @@ class CSVFormatter:
         doublequote: bool = True,
         escapechar: str | None = None,
         storage_options: StorageOptions | None = None,
+        excel_sep_hint: bool = False,
     ) -> None:
         self.fmt = formatter
 
@@ -85,6 +86,7 @@ class CSVFormatter:
         self.compression: CompressionOptions = compression
         self.mode = mode
         self.storage_options = storage_options
+        self.excel_sep_hint = excel_sep_hint
 
         self.sep = sep
         self.index_label = self._initialize_index_label(index_label)
@@ -272,9 +274,11 @@ class CSVFormatter:
             self._save()
 
     def _save(self) -> None:
-        if self._need_to_save_header:
-            self._save_header()
-        self._save_body()
+    if self.excel_sep_hint:
+        self.writer.writerow([f"sep={self.sep}"])
+    if self._need_to_save_header:
+        self._save_header()
+    self._save_body()
 
     def _save_header(self) -> None:
         if not self.has_mi_columns or self._has_aliases:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -994,6 +994,7 @@ class DataFrameRenderer:
         escapechar: str | None = None,
         errors: str = "strict",
         storage_options: StorageOptions | None = None,
+        excel_sep_hint: bool = False,
     ) -> str | None:
         """
         Render dataframe as comma-separated file.
@@ -1023,6 +1024,7 @@ class DataFrameRenderer:
             doublequote=doublequote,
             escapechar=escapechar,
             storage_options=storage_options,
+            excel_sep_hint=excel_sep_hint,
             formatter=self.fmt,
         )
         csv_formatter.save()

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -182,6 +182,14 @@ $1$,$2$
         # same for a multi-index
         assert df.set_index(["a", "b"]).to_csv(float_format="%.2f") == expected
 
+    def test_to_csv_excel_sep_hint():
+    df = DataFrame({"a": [1, 2], "b": [3, 4]})
+
+    result = df.to_csv(sep=";", excel_sep_hint=True)
+    expected = "sep=;\n" + df.to_csv(sep=";")
+
+    assert result == expected
+
     def test_to_csv_na_rep(self):
         # see gh-11553
         #

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -183,12 +183,12 @@ $1$,$2$
         assert df.set_index(["a", "b"]).to_csv(float_format="%.2f") == expected
 
     def test_to_csv_excel_sep_hint():
-    df = DataFrame({"a": [1, 2], "b": [3, 4]})
-
-    result = df.to_csv(sep=";", excel_sep_hint=True)
-    expected = "sep=;\n" + df.to_csv(sep=";")
-
-    assert result == expected
+        df = DataFrame({"a": [1, 2], "b": [3, 4]})
+    
+        result = df.to_csv(sep=";", excel_sep_hint=True)
+        expected = "sep=;\n" + df.to_csv(sep=";")
+    
+        assert result == expected
 
     def test_to_csv_na_rep(self):
         # see gh-11553

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -182,7 +182,7 @@ $1$,$2$
         # same for a multi-index
         assert df.set_index(["a", "b"]).to_csv(float_format="%.2f") == expected
 
-    def test_to_csv_excel_sep_hint():
+    def test_to_csv_excel_sep_hint(self):
         df = DataFrame({"a": [1, 2], "b": [3, 4]})
     
         result = df.to_csv(sep=";", excel_sep_hint=True)

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -189,7 +189,6 @@ $1$,$2$
         expected = "sep=;\n" + df.to_csv(sep=";")
     
         assert result == expected
-
     def test_to_csv_na_rep(self):
         # see gh-11553
         #


### PR DESCRIPTION
### What does this PR do?

Adds an `excel_sep_hint` parameter to `to_csv()` to optionally prepend
an Excel separator hint to CSV output.

For example:

    df.to_csv("data.csv", sep=";", excel_sep_hint=True)

produces:

    sep=;
    ...

### Why is this needed?

Excel may not automatically detect non-comma CSV delimiters in some
locales. The `sep=` hint helps Excel detect the delimiter.

### Tests

Added a test covering `excel_sep_hint=True`.