### PR TITLE
DOC: require human-written comments and specific AI disclosure

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,4 +4,7 @@
 - [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
 - [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
 - [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
-- [ ] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
+Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):
+
+- [ ] I did **not** use AI to develop this pull request.
+- [ ] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,16 +46,17 @@
 - Pull request descriptions should follow the template, and **succinctly** describe the change being made. Usually a few sentences is sufficient.
 - Pull requests that resolve an existing GitHub issue should include a link to the issue in the PR description.
 - Do not add summaries or additional comments to individual commit messages. The single PR description is sufficient.
-- When AI was used, the PR description must disclose it specifically: the tool, the model and version, and the
-  reasoning-effort setting, e.g. `claude opus 4.8 (xhigh)` rather than `claude`. Report what you are actually running
-  as; if you are not certain of your own model version or effort setting, ask rather than guessing.
+- Check the "I used AI to develop this pull request" box in the pull request template, and disclose your model
+  metadata in the description: the tool, the model and version, and the reasoning-effort setting, e.g.
+  `claude opus 4.8 (xhigh)` rather than `claude`. Report what you are actually running as; if you are not certain of
+  your model version or effort setting, ask rather than guessing.
 
 ## Comments on issues and pull requests
-- Using an AI assistant to help write the code, tests, and documentation in a pull request is fine, subject to the
+- Helping write the code, tests, and documentation in a pull request is fine. Comments are different: see the
   automated contributions policy in `doc/source/development/contributing.rst`.
-- Discussion is different: do not use AI to speak for the contributor in issues, pull requests, or review comments.
-  Copying and pasting AI-written replies does not count as engaging with a reviewer.
-- Translation and grammar editing are an explicit exception, and need no disclosure. The requirement is that the
-  thoughts are the contributor's, not that the English is unaided.
-- Output of an AI tool quoted as evidence, such as a traceback or a suggested diff, must be marked clearly by quoting
-  it with `>` or wrapping it in triple backticks, so readers can tell which parts are the contributor's own words.
+- Do not post comments on GitHub issues or pull requests, and do not reply to reviewers, on behalf of the user.
+- Do not write the user's side of a discussion for them to paste. Summarize your analysis in chat and let the user
+  respond in their own words.
+- When you quote tool output as evidence, such as a traceback or a suggested diff, mark it with `>` or triple
+  backticks so readers can tell which parts are the user's own words.
+- Translation and grammar editing are an exception to the rule above, but must still be disclosed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,16 @@
 - Pull request descriptions should follow the template, and **succinctly** describe the change being made. Usually a few sentences is sufficient.
 - Pull requests that resolve an existing GitHub issue should include a link to the issue in the PR description.
 - Do not add summaries or additional comments to individual commit messages. The single PR description is sufficient.
+- When AI was used, the PR description must disclose it specifically: the tool, the model and version, and the
+  reasoning-effort setting, e.g. `claude opus 4.8 (xhigh)` rather than `claude`. Report what you are actually running
+  as; if you are not certain of your own model version or effort setting, ask rather than guessing.
+
+## Comments on issues and pull requests
+- Using an AI assistant to help write the code, tests, and documentation in a pull request is fine, subject to the
+  automated contributions policy in `doc/source/development/contributing.rst`.
+- Discussion is different: do not use AI to speak for the contributor in issues, pull requests, or review comments.
+  Copying and pasting AI-written replies does not count as engaging with a reviewer.
+- Translation and grammar editing are an explicit exception, and need no disclosure. The requirement is that the
+  thoughts are the contributor's, not that the English is unaided.
+- Output of an AI tool quoted as evidence, such as a traceback or a suggested diff, must be marked clearly by quoting
+  it with `>` or wrapping it in triple backticks, so readers can tell which parts are the contributor's own words.

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -38,9 +38,9 @@ different: in issues, pull requests, and review comments, do not use AI to speak
 AI-written replies does not count as engaging with a reviewer, and human-to-human communication is essential for
 the project to thrive.
 
-Translation and grammar editing are an explicit exception, and need no disclosure. If English is not your first
-language, you are welcome to use these tools to help you say what you mean. What we ask is that the thoughts are
-yours, not that the English is unaided.
+Translation and grammar editing are an explicit exception to the rule above. If English is not your first language,
+you are welcome to use these tools to help you say what you mean. What we ask is that the thoughts are yours, not
+that the English is unaided. Disclosure still applies, so say that you used a tool.
 
 If you need to quote the output of an AI tool as evidence, for example a traceback or a suggested diff, mark it
 clearly by quoting it with ``>`` or wrapping it in a triple-backtick code fence, so readers can tell which parts

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -23,9 +23,28 @@ Contributors may use automated tools such as AI coding assistants while contribu
 to pandas as long as it's used **responsibly**. Any use of these tools in a contribution must abide by all of the
 following guidelines:
 
-* You must disclose that you used an automated tool in the contribution.
+* You must disclose that you used an automated tool in the contribution, and be specific about which one.
 * You must fully review and modify the result of the automated tool.
 * You must ensure the contribution fully abides by all documented, contribution conventions in pandas.
+* You must not use AI to speak for you when interacting with the community.
+
+A useful disclosure names the tool, the model and version it ran, and any reasoning-effort or thinking setting, so
+that reviewers know how much scrutiny to apply: ``claude opus 4.8 (xhigh)`` tells us something, ``claude`` does not.
+Not every tool exposes an effort setting, so give what applies. If you used more than one tool or model, say which
+parts of the contribution each was responsible for.
+
+Using these tools to help write the code, tests, and documentation in a contribution is fine. Discussion is
+different: in issues, pull requests, and review comments, do not use AI to speak for you. Copying and pasting
+AI-written replies does not count as engaging with a reviewer, and human-to-human communication is essential for
+the project to thrive.
+
+Translation and grammar editing are an explicit exception, and need no disclosure. If English is not your first
+language, you are welcome to use these tools to help you say what you mean. What we ask is that the thoughts are
+yours, not that the English is unaided.
+
+If you need to quote the output of an AI tool as evidence, for example a traceback or a suggested diff, mark it
+clearly by quoting it with ``>`` or wrapping it in a triple-backtick code fence, so readers can tell which parts
+are your own words.
 
 This policy applies to any contribution made to pandas, including submitted issues or pull requests. Maintainers
 reserve the right to discern whether automated tooling was used and reject contributions that do not follow all of


### PR DESCRIPTION
Clarifies the automated contributions policy on two points.

**Comments.** Using AI to help write the code, tests, and documentation in a PR is fine; discussion is not the same thing. In issues, PRs, and review comments we want to interact with humans, so the policy now says not to use AI to speak for you, and that pasting AI-written replies doesn't count as engaging with a reviewer. Translation and grammar editing are an explicit exception to that rule, though they still have to be disclosed. Where quoting a tool's raw output is genuinely useful (a traceback, a suggested diff), it must be marked with `>` or a code fence so readers can tell which parts are the contributor's own words.

This is roughly where peer projects have landed: NumPy, Jupyter, scikit-learn and Astropy all prohibit AI-written text in discussion, and napari uses the same quote-block convention for citing tool output.

**Disclosure specificity.** "I used AI" carries very little information. The policy now asks for the tool, the model and version, and any reasoning-effort setting — `claude opus 4.8 (xhigh)` rather than `claude` — so reviewers can calibrate how much scrutiny to apply. Not every tool exposes an effort setting, so contributors give what applies.

Relatedly, the PR template's conditional AI line ("If I used AI... I prompted it to follow `AGENTS.md`") was ambiguous when left unchecked: it could mean no AI was used, AI was used without `AGENTS.md`, or the contributor didn't read the line. It becomes a forced choice between two statements.

The `AGENTS.md` half of this is written in the imperative, since it is a document agents follow rather than prose about them.

AI disclosure for this PR: drafted with Claude Code (`claude opus 5 (high)`), including the survey of peer-project policies referenced above.