### PR TITLE
BUG: guard ArrowExtensionArray._replace_with_mask against null-type SIGABRT (GH#66703)

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -3305,6 +3305,16 @@ class ArrowExtensionArray(
             # GH#52059 replace_with_mask segfaults for chunked array
             # https://github.com/apache/arrow/issues/34634
             values = values.combine_chunks()
+        if pa.types.is_null(values.type):
+            # GH#66703 replace_with_mask aborts the process (not a catchable
+            # exception, so it cannot be handled by the try/except below) for
+            # null-typed arrays on pyarrow < 25.0.0.
+            # https://github.com/apache/arrow/issues/47447
+            # A null-typed array can only ever contain None, so masking some
+            # positions to be replaced with `replacements` -- which, to be a
+            # valid value for this dtype, must itself be null -- can never
+            # change the result. Skip the buggy kernel entirely.
+            return values
         try:
             return pc.replace_with_mask(values, mask, replacements)
         except pa.ArrowNotImplementedError:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3562,6 +3562,37 @@ def test_setitem_boolean_replace_with_mask_segfault():
     assert arr._pa_array == expected._pa_array
 
 
+def test_replace_with_mask_null_type_no_abort():
+    # GH#66703: pc.replace_with_mask aborts the process (a non-catchable
+    # SIGABRT, not a Python exception) for a null-typed array on
+    # pyarrow < 25.0.0 (https://github.com/apache/arrow/issues/47447).
+    # _replace_with_mask short-circuits for the null type before ever
+    # calling into the buggy kernel, since a null-typed array can only
+    # ever contain None and so is unaffected by any mask/replacement.
+    ser = pd.Series(
+        pa.array([None, None, None], type=pa.null()), dtype=ArrowDtype(pa.null())
+    )
+    mask = np.array([True, False, False])
+
+    # boolean-mask __setitem__
+    result = ser.copy()
+    result[mask] = None
+    assert result.isna().all()
+    assert len(result) == 3
+
+    # .where / .mask
+    assert ser.where(mask).isna().all()
+    assert ser.mask(mask).isna().all()
+
+    # .combine_first
+    assert ser.combine_first(ser.copy()).isna().all()
+
+    # boolean-mask DataFrame.loc __setitem__
+    df = ser.to_frame("a")
+    df.loc[mask, "a"] = None
+    assert df["a"].isna().all()
+
+
 def test_setitem_na_chunked_string_if_else():
     # GH#64320
     df = pd.concat(


### PR DESCRIPTION
## Bug

For a `null`-typed `ArrowDtype` column, any operation routed through `ArrowExtensionArray._replace_with_mask` -- boolean-mask `__setitem__`, `.where`, `.mask`, `.combine_first`, boolean-mask `DataFrame.loc` `__setitem__` -- aborts the interpreter with `SIGABRT` rather than raising a catchable exception, on `pyarrow < 25.0.0`:

```python
import numpy as np
import pandas as pd
import pyarrow as pa

ser = pd.Series(pa.array([None, None, None], type=pa.null()), dtype=pd.ArrowDtype(pa.null()))
ser[np.array([True, False, False])] = None   # process aborts (SIGABRT)
```

Closes #66703

## Root cause

This is a pyarrow kernel bug in `pc.replace_with_mask` for null-typed arrays, reduced by the issue reporter to:

```python
import pyarrow as pa, pyarrow.compute as pc
pc.replace_with_mask(pa.array([None], pa.null()), [True], pa.scalar(None, type=pa.null()))
```

Reported upstream at https://github.com/apache/arrow/issues/47447 and fixed, but only as of pyarrow 25.0.0. pandas supports `pyarrow >= 13.0.0`, so this is reachable from public pandas APIs with every currently-supported pyarrow release below 25. Because the crash is a hard process abort rather than a Python exception, the existing `try: ... except pa.ArrowNotImplementedError:` fallback in `_replace_with_mask` cannot catch it.

## Fix

`_replace_with_mask` already has an established, similarly-motivated guard immediately above the failing call (GH#52059, chunked-boolean-array segfault) that proactively works around a known-bad pyarrow kernel case rather than relying on catching an exception. This PR adds a sibling guard for the null type in the same spot: a null-typed array can only ever contain `None`, so masking some positions to be replaced with `replacements` -- which, to be a valid value for this dtype, must itself be null (`_validate_setitem_value`/`_box_pa` reject anything else earlier) -- can never change the result. The fix returns `values` unchanged for that case, skipping the buggy kernel entirely, matching the "Alternatively..." suggestion the issue reporter already sketched out.

## Testing

Added `test_replace_with_mask_null_type_no_abort` to `pandas/tests/extension/test_arrow.py`, right next to the existing `test_setitem_boolean_replace_with_mask_segfault` (GH#52059) test it mirrors. It covers all five call sites listed in the issue: boolean-mask `__setitem__`, `.where`, `.mask`, `.combine_first`, and boolean-mask `DataFrame.loc` `__setitem__`.

Since building pandas' Cython/C extensions from source wasn't practical in my sandbox, I verified this two ways:

1. Installed pandas + pyarrow==23.0.1 from PyPI (matching the pyarrow version bracket where the pyarrow bug is present) into a venv, applied this same source diff to the installed copy, and confirmed: (a) without the fix, a pytest run of the new test reproduces the exact reported `SIGABRT`/`Fatal Python error` abort; (b) with the fix applied, the test passes cleanly. Also re-verified against pyarrow 25.0.1 (where the underlying pyarrow bug is already fixed) to confirm no regression there.
2. Ran the full bundled `pandas/tests/extension/test_arrow.py` suite (from the pandas 3.0.5 wheel, same pandas version installed above, with only this fix's surgical diff applied -- not the full dev-branch file, to avoid an unrelated version mismatch) -- 25265 passed, 1928 skipped, 526 xfailed, 13 failed. All 13 failures are pre-existing and unrelated: `pyarrow.lib.ArrowInvalid: Cannot locate or parse timezone 'US/Pacific'` / `'US/Eastern'`, caused by the sandbox lacking a system tzdata pyarrow can find -- nothing related to masking, setitem, or the null dtype.

`ruff check` and `ruff format --check` (per `.pre-commit-config.yaml`) are clean on both changed files.
