### PR TITLE
TST: repair vacuous read_csv parallel-read regression guards

### DIFF
--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -1309,15 +1309,24 @@ def test_parallel_multichar_sep_matches_serial(tmp_path, monkeypatch):
     tm.assert_frame_equal(result, expected)
 
 
-def _write_with_line_at_chunk_start(path, replacement: bytes) -> None:
+def _write_with_line_at_chunk_start(path, replacement: bytes, monkeypatch) -> int:
     """Write a fixed-width CSV, then overwrite the line at the second chunk
-    boundary with *replacement* (same byte length, so offsets stay valid)."""
+    boundary with *replacement* (same byte length, so offsets stay valid).
+
+    Returns the boundary, for :func:`_assert_chunk_starts_at` to check against
+    the split the read actually plans - hard-coding a count here that the read
+    does not use would put the line in the middle of a chunk instead.
+    """
     rows = [f"{i:06d},{i * 2:06d}" for i in range(4000)]
     # write bytes so line endings stay "\n" on every platform - the byte-offset
     # math below assumes single-byte terminators (Windows text mode adds "\r")
     path.write_bytes(("a,b\n" + "\n".join(rows) + "\n").encode("utf-8"))
+    # 4000 rows is only two chunks' worth at the row floor, and the split has to
+    # be finer than that for a boundary to land mid-file.  _read_forced_parallel
+    # uses 4 workers, so this yields the 4 * 3 oversubscription.
+    monkeypatch.setattr("pandas.io.parsers.readers._PARALLEL_MIN_CHUNK_ROWS", 1)
     data_start = _find_data_start_offset(str(path), 0, 0)
-    offsets = _find_chunk_byte_offsets(str(path), 4, data_start)
+    offsets = _find_chunk_byte_offsets(str(path), 12, data_start)
     boundary = offsets[1]
     raw = path.read_bytes()
     line_end = raw.index(b"\n", boundary)
@@ -1325,6 +1334,29 @@ def _write_with_line_at_chunk_start(path, replacement: bytes) -> None:
     with open(path, "r+b") as fd:
         fd.seek(boundary)
         fd.write(replacement)
+    return boundary
+
+
+def _spy_on_chunk_offsets(monkeypatch) -> list:
+    """Record the byte offsets each planned split actually uses."""
+    seen: list = []
+    real = _find_chunk_byte_offsets
+
+    def spy(filepath, n_chunks, data_start):
+        offsets = real(filepath, n_chunks, data_start)
+        seen.append(offsets)
+        return offsets
+
+    monkeypatch.setattr("pandas.io.parsers.readers._find_chunk_byte_offsets", spy)
+    return seen
+
+
+def _assert_chunk_starts_at(seen: list, boundary: int) -> None:
+    # Without this the tests below still pass on a coarser split - a ragged line
+    # raises (and a skipped one is skipped) wherever it sits - while no longer
+    # placing it at the chunk start that is the point of the fixture.
+    assert seen, "the parallel path did not run"
+    assert boundary in seen[0], f"{boundary} is not a chunk start in {seen[0]}"
 
 
 def test_parallel_ragged_line_at_chunk_start_raises(tmp_path, monkeypatch):
@@ -1332,23 +1364,27 @@ def test_parallel_ragged_line_at_chunk_start_raises(tmp_path, monkeypatch):
     # worker's first line used to be exempt from the field-count check, so
     # parallel silently truncated the row while serial raised (GH#64347).
     path = tmp_path / "ragged.csv"
-    _write_with_line_at_chunk_start(path, b"11,22,33,4444")
+    boundary = _write_with_line_at_chunk_start(path, b"11,22,33,4444", monkeypatch)
+    seen = _spy_on_chunk_offsets(monkeypatch)
 
     with pytest.raises(ParserError, match="Expected 2 fields"):
         _read_forced_parallel(path, monkeypatch)
+    _assert_chunk_starts_at(seen, boundary)
 
 
 def test_parallel_ragged_line_at_chunk_start_skip_matches_serial(tmp_path, monkeypatch):
     # Same layout with on_bad_lines="skip": the chunk worker must skip the
     # bad line just like serial, not keep a truncated version of it.
     path = tmp_path / "ragged.csv"
-    _write_with_line_at_chunk_start(path, b"11,22,33,4444")
+    boundary = _write_with_line_at_chunk_start(path, b"11,22,33,4444", monkeypatch)
+    seen = _spy_on_chunk_offsets(monkeypatch)
 
     with option_context("mode.max_threads", 1):
         expected = read_csv(path, on_bad_lines="skip")
     result = _read_forced_parallel(path, monkeypatch, on_bad_lines="skip")
     tm.assert_frame_equal(result, expected)
     assert len(result) == 3999
+    _assert_chunk_starts_at(seen, boundary)
 
 
 def test_parallel_bom_bytes_mid_file_match_serial(tmp_path, monkeypatch):
@@ -1424,6 +1460,10 @@ def test_parallel_bad_line_run_skip(tmp_path, monkeypatch):
     bad = "\n".join("x,y,z,w,v" for _ in range(5000))
     path.write_text("a,b\n" + rows + "\n" + bad + "\n" + rows + "\n", encoding="utf-8")
     monkeypatch.setattr("pandas.io.parsers.readers._PARALLEL_READ_MIN_BYTES", 1)
+    # The good rows sit at both ends of the file, so at the two chunks the row
+    # floor allows here every chunk has something to parse and the all-skipped
+    # chunk this is about never happens.
+    monkeypatch.setattr("pandas.io.parsers.readers._PARALLEL_MIN_CHUNK_ROWS", 1)
 
     with option_context("mode.max_threads", 1):
         expected = read_csv(path, on_bad_lines="skip")

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -1359,6 +1359,7 @@ def _assert_chunk_starts_at(seen: list, boundary: int) -> None:
     assert boundary in seen[0], f"{boundary} is not a chunk start in {seen[0]}"
 
 
+@pytest.mark.skipif(WASM, reason="WASM stays serial, so the spy sees no call")
 def test_parallel_ragged_line_at_chunk_start_raises(tmp_path, monkeypatch):
     # A line with extra fields sitting exactly at a chunk boundary: the chunk
     # worker's first line used to be exempt from the field-count check, so
@@ -1372,6 +1373,7 @@ def test_parallel_ragged_line_at_chunk_start_raises(tmp_path, monkeypatch):
     _assert_chunk_starts_at(seen, boundary)
 
 
+@pytest.mark.skipif(WASM, reason="WASM stays serial, so the spy sees no call")
 def test_parallel_ragged_line_at_chunk_start_skip_matches_serial(tmp_path, monkeypatch):
     # Same layout with on_bad_lines="skip": the chunk worker must skip the
     # bad line just like serial, not keep a truncated version of it.


### PR DESCRIPTION
The parallel read_csv suite had two regression guards that were silently vacuous:

- `test_parallel_bad_line_run_skip` split its fixture into only 2 chunks, so no chunk was entirely skipped and the GH-66275 StopIteration path was never exercised. It now patches the sizing constants to get 12 chunks, with all-skipped chunks [1..10].
- `test_parallel_ragged_line_at_chunk_start_*` hard-coded a 4-chunk boundary while the read actually planned 2 chunks, so the ragged line was not at a chunk start and the GH-64347 field-count regression was unguarded. The helper now pins the sizing constants, targets a boundary in the read's real 12-way split, and asserts against the read's actual chunk offsets so the fixture cannot silently drift off a boundary again.

Both repairs verified by instrumentation (actual chunk offsets and per-chunk skip counts), not by reading.

This PR originally carried a chunk-count sizing change for GH-66152. That work is parked pending a better cost model (the heuristics tried each regressed some region of the size/width grid — see the review discussion); the branch now contains only the test repairs, which stand on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
