### PR TITLE
DOC: Update DataFrame and Index docs to say that dicts are accepted (#66742)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -291,13 +291,15 @@ class DataFrame(NDFrame, OpsMixin):
 
         If data is a list of dicts, column order follows insertion-order.
 
-    index : Index or array-like
+    index : Index, array-like or dict
         Index to use for resulting frame. Will default to RangeIndex if
         no indexing information part of input data and no index provided.
-    columns : Index or array-like
+        If a dict is provided, its keys will be used to determine the index values.
+    columns : Index, array-like or dict
         Column labels to use for resulting frame when data does not have them,
         defaulting to RangeIndex(0, 1, 2, ..., n). If data contains column labels,
         will perform column selection instead.
+        If a dict is provided, its keys will be used to determine the columns values.
     dtype : dtype, default None
         Data type to force. Only a single dtype is allowed. If None, infer.
         If ``data`` is DataFrame then is ignored. Missing values in ``data``

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -327,9 +327,10 @@ class Index(IndexOpsMixin, PandasObject):
 
     Parameters
     ----------
-    data : array-like (1-dimensional)
+    data : array-like (1-dimensional) or dict
         An array-like structure containing the data for the index. This could be a
-        Python list, a NumPy array, or a pandas Series.
+        Python list, a NumPy array, or a pandas Series. If a dict is provided, its
+        keys will be used to create the values for the Index.
     dtype : str, numpy.dtype, or ExtensionDtype, optional
         Data type for the output Index. If not specified, this will be
         inferred from `data`.


### PR DESCRIPTION
Resolves #66742. This PR updates the docstrings of \pandas.DataFrame\ and \pandas.Index\ to explicitly state that dictionaries are accepted as the \data\, \index\, or \columns\ arguments and that the keys of the dictionary are used.