### PR TITLE
Timezone-aware Timestamp

### DIFF
--- a/pandas/core/tslibs/timestamp_tz.py
+++ b/pandas/core/tslibs/timestamp_tz.py
@@ -1,0 +1,74 @@
+"""TimestampTZ - a thin Timestamp subclass that requires timezone-aware datetimes.
+
+This module provides TimestampTZ, a small subclass of pandas.Timestamp that
+validates that the resulting Timestamp is timezone-aware. It keeps construction
+and timezone parsing/validation delegated to pandas.Timestamp and only enforces
+that the produced Timestamp has a tz. This avoids duplicating timezone parsing
+logic and keeps the class lightweight.
+
+Examples
+--------
+>>> from pandas.core.tslibs.timestamp_tz import TimestampTZ
+>>> TimestampTZ("2020-01-01T00:00:00+00:00")
+TimestampTZ('2020-01-01 00:00:00+00:00', tz='UTC')
+
+You can also pass a tz keyword to localize naive inputs:
+>>> TimestampTZ("2020-01-01T00:00:00", tz="UTC")
+TimestampTZ('2020-01-01 00:00:00+00:00', tz='UTC')
+
+Naive datetimes without an explicit tz will raise:
+>>> TimestampTZ("2020-01-01T00:00:00")
+Traceback (most recent call last):
+    ...
+ValueError: TimestampTZ requires a timezone-aware Timestamp
+
+Notes
+-----
+- This class intentionally does minimal work: it delegates parsing and
+  localization to pandas.Timestamp and only tests for presence of `tz`.
+- Because pandas.Timestamp is an extension/Cython-backed type, some
+  operations on TimestampTZ may return base Timestamp instances. If preserving
+  the subclass across all operations is required, consider implementing a
+  wrapper type instead.
+
+"""
+
+from pandas import Timestamp
+
+__all__ = ["TimestampTZ"]
+
+
+class TimestampTZ(Timestamp):
+    """A Timestamp subclass that requires timezone-aware datetimes.
+
+    Parameters
+    ----------
+    *args, **kwargs
+        Same as pandas.Timestamp. A `tz` keyword may be provided to localize
+        naive inputs. After construction, the resulting Timestamp must have a
+        timezone; otherwise a ValueError is raised.
+
+    Examples
+    --------
+    >>> TimestampTZ("2020-01-01T00:00:00+00:00")
+    TimestampTZ('2020-01-01 00:00:00+00:00', tz='UTC')
+
+    >>> TimestampTZ("2020-01-01T00:00:00", tz="UTC")
+    TimestampTZ('2020-01-01 00:00:00+00:00', tz='UTC')
+
+    >>> TimestampTZ("2020-01-01T00:00:00")
+    Traceback (most recent call last):
+        ...
+    ValueError: TimestampTZ requires a timezone-aware Timestamp
+    """
+
+    def __new__(cls, *args, tz=None, **kwargs):
+        # Delegate construction and timezone parsing/localization to pandas.Timestamp
+        # Timestamp accepts a `tz` kw and will localize/convert as appropriate.
+        ts = super().__new__(cls, *args, tz=tz, **kwargs)
+
+        # Ensure the resulting Timestamp is timezone-aware
+        if ts.tz is None:
+            raise ValueError("TimestampTZ requires a timezone-aware Timestamp")
+
+        return ts

