### PR TITLE
ENH: Add excel_sep_hint parameter to to_csv

### DIFF
--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3879,6 +3879,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ...,
         errors: OpenFileErrors = ...,
         storage_options: StorageOptions = ...,
+        excel_sep_hint: bool = ...,
     ) -> str: ...
 
     @overload
@@ -3906,6 +3907,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ...,
         errors: OpenFileErrors = ...,
         storage_options: StorageOptions = ...,
+        excel_sep_hint: bool = ...,
     ) -> None: ...
 
     @final
@@ -3933,6 +3935,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ".",
         errors: OpenFileErrors = "strict",
         storage_options: StorageOptions | None = None,
+        excel_sep_hint: bool = False,
     ) -> str | None:
         r"""
         Write object to a comma-separated values (csv) file.
@@ -4123,6 +4126,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             doublequote=doublequote,
             escapechar=escapechar,
             storage_options=storage_options,
+            excel_sep_hint=excel_sep_hint,
         )
 
     # ----------------------------------------------------------------------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4045,6 +4045,10 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             details, and for more examples on storage options refer `here
             <https://pandas.pydata.org/docs/user_guide/io.html?
             highlight=storage_options#reading-writing-remote-files>`_.
+        excel_sep_hint : bool, default False
+            If True, prepend a ``sep=<delimiter>`` line before the header row
+            so that Microsoft Excel automatically detects the delimiter when
+            opening the file.
 
         Returns
         -------

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -245,7 +245,7 @@ class CSVFormatter:
 
         return encoded_labels
 
-    def save(self) -> None:
+   def save(self) -> None:
         """
         Create the writer & save.
         """
@@ -258,6 +258,9 @@ class CSVFormatter:
             compression=self.compression,
             storage_options=self.storage_options,
         ) as handles:
+            if self.excel_sep_hint:
+                handles.handle.write(f"sep={self.sep}{self.lineterminator}")
+
             # Note: self.encoding is irrelevant here
             # error: Argument "quoting" to "writer" has incompatible type "int";
             # expected "Literal[0, 1, 2, 3]"
@@ -274,8 +277,6 @@ class CSVFormatter:
             self._save()
 
     def _save(self) -> None:
-        if self.excel_sep_hint:
-            self.writer.writerow([f"sep={self.sep}"])
         if self._need_to_save_header:
             self._save_header()
         self._save_body()

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -245,7 +245,7 @@ class CSVFormatter:
 
         return encoded_labels
 
-   def save(self) -> None:
+    def save(self) -> None:
         """
         Create the writer & save.
         """

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -75,6 +75,7 @@ class CSVFormatter:
         doublequote: bool = True,
         escapechar: str | None = None,
         storage_options: StorageOptions | None = None,
+        excel_sep_hint: bool = False,
     ) -> None:
         self.fmt = formatter
 
@@ -87,6 +88,7 @@ class CSVFormatter:
         self.storage_options = storage_options
 
         self.sep = sep
+        self.excel_sep_hint = excel_sep_hint
         self.index_label = self._initialize_index_label(index_label)
         self.errors = errors
         self.quoting = quoting or csvlib.QUOTE_MINIMAL
@@ -272,6 +274,8 @@ class CSVFormatter:
             self._save()
 
     def _save(self) -> None:
+        if self.excel_sep_hint:
+            self.writer.writerow([f"sep={self.sep}"])
         if self._need_to_save_header:
             self._save_header()
         self._save_body()

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -994,6 +994,7 @@ class DataFrameRenderer:
         escapechar: str | None = None,
         errors: str = "strict",
         storage_options: StorageOptions | None = None,
+        excel_sep_hint: bool = False,
     ) -> str | None:
         """
         Render dataframe as comma-separated file.
@@ -1023,6 +1024,7 @@ class DataFrameRenderer:
             doublequote=doublequote,
             escapechar=escapechar,
             storage_options=storage_options,
+            excel_sep_hint=excel_sep_hint,
             formatter=self.fmt,
         )
         csv_formatter.save()

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -1038,3 +1038,8 @@ def test_to_csv_datetime_tz_consistent_format():
     ]
     expected = tm.convert_rows_list_to_csv_str(expected_rows)
     assert result == expected
+
+def test_excel_sep_hint():
+    df = DataFrame({"A": [1, 2], "B": [3, 4]})
+    result = df.to_csv(sep=";", excel_sep_hint=True, lineterminator="\n")
+    assert result.startswith("sep=;\n")

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -1039,6 +1039,7 @@ def test_to_csv_datetime_tz_consistent_format():
     expected = tm.convert_rows_list_to_csv_str(expected_rows)
     assert result == expected
 
+
 def test_excel_sep_hint():
     df = DataFrame({"A": [1, 2], "B": [3, 4]})
     result = df.to_csv(sep=";", excel_sep_hint=True, lineterminator="\n")


### PR DESCRIPTION
### Feature Description

Adds a new `excel_sep_hint` boolean parameter (default `False`) to `to_csv`. When `True`, prepends a `sep=<delimiter>` line before the header row in the output, which allows Microsoft Excel to automatically detect the correct delimiter when opening CSV files that use a non-comma separator (e.g. semicolons, common in European locales).

**Example:**
```python
df.to_csv('data.csv', sep=';', excel_sep_hint=True)
```

Output:
sep=;
col1;col2;col3
val1;val2;val3

Currently users have to manually prepend this line themselves before calling `to_csv`, which this makes unnecessary.

### Implementation

Threaded the parameter through the full CSV formatting chain:
- `NDFrame.to_csv` (`pandas/core/generic.py`) — added parameter to both overloads and the implementation
- `DataFrameRenderer.to_csv` (`pandas/io/formats/format.py`) — passes it through to `CSVFormatter`
- `CSVFormatter` (`pandas/io/formats/csvs.py`) — stores the flag and writes the `sep=` line in `_save()` before the header

### Tests

Added `test_excel_sep_hint` in `pandas/tests/io/formats/test_to_csv.py` verifying the output starts with the correct `sep=` line when the flag is set.

Closes #61692