### PR TITLE
BUG: test_spss_metadata fails with pyreadstat 1.3.6 due to new original_variable_informats metadata key

### DIFF
--- a/pandas/tests/io/test_spss.py
+++ b/pandas/tests/io/test_spss.py
@@ -166,4 +166,14 @@ def test_spss_metadata(datapath):
         "modification_time": datetime.datetime(2015, 2, 6, 14, 33, 36),
         "mr_sets": {},
     }
-    tm.assert_dict_equal(df.attrs, metadata)
+
+    # GH 66750: pyreadstat >= 1.3.6 exposes an additional
+    # "original_variable_informats" metadata key that older versions did not.
+    # Only assert its value when present, then drop it so the remaining
+    # metadata can still be compared for exact equality.
+    result_attrs = dict(df.attrs)
+    if "original_variable_informats" in result_attrs:
+        assert result_attrs.pop("original_variable_informats") == {
+            "VAR00002": None
+        }
+    tm.assert_dict_equal(result_attrs, metadata)


### PR DESCRIPTION
- [x] closes #66750 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
