### PR TITLE
BUG: to_numpy with a unit-less datetime64 dtype on tz-aware data (GH#59772)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -483,6 +483,7 @@ Datetimelike
 - Bug in :meth:`DatetimeIndex.union` and :meth:`TimedeltaIndex.union` with ``sort=False`` silently dropping values from the other index that fell after the end of ``self`` (:issue:`66322`)
 - Bug in :meth:`Series.dt.isocalendar` with a pyarrow-backed datetime or date dtype not preserving the original index, resetting it to a default :class:`RangeIndex` (:issue:`65894`)
 - Bug in :meth:`Series.dt.to_pydatetime` not preserving the original index and name (:issue:`66443`)
+- Bug in :meth:`Series.to_numpy` and :meth:`Index.to_numpy` with a unit-less ``dtype="datetime64"`` on timezone-aware data raising ``TypeError`` when any value was ``NaT``, and otherwise silently truncating to microsecond resolution instead of keeping the data's own resolution (:issue:`59772`)
 - Bug in ``day_of_week``, :meth:`Timestamp.weekday` and :meth:`Timestamp.day_name` returning a wrong weekday, or raising ``OverflowError``, for second-resolution datetimes with a year beyond ``2**31`` (:issue:`66549`)
 - Bug in adding a :class:`BusinessDay` offset to a :class:`DatetimeIndex` or :class:`Series` where an out-of-bounds result silently wrapped to an unrelated date, and a result landing exactly on the ``NaT`` sentinel came back as a missing value, instead of raising ``OverflowError`` (:issue:`66552`)
 - Bug in adding a :class:`BusinessDay` offset with ``n`` of magnitude ``2**31`` or more to a :class:`DatetimeIndex` or :class:`Series` silently shifting by a wrapped number of business days, e.g. ``n=2**32`` behaving like ``n=0`` (:issue:`66549`)

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -677,6 +677,22 @@ class DatetimeArray(dtl.TimelikeOps, dtl.DatelikeOps):
 
         return super().__array__(dtype=dtype, copy=copy)
 
+    def to_numpy(
+        self,
+        dtype: npt.DTypeLike | None = None,
+        copy: bool = False,
+        na_value: object = lib.no_default,
+    ) -> np.ndarray:
+        if dtype is not None:
+            npdtype = pandas_dtype(dtype)
+            if lib.is_np_dtype(npdtype, "M") and is_unitless(npdtype):
+                # GH#59772 numpy discards a unit-less datetime64 dtype before
+                #  calling __array__, so tz-aware values would go out as objects
+                #  and come back truncated to microseconds, or raise on NaT.
+                dtype = self._ndarray.dtype
+
+        return super().to_numpy(dtype, copy=copy, na_value=na_value)
+
     def _iter_convert_chunk(self, data: np.ndarray) -> np.ndarray:
         return ints_to_pydatetime(
             data.view("i8"), tz=self.tz, box="timestamp", reso=self._creso

--- a/pandas/tests/base/test_conversion.py
+++ b/pandas/tests/base/test_conversion.py
@@ -435,6 +435,24 @@ def test_to_numpy_dtype(as_series):
     tm.assert_numpy_array_equal(result, expected)
 
 
+@pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+def test_to_numpy_unitless_dtype_tzaware(index_or_series_or_array, unit):
+    # GH#59772 a unit-less "datetime64" keeps the object's own unit and
+    #  preserves NaT, instead of going out through object dtype
+    box = index_or_series_or_array
+    dti = pd.DatetimeIndex(["2000-01-01 00:00:00.123456789", "NaT"]).as_unit(unit)
+    obj = box(dti.tz_localize("US/Eastern"))
+
+    result = obj.to_numpy(dtype="datetime64")
+    expected = np.array(["2000-01-01T05:00:00.123456789", "NaT"], dtype="M8[ns]")
+    expected = expected.astype(f"M8[{unit}]")
+    tm.assert_numpy_array_equal(result, expected)
+
+    # same unit the tz-naive path gives
+    naive = box(dti).to_numpy(dtype="datetime64")
+    assert naive.dtype == result.dtype
+
+
 @pytest.mark.parametrize(
     "values, dtype, na_value, expected",
     [


### PR DESCRIPTION
closes #59772

numpy discards a unit-less `datetime64` dtype before calling `__array__`, so `DatetimeArray` read the request as "no dtype given" and returned its tz-aware default, an object array of `Timestamp`s. numpy then converted object -> `M8`, discovering the unit from the objects, which

- raised `TypeError: 'float' object cannot be interpreted as an integer` when any value was `NaT` (numpy probes `NaT.year`, which is `nan`), the case reported in the issue, and
- otherwise silently truncated to microseconds, `datetime`'s resolution, so nanosecond tz-aware data lost precision.

tz-naive data was never affected: numpy preserves the unit casting `M8[unit]` to a unit-less `M8`.

```python
ser = pd.Series(pd.to_datetime(["2000-01-01 00:00:00.123456789", "NaT"])).dt.tz_localize("US/Eastern")

ser.to_numpy("datetime64")      # TypeError: 'float' object cannot be interpreted as an integer
ser[:1].to_numpy("datetime64")  # array(['2000-01-01T05:00:00.123456'], dtype='datetime64[us]')
```

`DatetimeArray.to_numpy` now resolves a unit-less `M8` request to the array's own unit before delegating, so the tz-aware result matches the tz-naive one: UTC values, the data's own resolution, `NaT` preserved.

`np.asarray(dta, dtype="M8")` still raises; that conversion happens inside numpy and is not reachable from here. `TimedeltaArray` has no object path and no equivalent bug, so the change is `DatetimeArray`-only.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the root cause, wrote the fix and test, and ran the verification sweep.