### PR TITLE
BUG: cast values before categorical dtype lookup

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -469,6 +469,7 @@ Categorical
 - Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory by using ``dict.get``, causing ``NA`` values to be replaced with ``NaN`` instead of the mapper's default value (:issue:`62710`)
 - Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
 - Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)
+- Bug in :meth:`Series.astype` with a :class:`CategoricalDtype` silently converting values to missing values when their dtype differed from the categories' dtype (:issue:`66688`)
 -
 
 Datetimelike

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -555,8 +555,32 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
 
     @classmethod
     def _from_sequence(
-        cls, scalars, *, dtype: Dtype | None = None, copy: bool = False
+        cls,
+        scalars,
+        *,
+        dtype: Dtype | None = None,
+        copy: bool = False,
+        cast_values: bool = False,
     ) -> Self:
+        if (
+            cast_values
+            and isinstance(dtype, CategoricalDtype)
+            and dtype.categories is not None
+            and len(scalars)
+            and scalars.dtype != dtype.categories.dtype
+        ):
+            from pandas import Index
+
+            na_mask = isna(scalars)
+            values = Index(scalars[~na_mask], copy=False).astype(
+                dtype.categories.dtype, copy=False
+            )
+            if na_mask.any():
+                result = np.asarray(scalars, dtype=object)
+                result[~na_mask] = values
+                scalars = result
+            else:
+                scalars = values
         return cls(scalars, dtype=dtype, copy=copy)
 
     def _cast_pointwise_result(self, values) -> ArrayLike:

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -560,27 +560,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         *,
         dtype: Dtype | None = None,
         copy: bool = False,
-        cast_values: bool = False,
     ) -> Self:
-        if (
-            cast_values
-            and isinstance(dtype, CategoricalDtype)
-            and dtype.categories is not None
-            and len(scalars)
-            and scalars.dtype != dtype.categories.dtype
-        ):
-            from pandas import Index
-
-            na_mask = isna(scalars)
-            values = Index(scalars[~na_mask], copy=False).astype(
-                dtype.categories.dtype, copy=False
-            )
-            if na_mask.any():
-                result = np.asarray(scalars, dtype=object)
-                result[~na_mask] = values
-                scalars = result
-            else:
-                scalars = values
         return cls(scalars, dtype=dtype, copy=copy)
 
     def _cast_pointwise_result(self, values) -> ArrayLike:

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -178,6 +178,13 @@ def astype_array(values: ArrayLike, dtype: DtypeObj, copy: bool = False) -> Arra
             return values.copy()
         return values
 
+    if isinstance(dtype, CategoricalDtype) and not isinstance(
+        values.dtype, CategoricalDtype
+    ):
+        return dtype.construct_array_type()._from_sequence(
+            values, dtype=dtype, copy=copy, cast_values=True
+        )
+
     if not isinstance(values, np.ndarray):
         # i.e. ExtensionArray
         values = values.astype(dtype, copy=copy)

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -190,12 +190,13 @@ def astype_array(values: ArrayLike, dtype: DtypeObj, copy: bool = False) -> Arra
             converted = Index(values[~na_mask], copy=False).astype(
                 dtype.categories.dtype, copy=False
             )
+            converted_values = converted._values
             if na_mask.any():
                 result = np.asarray(values, dtype=object)
-                result[~na_mask] = converted
+                result[~na_mask] = converted_values
                 values = result
             else:
-                values = converted
+                values = converted_values
         return dtype.construct_array_type()._from_sequence(
             values, dtype=dtype, copy=copy
         )

--- a/pandas/core/dtypes/astype.py
+++ b/pandas/core/dtypes/astype.py
@@ -181,8 +181,23 @@ def astype_array(values: ArrayLike, dtype: DtypeObj, copy: bool = False) -> Arra
     if isinstance(dtype, CategoricalDtype) and not isinstance(
         values.dtype, CategoricalDtype
     ):
+        if dtype.categories is not None:
+            from pandas.core.dtypes.missing import isna
+
+            from pandas import Index
+
+            na_mask = isna(values)
+            converted = Index(values[~na_mask], copy=False).astype(
+                dtype.categories.dtype, copy=False
+            )
+            if na_mask.any():
+                result = np.asarray(values, dtype=object)
+                result[~na_mask] = converted
+                values = result
+            else:
+                values = converted
         return dtype.construct_array_type()._from_sequence(
-            values, dtype=dtype, copy=copy, cast_values=True
+            values, dtype=dtype, copy=copy
         )
 
     if not isinstance(values, np.ndarray):

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -409,6 +409,36 @@ class TestCategoricalConstructors:
         tm.assert_categorical_equal(result, expected)
         assert result.ordered is ordered
 
