### PR TITLE
TST: fix MultiIndex freq check in assert_frame_equal

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -436,6 +436,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :class:`Series` where empty frozensets were formatted incorrectly (:issue:`66192`)
+- Fixed bug in :func:`testing.assert_frame_equal` raising an ``AssertionError`` for a frequency mismatch in a :class:`MultiIndex` level (:issue:`66761`)
 - Fixed bug in :func:`testing.assert_series_equal` showing a misleading class mismatch message when Series values were backed by different :class:`numpy.ndarray` subclasses (:issue:`65770`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
 

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -1456,7 +1456,7 @@ def assert_frame_equal(
         check_exact=_check_exact,
         check_categorical=check_categorical,
         check_order=not check_like,
-        check_freq=_check_freq,
+        check_freq=check_freq if isinstance(left.index, MultiIndex) else _check_freq,
         rtol=_rtol,
         atol=_atol,
         obj=f"{obj}.index",

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -459,6 +459,23 @@ def test_assert_frame_equal_check_freq_columns():
         tm.assert_frame_equal(df1, df2, check_freq=False)
 
 
+def test_assert_frame_equal_check_freq_multiindex():
+    # GH#66761
+    dates = pd.date_range("2012-01-01", periods=3)
+    midx1 = pd.MultiIndex.from_arrays([dates, [1, 2, 3]])
+    midx2 = pd.MultiIndex.from_arrays([dates._with_freq(None), [1, 2, 3]])
+    df1 = DataFrame({"a": [1, 2, 3]}, index=midx1)
+    df2 = DataFrame({"a": [1, 2, 3]}, index=midx2)
+    warn_msg = "will check the 'freq' attribute"
+    with tm.assert_produces_warning(Pandas4Warning, match=warn_msg):
+        tm.assert_frame_equal(df1, df2)
+    raise_msg = 'Attribute "freq" are different'
+    with pytest.raises(AssertionError, match=raise_msg):
+        tm.assert_frame_equal(df1, df2, check_freq=True)
+    with tm.assert_produces_warning(None):
+        tm.assert_frame_equal(df1, df2, check_freq=False)
+
+
 @pytest.mark.parametrize(
     "left,right",
     [


### PR DESCRIPTION
- [x] closes #66761
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html).
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

### changes

`assert_frame_equal` was forwarding its resolved `check_freq=True` value into `MultiIndex` level comparisons. This caused a frequency mismatch in a `MultiIndex` level to raise immediately instead of following the warn-first deprecation behavior of `assert_index_equal`.

This change preserves the existing hard frequency check for non-`MultiIndex` indexes while allowing the unresolved `check_freq` value to propagate through `MultiIndex` level comparisons.

The regression test covers the default behavior, `check_freq=True`, and `check_freq=False`.