### PR TITLE
DOC: Document dict acceptance for Index and DataFrame index/columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -54,6 +54,7 @@ Other enhancements
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)
 - Building from source no longer fails when compiling the windowing extensions against C++ standard libraries that provide only ``std::signbit`` (:issue:`50979`, :issue:`51047`)
 - Setting values with :meth:`DataFrame.at` or :meth:`Series.at` using a non-scalar indexer (e.g. a boolean mask, list, or array) now raises a clearer ``InvalidIndexError`` directing users to ``.loc`` (:issue:`51866`)
+- :class:`Index` and the ``index``/``columns`` arguments of :class:`DataFrame` now document that a ``dict`` is accepted and that its keys are used (:issue:`66742`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.notable_bug_fixes:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -294,10 +294,12 @@ class DataFrame(NDFrame, OpsMixin):
     index : Index or array-like
         Index to use for resulting frame. Will default to RangeIndex if
         no indexing information part of input data and no index provided.
+        If a dict is passed, its keys are used as the index labels.
     columns : Index or array-like
         Column labels to use for resulting frame when data does not have them,
         defaulting to RangeIndex(0, 1, 2, ..., n). If data contains column labels,
-        will perform column selection instead.
+        will perform column selection instead. If a dict is passed, its keys are
+        used as the column labels.
     dtype : dtype, default None
         Data type to force. Only a single dtype is allowed. If None, infer.
         If ``data`` is DataFrame then is ignored. Missing values in ``data``

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -329,7 +329,8 @@ class Index(IndexOpsMixin, PandasObject):
     ----------
     data : array-like (1-dimensional)
         An array-like structure containing the data for the index. This could be a
-        Python list, a NumPy array, or a pandas Series.
+        Python list, a NumPy array, or a pandas Series. If a dict is passed, its
+        keys are used as the index values.
     dtype : str, numpy.dtype, or ExtensionDtype, optional
         Data type for the output Index. If not specified, this will be
         inferred from `data`.


### PR DESCRIPTION
## Summary

Documents that `pd.Index` and the `index`/`columns` arguments of `pd.DataFrame` accept a `dict` at runtime, and that the dict's keys are used. This was confirmed in the 2026-08-12 dev meeting and matches runtime behavior on pandas 3.0.5.

## Changes

- `Index.__init__` docstring: `data` parameter now states a dict's keys are used as index values.
- `DataFrame.__init__` docstring: `index` and `columns` parameters now state a dict's keys are used as the labels.
- Whatsnew entry under 3.1.0 enhancements.

## Validation

- Runtime verification on pandas 3.0.5: `pd.Index({...})`, `pd.DataFrame(..., index={...})`, and `pd.DataFrame(..., columns={...})` all use dict keys.
- `ast.parse` passes on both edited files; `git diff --check` passes.
