### PR TITLE
DOC improve select_dtypes documentation wording

### DIFF
--- a/doc/source/user_guide/basics.rst
+++ b/doc/source/user_guide/basics.rst
@@ -2450,7 +2450,7 @@ You can also pass the name of a dtype in the `NumPy dtype hierarchy
 
    df.select_dtypes(include=["bool"])
 
-:meth:`~pandas.DataFrame.select_dtypes` also works with generic dtypes as well.
+:meth:`~pandas.DataFrame.select_dtypes` also works with generic dtypes.
 
 For example, to select all numeric and boolean columns while excluding unsigned
 integers:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### What does this PR do?

Removes redundant wording in the `select_dtypes` documentation.

Before:
`:meth:\`~pandas.DataFrame.select_dtypes\` also works with generic dtypes as well.`

After:
`:meth:\`~pandas.DataFrame.select_dtypes\` also works with generic dtypes.`

This improves the clarity and readability of the documentation.