### PR TITLE
CLN: share checked integer extern declarations

### DIFF
--- a/pandas/_libs/groupby.pyx
+++ b/pandas/_libs/groupby.pyx
@@ -52,12 +52,9 @@ from pandas._libs.dtypes cimport (
     numeric_t,
 )
 from pandas._libs.missing cimport checknull
+from pandas._libs.portable cimport checked_add
 
 from pandas._libs.tslibs.np_datetime import OutOfBoundsTimedelta
-
-
-cdef extern from "pandas/portable.h":
-    int checked_add(int64_t a, int64_t b, int64_t *res) noexcept nogil
 
 
 cdef int64_t NPY_NAT = util.get_nat()

--- a/pandas/_libs/portable.pxd
+++ b/pandas/_libs/portable.pxd
@@ -1,0 +1,7 @@
+from numpy cimport int64_t
+
+
+cdef extern from "pandas/portable.h":
+    int checked_add(int64_t a, int64_t b, int64_t *res) noexcept nogil
+    int checked_sub(int64_t a, int64_t b, int64_t *res) noexcept nogil
+    int checked_mul(int64_t a, int64_t b, int64_t *res) noexcept nogil

--- a/pandas/_libs/tslibs/conversion.pyx
+++ b/pandas/_libs/tslibs/conversion.pyx
@@ -34,6 +34,7 @@ from cpython.datetime cimport (
 import_datetime()
 
 from pandas._libs.missing cimport checknull_with_nat_and_na
+from pandas._libs.portable cimport checked_sub
 from pandas._libs.tslibs.ccalendar cimport get_days_in_month
 from pandas._libs.tslibs.dtypes cimport (
     abbrev_to_npy_unit,
@@ -65,10 +66,6 @@ from pandas._libs.tslibs.np_datetime cimport (
 )
 
 import_pandas_datetime()
-
-
-cdef extern from "pandas/portable.h":
-    int checked_sub(int64_t a, int64_t b, int64_t *res)
 
 
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime

--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -36,6 +36,10 @@ from typing import ClassVar
 
 from pandas._libs.properties import cache_readonly
 
+from pandas._libs.portable cimport (
+    checked_add,
+    checked_mul,
+)
 from pandas._libs.tslibs cimport util
 from pandas._libs.tslibs.util cimport (
     is_float_object,
@@ -102,12 +106,6 @@ from .timedeltas import Timedelta
 from .timestamps cimport _Timestamp
 
 from .timestamps import Timestamp
-
-
-cdef extern from "pandas/portable.h":
-    bint checked_add(int64_t a, int64_t b, int64_t *res) noexcept nogil
-    bint checked_mul(int64_t a, int64_t b, int64_t *res) noexcept nogil
-
 
 # ---------------------------------------------------------------------
 # day_opt enum: avoids repeated string comparisons in nogil loops

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -49,6 +49,7 @@ from numpy cimport (
 )
 
 from pandas._libs.missing cimport checknull_with_nat_and_na
+from pandas._libs.portable cimport checked_sub
 from pandas._libs.tslibs.conversion cimport (
     get_datetime64_nanos,
     parse_pydatetime,
@@ -76,10 +77,6 @@ from pandas._libs.tslibs.np_datetime cimport (
 )
 
 import_pandas_datetime()
-
-
-cdef extern from "pandas/portable.h":
-    int checked_sub(int64_t a, int64_t b, int64_t *res)
 
 
 from pandas._libs.tslibs.np_datetime import OutOfBoundsDatetime

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -43,6 +43,10 @@ from pandas._libs.tslibs.np_datetime cimport (
 
 import_pandas_datetime()
 
+from pandas._libs.portable cimport (
+    checked_add,
+    checked_sub,
+)
 from pandas._libs.tslibs.timestamps cimport _Timestamp
 from pandas._libs.tslibs.timezones cimport (
     get_dst_info,
@@ -51,11 +55,6 @@ from pandas._libs.tslibs.timezones cimport (
     is_utc,
     is_zoneinfo,
 )
-
-
-cdef extern from "pandas/portable.h":
-    int checked_add(int64_t a, int64_t b, int64_t *res)
-    int checked_sub(int64_t a, int64_t b, int64_t *res)
 
 
 cdef const int64_t[::1] _deltas_placeholder = np.array([], dtype=np.int64)


### PR DESCRIPTION
Addresses item 5 of GH#66549. This intentionally does not use a closing keyword for the umbrella issue.

`checked_add`, `checked_sub`, and `checked_mul` from `portable.h` were declared independently by several Cython modules. Those declarations had drifted between `int` and `bint` return types and differed in their `noexcept nogil` qualifiers.

This adds a shared `pandas/_libs/portable.pxd` with one canonical signature for each helper and updates all existing Cython consumers to cimport those declarations. This is declaration-only cleanup with no runtime behavior change.

Validated with an MSVC editable build, direct imports of all affected extension modules, 147 focused tests covering the affected modules and checked-arithmetic paths, and pre-commit on every changed file.

This pull request was developed with OpenAI Codex assistance. I reviewed the generated changes and validation results and prompted Codex to follow the repository's `AGENTS.md` and contribution guidelines.

- [x] Addresses item 5 of #66549 without closing the umbrella issue
- [x] Relevant tests passed; no new tests were added because this is declaration-only cleanup
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Type annotations are not applicable; no Python API or signatures were added
- [x] A whatsnew entry is not applicable; there is no user-visible behavior change
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] I used AI assistance and prompted it to follow `AGENTS.md`