+    @pytest.mark.parametrize(
+        "values, categories, expected",
+        [
+            ([1, 2], Index(pd.array(["1", "2"], dtype="string")), ["1", "2"]),
+            (["1", "2"], Index([1, 2]), [1, 2]),
+            (
+                pd.array([1, None], dtype="Int64"),
+                Index(pd.array(["1", "2"], dtype="string")),
+                ["1", None],
+            ),
+        ],
+    )
+    def test_astype_categorical_dtype_casts_values_to_categories_dtype(
+        self, values, categories, expected
+    ):
+        # GH#66688
+        dtype = CategoricalDtype(categories)
+
+        result = Series(values).astype(dtype)
+        expected = Series(expected, dtype=dtype)
+
+        tm.assert_series_equal(result, expected)
+
+    def test_astype_categorical_dtype_raises_on_invalid_cast(self):
+        # GH#66688
+        dtype = CategoricalDtype(Index([1, 2]))
+
+        with pytest.raises(ValueError, match="invalid literal for int"):
+            Series(["a", "b"]).astype(dtype)
+
     def test_constructor_dtype_and_others_raises(self):
         dtype = CategoricalDtype(["a", "b"], ordered=True)
         msg = "Cannot specify `categories` or `ordered` together with `dtype`."

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -412,11 +412,15 @@ class TestCategoricalConstructors:
     @pytest.mark.parametrize(
         "values, categories, expected",
         [
-            ([1, 2], Index(pd.array(["1", "2"], dtype="string")), ["1", "2"]),
-            (["1", "2"], Index([1, 2]), [1, 2]),
+            (
+                [1, 2],
+                pd.Index(pd.array(["1", "2"], dtype="string")),
+                ["1", "2"],
+            ),
+            (["1", "2"], pd.Index([1, 2]), [1, 2]),
             (
                 pd.array([1, None], dtype="Int64"),
-                Index(pd.array(["1", "2"], dtype="string")),
+                pd.Index(pd.array(["1", "2"], dtype="string")),
                 ["1", None],
             ),
         ],
@@ -427,17 +431,17 @@ class TestCategoricalConstructors:
         # GH#66688
         dtype = CategoricalDtype(categories)
 
-        result = Series(values).astype(dtype)
-        expected = Series(expected, dtype=dtype)
+        result = pd.Series(values).astype(dtype)
+        expected = pd.Series(expected, dtype=dtype)
 
         tm.assert_series_equal(result, expected)
 
     def test_astype_categorical_dtype_raises_on_invalid_cast(self):
         # GH#66688
-        dtype = CategoricalDtype(Index([1, 2]))
+        dtype = CategoricalDtype(pd.Index([1, 2]))
 
         with pytest.raises(ValueError, match="invalid literal for int"):
-            Series(["a", "b"]).astype(dtype)
+            pd.Series(["a", "b"]).astype(dtype)
 
     def test_constructor_dtype_and_others_raises(self):
         dtype = CategoricalDtype(["a", "b"], ordered=True)


### PR DESCRIPTION
Closes #66688

`Categorical` resolved values against explicit categories before casting them to the categories dtype. Values that were castable but stored with a different dtype were therefore treated as absent and silently converted to missing values.

Cast values to `categories.dtype` before lookup in `_get_codes_for_values`. This preserves valid conversions and propagates actual conversion errors instead of emitting the deprecated missing-category warning.

Tests cover int-to-string and string-to-int categorical casts, plus an invalid string-to-integer cast.

Tests:
- `pytest pandas/tests/arrays/categorical/test_constructors.py -k "astype_categorical_dtype_casts_values_to_categories_dtype or astype_categorical_dtype_raises_on_invalid_cast"`
- `pre-commit run --files pandas/core/arrays/categorical.py pandas/tests/arrays/categorical/test_constructors.py doc/source/whatsnew/v3.1.0.rst`

This contribution was prepared with assistance from an AI coding tool and reviewed by the contributor.