--- a/pandas/core/tslibs/timestamp_with_zone.py
+++ b/pandas/core/tslibs/timestamp_with_zone.py
@@ -1,0 +1,115 @@
+"""TimestampWithZone - a Timestamp subclass that enforces timezone-aware datetimes.
+
+This module provides TimestampWithZone, a subclass of pandas.Timestamp that
+validates that the resulting Timestamp is timezone-aware. It keeps construction
+and timezone parsing/validation delegated to pandas.Timestamp and only enforces
+that the produced Timestamp has a tz. This avoids duplicating timezone parsing
+logic and keeps the class lightweight.
+
+Examples
+--------
+>>> from pandas.core.tslibs.timestamp_with_zone import TimestampWithZone
+>>> TimestampWithZone("2020-01-01T00:00:00+00:00")
+TimestampWithZone('2020-01-01 00:00:00+00:00', tz='UTC')
+
+You can also pass a tz keyword to localize naive inputs:
+>>> TimestampWithZone("2020-01-01T00:00:00", tz="UTC")
+TimestampWithZone('2020-01-01 00:00:00+00:00', tz='UTC')
+
+Naive datetimes without an explicit tz will raise:
+>>> TimestampWithZone("2020-01-01T00:00:00")
+Traceback (most recent call last):
+    ...
+ValueError: TimestampWithZone requires a timezone-aware Timestamp
+
+Notes
+-----
+- This class intentionally does minimal work: it delegates parsing and
+  localization to pandas.Timestamp and only tests for presence of `tz`.
+- Because pandas.Timestamp is an extension/Cython-backed type, some
+  operations on TimestampWithZone may return base Timestamp instances. If preserving
+  the subclass across all operations is required, consider implementing a
+  wrapper type instead.
+
+"""
+
+from pandas import Timestamp
+
+__all__ = ["TimestampWithZone"]
+
+
+class TimestampWithZone(Timestamp):
+    """A Timestamp subclass that enforces timezone-aware datetimes.
+
+    This class ensures that any Timestamp created is always timezone-aware,
+    raising a ValueError if a naive datetime is provided without an explicit tz.
+
+    Parameters
+    ----------
+    *args, **kwargs
+        Same as pandas.Timestamp. A `tz` keyword may be provided to localize
+        naive inputs. After construction, the resulting Timestamp must have a
+        timezone; otherwise a ValueError is raised.
+
+    Raises
+    ------
+    ValueError
+        If the resulting Timestamp does not have a timezone (tz is None).
+
+    Examples
+    --------
+    Create from an ISO string with timezone:
+
+    >>> TimestampWithZone("2020-01-01T00:00:00+00:00")  # doctest: +SKIP
+    TimestampWithZone('2020-01-01 00:00:00+00:00', tz='UTC')
+
+    Localize a naive datetime by providing tz keyword:
+
+    >>> TimestampWithZone("2020-01-01T00:00:00", tz="UTC")  # doctest: +SKIP
+    TimestampWithZone('2020-01-01 00:00:00+00:00', tz='UTC')
+
+    Creating from a naive datetime string without tz keyword raises:
+
+    >>> TimestampWithZone("2020-01-01T00:00:00")  # doctest: +SKIP
+    Traceback (most recent call last):
+        ...
+    ValueError: TimestampWithZone requires a timezone-aware Timestamp
+    """
+
+    def __new__(cls, *args, tz=None, **kwargs):
+        """Create a new TimestampWithZone instance.
+
+        Parameters
+        ----------
+        *args
+            Positional arguments passed to pandas.Timestamp.
+        tz : str, pytz.timezone, dateutil.tz.tzfile, or None, optional
+            Time zone for the Timestamp. If provided, will localize naive inputs.
+        **kwargs
+            Keyword arguments passed to pandas.Timestamp.
+
+        Returns
+        -------
+        TimestampWithZone
+            A timezone-aware Timestamp instance.
+
+        Raises
+        ------
+        ValueError
+            If the resulting Timestamp is not timezone-aware.
+        """
+        # Delegate construction and timezone parsing/localization to pandas.Timestamp
+        # Timestamp accepts a `tz` kw and will localize/convert as appropriate.
+        ts = super().__new__(cls, *args, tz=tz, **kwargs)
+
+        # Ensure the resulting Timestamp is timezone-aware
+        if ts.tz is None:
+            raise ValueError("TimestampWithZone requires a timezone-aware Timestamp")
+
+        return ts
+
+    def __repr__(self) -> str:
+        """Return string representation of the Timestamp."""
+        return (
+            f"{self.__class__.__name__}('{self.isoformat()}', tz='{self.tz}')"
+        )


### PR DESCRIPTION
work in progress. add tz-aware timestamps that enforce presence of time zone

---

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
