### PR TITLE
PERF: enable parallel read_csv by default on Windows

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -1542,7 +1542,7 @@ considerably. This happens automatically when all of the following hold:
 * the C engine is used (the default)
 * the file's data rows total at least 5 MB, excluding any header preamble
 * more than one thread is in use -- see ``mode.max_threads`` below, which
-  defaults to ``1`` on Windows and when the process is limited to a single CPU
+  defaults to ``1`` when the process is limited to a single CPU
 * no options are passed that require parsing the file as a whole, such as
   ``iterator``, ``chunksize``, ``nrows``, ``usecols``, ``index_col``,
   ``parse_dates``, list/callable ``skiprows``, multi-row headers, or
@@ -1555,10 +1555,8 @@ The number of threads is controlled with the ``mode.max_threads`` option, which
 defaults to the number of CPU cores, capped at ``4`` and limited to the CPUs
 available to the process -- CPU affinity, and the cgroup CPU quota when the
 process runs in its own cgroup namespace, as it does under Docker and
-Kubernetes. On Windows the default is ``1`` (serial), as parallel reading
-currently does not improve performance there. Set the option to ``1`` to
-disable parallel reading, e.g. when pandas runs inside an application that
-already parallelizes work:
+Kubernetes. Set the option to ``1`` to disable parallel reading, e.g. when
+pandas runs inside an application that already parallelizes work:
 
 .. code-block:: python
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -320,7 +320,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns (:issue:`65767`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for float columns with default settings (:issue:`66239`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for integer and string columns (:issue:`65350`)
-- Performance improvement in :func:`read_csv` with ``engine="c"`` for large uncompressed local files, which are now read in parallel across multiple CPU cores; this is enabled by default except on Windows and can be controlled with the ``mode.max_threads`` option (:issue:`64347`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` for large uncompressed local files, which are now read in parallel across multiple CPU cores; this is enabled by default and can be controlled with the ``mode.max_threads`` option (:issue:`64347`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, growing with the number of columns in the file (:issue:`66619`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns, particularly for multi-threaded reads and chunked (``low_memory``) reads (:issue:`66277`)

--- a/pandas/compat/_cpu.py
+++ b/pandas/compat/_cpu.py
@@ -79,7 +79,8 @@ def available_cpu_count() -> int | None:
     ``None`` only where neither limit is probed -- in practice macOS and
     Windows.  macOS exposes no affinity mask at all; Windows does (via
     ``GetProcessAffinityMask`` and job-object rate limits) but it is not
-    implemented here, since parallel reading is off by default there anyway.
+    implemented here, so a restricted Windows process falls back to the
+    logical CPU count clamped by ``_MAX_DEFAULT_WORKERS``.
     On Linux ``sched_getaffinity`` always succeeds, so an unconstrained box
     reports its full logical CPU count rather than ``None``.
 

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -463,8 +463,7 @@ max_threads_doc = """
     Maximum number of worker threads for parallel operations (e.g. ``read_csv``
     for large files).  ``None`` (the default) means use ``min(os.cpu_count(), 4)``,
     further limited to the CPUs available to the process (CPU affinity and cgroup
-    limits); on Windows the default is ``1``, as parallel reading is not faster
-    there.  Set to ``1`` to disable parallel execution, or to a fixed number to
+    limits).  Set to ``1`` to disable parallel execution, or to a fixed number to
     raise the cap or to limit thread usage when pandas is embedded in a larger
     parallel workflow.  Ignored on Emscripten/Pyodide, which cannot spawn threads.
 """

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -382,10 +382,9 @@ def _default_n_workers() -> int:
     Default worker count for a parallel ``read_csv``.
 
     ``mode.max_threads`` wins whenever it is set (except on Emscripten, which
-    cannot spawn threads at all).  Otherwise parallel reading is off by default
-    on Windows, and elsewhere is the smallest of the machine's logical CPU
-    count, ``_MAX_DEFAULT_WORKERS``, and the CPUs actually available to the
-    process (CPU affinity / cgroup limits) -- so that an embedded or
+    cannot spawn threads at all).  Otherwise it is the smallest of the machine's
+    logical CPU count, ``_MAX_DEFAULT_WORKERS``, and the CPUs actually available
+    to the process (CPU affinity / cgroup limits) -- so that an embedded or
     containerised pandas does not oversubscribe its allocation.
     """
     max_threads = get_option("mode.max_threads")
@@ -394,14 +393,6 @@ def _default_n_workers() -> int:
         return 1
     if max_threads is not None:
         return max_threads
-    if sys.platform == "win32":
-        # Parallel CSV reading does not currently speed up on Windows: even
-        # with the file warm in the OS cache, using more than one thread is
-        # no faster (and slower at two threads).  Default to serial there;
-        # users can still opt in explicitly via mode.max_threads.  See the
-        # benchmark numbers in the GH#64347 discussion:
-        # https://github.com/pandas-dev/pandas/pull/64347#issuecomment-4468820601
-        return 1
     n_workers = min(os.cpu_count() or 1, _MAX_DEFAULT_WORKERS)
     # os.cpu_count() counts the machine's CPUs, not the ones this process may
     # use, so it alone would put _MAX_DEFAULT_WORKERS parse threads on a

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -741,8 +741,9 @@ def test_read_csv_auto_parallel(tmp_path, monkeypatch):
     # Lower the threshold so any file triggers the parallel path.
     monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
 
-    # Force the parallel path regardless of the platform default (it is off by
-    # default on Windows) so this exercises parallel == serial on every platform.
+    # Force the parallel path regardless of the host's CPU allocation (a
+    # single usable CPU defaults to serial) so this exercises parallel ==
+    # serial everywhere.
     with option_context("mode.max_threads", 4):
         result = read_csv(path)  # auto-selects parallel path for C engine
     expected = read_csv(path, engine="python")
@@ -760,26 +761,21 @@ def test_read_csv_parallel_vs_serial_large_file(tmp_path, monkeypatch):
     monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
 
     serial = read_csv(path, engine="python")
-    # Force the parallel path so this runs on every platform (off by default on
-    # Windows).
+    # Force the parallel path so this runs even on a single-CPU allocation.
     with option_context("mode.max_threads", 4):
         parallel = read_csv(path, engine="c")
     tm.assert_frame_equal(parallel, serial)
 
 
-def test_parallel_default_off_on_windows(tmp_path, monkeypatch):
-    """The parallel path is off by default on Windows but on elsewhere.
-
-    Windows shows no speedup (and a slowdown at two threads) even with the file
-    warm in the OS cache, so the default is serial there; users opt in via
-    ``mode.max_threads`` (which is honoured on every platform).
-    """
+@pytest.mark.parametrize("platform_name", ["linux", "darwin", "win32"])
+def test_parallel_on_by_default(tmp_path, monkeypatch, platform_name):
+    """The parallel path is on by default on every threaded platform."""
     path = tmp_path / "big.csv"
     _make_large_csv(path)
     monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
-    # Pin the non-Windows default so the test does not depend on the host's
-    # actual core count, or on how many CPUs a container/affinity mask leaves
-    # the runner -- one usable CPU would make the default serial everywhere.
+    # Pin the default so the test does not depend on the host's actual core
+    # count, or on how many CPUs a container/affinity mask leaves the runner --
+    # one usable CPU would make the default serial everywhere.
     monkeypatch.setattr(_readers.os, "cpu_count", lambda: 4)
     monkeypatch.setattr(_readers, "available_cpu_count", lambda: None)
 
@@ -793,14 +789,31 @@ def test_parallel_default_off_on_windows(tmp_path, monkeypatch):
         return DataFrame()
 
     monkeypatch.setattr(_readers, "_read_csv_parallel", stub)
+    monkeypatch.setattr(_readers.sys, "platform", platform_name)
 
-    monkeypatch.setattr(_readers.sys, "platform", "win32")
     read_csv(path)
-    assert calls == []  # serial by default on Windows
+    assert len(calls) == 1
 
-    monkeypatch.setattr(_readers.sys, "platform", "linux")
+
+def test_parallel_default_off_on_wasm(tmp_path, monkeypatch):
+    """Emscripten cannot spawn threads, so it stays serial."""
+    path = tmp_path / "big.csv"
+    _make_large_csv(path)
+    monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
+    monkeypatch.setattr(_readers.os, "cpu_count", lambda: 4)
+    monkeypatch.setattr(_readers, "available_cpu_count", lambda: None)
+
+    calls = []
+
+    def stub(*args, **kwargs):
+        calls.append(args)
+        return DataFrame()
+
+    monkeypatch.setattr(_readers, "_read_csv_parallel", stub)
+    monkeypatch.setattr(_readers.sys, "platform", "emscripten")
+
     read_csv(path)
-    assert len(calls) == 1  # parallel by default elsewhere
+    assert calls == []
 
 
 def test_parallel_default_thread_cap(tmp_path, monkeypatch):
@@ -841,6 +854,7 @@ def test_parallel_default_thread_cap(tmp_path, monkeypatch):
 class TestDefaultNWorkers:
     """Unit tests for the default worker count."""
 
+    @pytest.mark.parametrize("platform_name", ["linux", "darwin", "win32"])
     @pytest.mark.parametrize(
         "cpu_count, available, expected",
         [
@@ -853,20 +867,16 @@ class TestDefaultNWorkers:
         ],
     )
     def test_combines_cap_and_allocation(
-        self, monkeypatch, cpu_count, available, expected
+        self, monkeypatch, cpu_count, available, expected, platform_name
     ):
-        # Default = min(logical CPUs, available CPUs, _MAX_DEFAULT_WORKERS).
+        # Default = min(logical CPUs, available CPUs, _MAX_DEFAULT_WORKERS),
+        # on every threaded platform.
         assert _readers._MAX_DEFAULT_WORKERS == 4
-        monkeypatch.setattr(_readers.sys, "platform", "linux")
+        monkeypatch.setattr(_readers.sys, "platform", platform_name)
         monkeypatch.setattr(_readers.os, "cpu_count", lambda: cpu_count)
         monkeypatch.setattr(_readers, "available_cpu_count", lambda: available)
         with option_context("mode.max_threads", None):
             assert _default_n_workers() == expected
-
-    def test_windows_is_serial(self, monkeypatch):
-        monkeypatch.setattr(_readers.sys, "platform", "win32")
-        with option_context("mode.max_threads", None):
-            assert _default_n_workers() == 1
 
     def test_wasm_is_serial(self, monkeypatch):
         monkeypatch.setattr(_readers.sys, "platform", "emscripten")


### PR DESCRIPTION
Parallel `read_csv` (GH-64347) shipped with Windows hard-coded to a single worker, on the basis that splitting the file across threads gave no speedup there — and was a slowdown at two threads. That measurement no longer holds: the serializing cost it was reacting to was the doubling realloc chain in `grow_buffer`, where every growth step took the process-wide UCRT heap lock and pinned the parallel workers against each other. GH-66271 replaced that with a single up-front realloc, and Windows now scales with thread count like the other platforms.

So `_default_n_workers` drops its `win32` early return and Windows takes the same default as everywhere else: `min(os.cpu_count(), 4)`, further clamped to the CPUs available to the process. Emscripten stays serial — it cannot spawn threads at all. `mode.max_threads` continues to override on every platform, so setting it to `1` still turns parallel reading off.

The user guide, the `mode.max_threads` option doc, and the `read_csv` whatsnew entry all carried the "defaults to 1 on Windows" claim; all three are updated. The whatsnew entry for the parallel feature is amended in place rather than given a new note, since parallel reading has not been released yet.

One thing this does not change, called out in `available_cpu_count`'s docstring: Windows still reports no CPU-allocation limit, because that helper probes only `sched_getaffinity` and cgroups. A Windows process restricted by `GetProcessAffinityMask` or a job-object CPU rate limit will now start up to 4 parse threads regardless of that restriction. That was inert while the platform was unconditionally serial, and it is a separate change to fix.