### PR TITLE
BUG: UTC to local conversion wrapped int64 silently (GH#66550)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -532,6 +532,7 @@ Timezones
 - Bug in :meth:`Timestamp.isoformat`, ``str(Timestamp)``, and the rendering of :class:`Series` and :class:`DatetimeIndex` (including ``repr``, ``astype(str)``, and :meth:`DataFrame.to_csv`) splicing the fractional seconds into the middle of the UTC offset for timestamps in a timezone whose offset is not a whole number of minutes, such as any zone in its pre-standardization era (e.g. ``Asia/Tokyo`` before 1888) (:issue:`66547`)
 - Bug in :meth:`Timestamp.to_julian_date` and :meth:`DatetimeIndex.to_julian_date` returning the Julian date of the local wall clock for timezone-aware inputs instead of the underlying UTC instant (:issue:`54763`)
 - Bug in constructing a :class:`DatetimeIndex` with a ``freq``, or setting ``freq`` on an existing one, incorrectly raising ``ValueError`` for timezone-aware data spanning a DST transition when the frequency preserves wall time (e.g. ``"D"``) (:issue:`55499`)
+- Bug in timezone-aware :class:`DatetimeIndex` and :class:`Series` where a UTC instant near :attr:`Timestamp.min` or :attr:`Timestamp.max` whose local wall time is outside the representable range silently reported a wall time roughly 585 years off, or ``NaT``, instead of raising :class:`OutOfBoundsDatetime`; this affected ``tz_localize(None)``, field accessors such as ``.year``, ``strftime``, ``round``/``floor``/``ceil``, and conversion to :class:`PeriodIndex` (:issue:`66550`)
 
 Numeric
 ^^^^^^^

--- a/pandas/_libs/tslibs/tzconversion.pxd
+++ b/pandas/_libs/tslibs/tzconversion.pxd
@@ -20,6 +20,20 @@ cdef int64_t tz_localize_to_utc_single(
 ) except? -1
 
 
+cdef enum BoundaryStatus:
+    BS_OK
+    BS_UNDERFLOW
+    BS_OVERFLOW
+
+
+cdef void raise_out_of_bounds(
+    int64_t val,
+    BoundaryStatus err,
+    NPY_DATETIMEUNIT creso,
+    tzinfo to_tz=*,
+) except *
+
+
 cdef class Localizer:
     cdef:
         tzinfo tz

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -151,31 +151,50 @@ cdef class Localizer:
     cdef int64_t utc_val_to_local_val(
         self, int64_t utc_val, Py_ssize_t* pos, bint* fold=NULL
     ) except? -1:
+        cdef:
+            int64_t delta, result
+
         if self.use_utc:
             return utc_val
         elif self.use_tzlocal:
-            return utc_val + _tz_localize_using_tzinfo_api(
+            delta = _tz_localize_using_tzinfo_api(
                 utc_val, self.tz, to_utc=False, creso=self._creso, fold=fold
             )
         elif self.use_fixed:
-            return utc_val + self.delta
+            delta = self.delta
+        elif (
+            self.use_zoneinfo
+            and self.has_tz_rule
+            and utc_val > self.last_trans
+        ):
+            delta = _tz_localize_using_tzinfo_api(
+                utc_val, self.tz, to_utc=False, creso=self._creso, fold=fold
+            )
         else:
-            if (
-                self.use_zoneinfo
-                and self.has_tz_rule
-                and utc_val > self.last_trans
-            ):
-                return utc_val + _tz_localize_using_tzinfo_api(
-                    utc_val, self.tz, to_utc=False, creso=self._creso, fold=fold
-                )
-
             pos[0] = bisect_right_i8(self.tdata, utc_val, self.ntrans) - 1
             if fold is not NULL:
                 fold[0] = _infer_dateutil_fold(
                     utc_val, self.trans, self.deltas, pos[0]
                 )
 
-            return utc_val + self.deltas[pos[0]]
+            delta = self.deltas[pos[0]]
+
+        # GH#66550 the shift out of UTC must not wrap int64 silently; the wrapped
+        #  value renders as a wall time centuries away and is stored as such by
+        #  tz_localize(None) and floor/ceil/round.  The scalar path already
+        #  refuses the same conversion via conversion.check_overflows.
+        # NB: landing exactly on the NaT sentinel is *not* rejected here.  That
+        #  value still renders the correct wall time, so it is only unusable for
+        #  the callers that store it back into an i8 buffer; those check for it
+        #  themselves.
+        if checked_add(utc_val, delta, &result):
+            raise_out_of_bounds(
+                utc_val,
+                BS_OVERFLOW if delta > 0 else BS_UNDERFLOW,
+                self._creso,
+                self.tz,
+            )
+        return result
 
 
 cdef int64_t tz_localize_to_utc_single(
@@ -546,16 +565,11 @@ cdef str _render_tstamp(int64_t val, NPY_DATETIMEUNIT creso):
     return str(ts)
 
 
-cdef enum BoundaryStatus:
-    BS_OK
-    BS_UNDERFLOW
-    BS_OVERFLOW
-
-
 cdef void raise_out_of_bounds(
     int64_t val,
     BoundaryStatus err,
-    NPY_DATETIMEUNIT creso
+    NPY_DATETIMEUNIT creso,
+    tzinfo to_tz=None,
 ) except *:
     cdef:
         npy_datetimestruct dts
@@ -566,16 +580,20 @@ cdef void raise_out_of_bounds(
 
     pandas_datetime_to_datetimestruct(val, creso, &dts)
     fmt = dts_to_iso_string(&dts)
+    # Going UTC->local the only value left to render is the in-bounds UTC
+    #  instant, so without naming the target tz the message looks like it is
+    #  complaining about a value that is plainly fine.
+    target = "" if to_tz is None else f" to {to_tz}"
 
     if err == BS_OVERFLOW:
         limit_ts = (<_Timestamp>Timestamp(0))._as_creso(creso).max
         raise OutOfBoundsDatetime(
-            f"Converting {fmt} overflows past {limit_ts}"
+            f"Converting {fmt}{target} overflows past {limit_ts}"
         )
     else:
         limit_ts = (<_Timestamp>Timestamp(0))._as_creso(creso).min
         raise OutOfBoundsDatetime(
-            f"Converting {fmt} underflows past {limit_ts}"
+            f"Converting {fmt}{target} underflows past {limit_ts}"
         )
 
 

--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -36,7 +36,11 @@ import_pandas_datetime()
 from .period cimport get_period_ordinal
 from .timestamps cimport create_timestamp_from_ts
 from .timezones cimport is_utc
-from .tzconversion cimport Localizer
+from .tzconversion cimport (
+    BS_UNDERFLOW,
+    Localizer,
+    raise_out_of_bounds,
+)
 
 
 @cython.boundscheck(False)
@@ -79,6 +83,10 @@ def tz_convert_from_utc(ndarray stamps, tzinfo tz, NPY_DATETIMEUNIT reso=NPY_FR_
             local_val = NPY_NAT
         else:
             local_val = info.utc_val_to_local_val(utc_val, &pos)
+            if local_val == NPY_NAT:
+                # GH#66550 the wall time is representable, but we are about to
+                #  store it where the sentinel reads back as NaT
+                raise_out_of_bounds(local_val, BS_UNDERFLOW, reso)
 
         # Analogous to: result[i] = local_val
         (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = local_val
@@ -356,6 +364,12 @@ def is_date_array_normalized(ndarray stamps, tzinfo tz, NPY_DATETIMEUNIT reso) -
         # Analogous to: utc_val = stamps[i]
         utc_val = (<int64_t*>cnp.PyArray_ITER_DATA(it))[0]
 
+        if utc_val == NPY_NAT:
+            # GH#66550 shifting the sentinel would trip the bounds check in
+            #  utc_val_to_local_val.  Returning False rather than skipping keeps
+            #  an all-NaT array reporting False as it does today.
+            return False
+
         local_val = info.utc_val_to_local_val(utc_val, &pos)
 
         if local_val % ppd != 0:
@@ -399,6 +413,10 @@ def dt64arr_to_periodarr(
             local_val = info.utc_val_to_local_val(utc_val, &pos)
             pandas_datetime_to_datetimestruct(local_val, reso, &dts)
             res_val = get_period_ordinal(&dts, freq)
+            if res_val == NPY_NAT:
+                # GH#66550 at nanosecond freq the ordinal *is* the local i8
+                #  value, so a local time on the sentinel would be stored as NaT
+                raise_out_of_bounds(local_val, BS_UNDERFLOW, reso)
 
         # Analogous to: result[i] = res_val
         (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 0))[0] = res_val

--- a/pandas/tests/indexes/datetimes/methods/test_tz_convert.py
+++ b/pandas/tests/indexes/datetimes/methods/test_tz_convert.py
@@ -1,16 +1,27 @@
-from datetime import datetime
+from datetime import (
+    datetime,
+    timedelta,
+    timezone,
+)
 
 import dateutil.tz
 from dateutil.tz import gettz
 import numpy as np
 import pytest
 
-from pandas._libs.tslibs import timezones
+from pandas._libs.tslibs import (
+    iNaT,
+    timezones,
+)
+from pandas.compat import WASM
+from pandas.errors import OutOfBoundsDatetime
+import pandas.util._test_decorators as td
 
 from pandas import (
     DatetimeIndex,
     Index,
     NaT,
+    Period,
     Timestamp,
     date_range,
     offsets,
@@ -290,3 +301,129 @@ class TestTZConvert:
         result = dti.tz_convert("UTC")
         assert (result == dti).all()
         assert result.freq is None
+
+
+def _utc_dti(value):
+    # Build a UTC-labelled index without going through the eager scalar
+    #  constructor, so that the UTC->local shift is what raises.
+    return DatetimeIndex(np.array([value], dtype="i8").view("M8[ns]")).tz_localize(
+        "UTC"
+    )
+
+
+@pytest.mark.parametrize(
+    "tz",
+    [
+        "Europe/Berlin",  # zoneinfo tz-rule fast path, val past the last transition
+        gettz("Europe/Berlin"),  # dateutil, so the transition bisect instead
+        "Etc/GMT-9",  # fixed offset
+    ],
+)
+def test_dti_utc_to_local_overflow(tz):
+    # GH#66550 the UTC->local shift was a bare add, so a UTC instant whose wall
+    #  time in tz is past Timestamp.max wrapped by 585 years instead of raising.
+    #  The scalar path already refuses the same conversion.
+    dti = _utc_dti(Timestamp.max._value).tz_convert(tz)
+
+    with pytest.raises(OutOfBoundsDatetime, match="overflows past"):
+        dti.tz_localize(None)
+
+
+def test_dti_utc_to_local_underflow():
+    # GH#66550 the same wrap at the bottom of the range.  US/Pacific is west of
+    #  UTC, so Timestamp.min's wall time there is below Timestamp.min.
+    dti = _utc_dti(Timestamp.min._value).tz_convert("US/Pacific")
+
+    with pytest.raises(OutOfBoundsDatetime, match="underflows past"):
+        dti.tz_localize(None)
+
+
+def test_dti_utc_to_local_overflow_message_names_the_target_tz():
+    # GH#66550 the only value left to render is the in-bounds UTC instant, so
+    #  without the target tz the message complains about a value that looks fine.
+    dti = _utc_dti(Timestamp.max._value).tz_convert("Etc/GMT-9")
+
+    msg = "Converting 2262-04-11 23:47:16 to Etc/GMT-9 overflows past"
+    with pytest.raises(OutOfBoundsDatetime, match=msg):
+        dti.tz_localize(None)
+
+
+@td.skip_if_windows  # `tm.set_timezone` does not work on Windows
+@pytest.mark.skipif(WASM, reason="`tm.set_timezone` does not work on WASM")
+@td.skip_if_32bit  # OverflowError inside tzlocal past 2038
+def test_dti_utc_to_local_overflow_tzlocal():
+    # GH#66550 the tzlocal branch of the shift needs the same guard.  Pin the
+    #  ambient zone: the wall time only overflows east of UTC.
+    dti = _utc_dti(Timestamp.max._value)
+
+    with tm.set_timezone("Asia/Tokyo"):
+        dti = dti.tz_convert(dateutil.tz.tzlocal())
+        with pytest.raises(OutOfBoundsDatetime, match="overflows past"):
+            dti.tz_localize(None)
+
+
+def test_dti_utc_to_local_at_the_boundary_still_converts():
+    # GH#66550 one step in from the wrap, and eastward, must keep working
+    dti = _utc_dti(Timestamp.max._value - 2 * 3600 * 10**9).tz_convert("Europe/Berlin")
+
+    result = dti.tz_localize(None)
+    expected = DatetimeIndex([Timestamp("2262-04-11 23:47:16.854775807")])
+    tm.assert_index_equal(result, expected)
+
+
+@pytest.fixture
+def dti_local_on_sentinel():
+    # A UTC instant that is representable, but whose wall time one hour west of
+    #  UTC is exactly the NaT sentinel.
+    return (
+        DatetimeIndex(np.array([iNaT + 3600 * 10**9], dtype="i8").view("M8[ns]"))
+        .tz_localize("UTC")
+        .tz_convert(timezone(timedelta(hours=-1)))
+    )
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        lambda dti: dti.tz_localize(None),
+        lambda dti: dti.year,
+        lambda dti: dti.floor("D"),
+        lambda dti: dti.to_period("ns"),
+    ],
+    ids=["tz_localize", "year", "floor", "to_period_ns"],
+)
+@pytest.mark.filterwarnings("ignore:Converting to PeriodArray:UserWarning")
+def test_dti_local_on_sentinel_raises_where_stored(dti_local_on_sentinel, func):
+    # GH#66550 the wall time is fine to render, but these consumers store it in
+    #  an i8 buffer where the sentinel reads back as NaT -- tz_localize(None) and
+    #  to_period("ns") silently returned NaT, and the field accessors returned -1.
+    with pytest.raises(OutOfBoundsDatetime, match="underflows past"):
+        func(dti_local_on_sentinel)
+
+
+@pytest.mark.filterwarnings("ignore:Converting to PeriodArray:UserWarning")
+def test_dti_local_on_sentinel_still_renders(dti_local_on_sentinel):
+    # GH#66550 ... but the consumers that only render it are correct today and
+    #  must stay that way.
+    dti = dti_local_on_sentinel
+    # datetime has no nanoseconds, so to_pydatetime stops at the microsecond
+    assert str(dti.to_pydatetime()[0]).startswith("1677-09-21 00:12:43.145224")
+    assert str(dti.astype(object)[0]).startswith("1677-09-21 00:12:43.145224192")
+    assert dti.strftime("%Y-%m-%d")[0] == "1677-09-21"
+    assert dti.to_period("D")[0] == Period("1677-09-21", "D")
+    assert dti.resolution == "nanosecond"
+    assert not dti.is_normalized
+
+
+@pytest.mark.parametrize(
+    "tz", [None, "UTC", "US/Pacific", "Etc/GMT-9", timezone(timedelta(hours=-1))]
+)
+def test_dti_all_nat_is_normalized(tz):
+    # GH#66550 is_date_array_normalized is the one Localizer loop that does not
+    #  skip NaT before shifting, so the guarded shift needs an explicit exit that
+    #  keeps reporting False rather than flipping an all-NaT array to True.
+    dti = DatetimeIndex([NaT, NaT])
+    if tz is not None:
+        dti = dti.tz_localize(tz)
+
+    assert not dti.is_normalized


### PR DESCRIPTION
closes #66550

Final item of GH-66550 (the issue was auto-closed by GH-66570, which only covered item 3; items 1-4 have since landed via GH-66569, GH-66570, GH-66589 and GH-66698).

`Localizer.utc_val_to_local_val` applied the UTC offset with a bare add, so a UTC instant whose wall time leaves the representable range wrapped by roughly 585 years instead of raising. This is not just a bad repr — `tz_localize(None)` and `floor`/`ceil`/`round` store the wrapped value, and `.year` / `strftime` agree with it. The scalar path already refuses the same conversion via `conversion.check_overflows`, so scalar and array disagreed.

```python
>>> dti = pd.DatetimeIndex([pd.Timestamp.min], tz="UTC").tz_convert("US/Pacific")
>>> dti.tz_localize(None)
DatetimeIndex(["2262-04-11 15:54:18.854775809"], dtype="datetime64[ns]")   # 585 years off
>>> pd.Timestamp(pd.Timestamp.min._value, tz="UTC").tz_convert("US/Pacific")
OutOfBoundsDatetime: Converting 2262-04-11 15:54:18 overflows past ...
```

The shift now goes through `checked_add`, and `raise_out_of_bounds` takes an optional target tz — going UTC->local the only value left to render is the in-bounds UTC instant, so without naming the zone the message reads as a complaint about a value that is plainly fine.

A local value landing *exactly* on the `NaT` sentinel is deliberately **not** rejected in the shift. Unlike a wrapped value, it still renders the correct wall time through `pandas_datetime_to_datetimestruct`, so rejecting it there would regress `to_pydatetime`, `astype(object)`, `to_period` at coarser freqs, `.resolution` and `read_csv` — all correct today. It is only unusable for the callers that store it back into an i8 buffer, and there are exactly two: `tz_convert_from_utc` (backing `tz_localize(None)` and everything reached via `_local_timestamps()`), and `dt64arr_to_periodarr`, where at nanosecond freq the period ordinal *is* the local i8 value.

`is_date_array_normalized` has to change in the same commit: it is the only `Localizer` loop that does not skip `NPY_NAT` before shifting, so the guarded shift would otherwise make `DatetimeIndex([NaT], tz=...).is_normalized` raise. It returns `False` rather than skipping — a bare `continue` would flip an all-NaT array to `True`.

Cost of the check is about +3% on the fixed-offset path over 1M values and within noise on the DST path, measured against an otherwise identical build with the `checked_add` reverted.