### PR TITLE
BUG: bar plot raises AttributeError when the DatetimeIndex freq attribute is unset

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -768,6 +768,7 @@ Period
 
 Plotting
 ^^^^^^^^
+- Bug in :meth:`DataFrame.plot.bar` and :meth:`DataFrame.plot.barh` raising ``AttributeError`` for a regularly-spaced :class:`DatetimeIndex` whose ``freq`` attribute is unset (:issue:`66771`)
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
 - Bug in :meth:`DataFrame.plot` and :meth:`Series.plot` with ``secondary_y`` hiding the primary y-axis when the data already on the axes was drawn as a collection rather than as lines, e.g. by :meth:`DataFrame.plot.scatter` (:issue:`66789`)
 - Bug in :meth:`Series.plot`, :meth:`DataFrame.plot`, :meth:`DataFrame.plot.scatter`, :meth:`Series.hist`, :meth:`DataFrame.hist`, :func:`plotting.lag_plot` and :func:`plotting.parallel_coordinates` with timezone-aware data labelling the axis in UTC instead of in the data's own timezone (:issue:`64613`)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -69,6 +69,7 @@ from pandas.plotting._matplotlib.misc import unpack_single_str_list
 from pandas.plotting._matplotlib.style import get_standard_colors
 from pandas.plotting._matplotlib.timeseries import (
     format_dateaxis,
+    get_period_offset,
     maybe_convert_index,
     prepare_ts_data,
     use_dynamic_x,
@@ -88,6 +89,7 @@ if TYPE_CHECKING:
     from matplotlib.axis import Axis
     from matplotlib.figure import Figure
 
+    from pandas._libs.tslibs import BaseOffset
     from pandas._typing import (
         IndexLabel,
         NDFrameT,
@@ -1920,11 +1922,19 @@ class BarPlot(MPLPlot):
             self.tick_pos = np.array(
                 PeriodConverter.convert_from_freq(
                     self._get_xticks(),
-                    data.index.freq,
+                    self._ts_freq,
                 )
             )
         else:
             self.tick_pos = np.arange(len(data))
+
+    @cache_readonly
+    def _ts_freq(self) -> BaseOffset:
+        freq = get_period_offset(self._get_ax(0), self.data.index)
+        # only evaluated when _is_ts_plot() is True, which resolves the freq
+        # the same way and is False unless it resolves to a period alias
+        assert freq is not None
+        return freq
 
     @cache_readonly
     def ax_pos(self) -> np.ndarray:

--- a/pandas/plotting/_matplotlib/timeseries.py
+++ b/pandas/plotting/_matplotlib/timeseries.py
@@ -315,6 +315,30 @@ def use_dynamic_x(ax: Axes, index: Index) -> bool:
     return True
 
 
+def get_period_offset(ax: Axes, index: Index) -> BaseOffset | None:
+    """
+    Resolve the period frequency to plot `index` with on `ax`, or None.
+
+    The freq is resolved the same way :func:`use_dynamic_x` resolves it, since
+    that is what decides whether the dynamic date axis is used at all: the
+    index ``freq`` attribute may be unset even when the index is regular (the
+    freq is then inferred), and an already-decorated axes carries the freq of
+    whatever was plotted on it first.  The result is normalized to a period
+    offset, because an axes stores its freq as a period alias string.
+    """
+    freq = _get_index_freq(index)
+    if freq is None:
+        freq = _get_ax_freq(ax)
+    if freq is None:
+        return None
+
+    freq_str = _get_period_alias(freq)
+    if freq_str is None:
+        return None
+    freq_str = OFFSET_TO_PERIOD_FREQSTR.get(freq_str, freq_str)
+    return to_offset(freq_str, is_period=True)
+
+
 def _get_index_freq(index: Index) -> BaseOffset | None:
     freq = getattr(index, "freq", None)
     if freq is None:

--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1948,6 +1948,51 @@ class TestTSPlot:
         with temp_file.open(mode="wb") as path:
             pickle.dump(fig, path)
 
+    @pytest.mark.parametrize("kind", ["bar", "barh"])
+    def test_bar_plot_datetime_index_inferred_freq(self, kind):
+        # GH#66771 - the index freq attribute is unset but inferable, so the
+        # bar plot must resolve the freq instead of raising AttributeError
+        idx = DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"])
+        assert idx.freq is None
+        df = DataFrame({"A": [1, 2, 3]}, index=idx)
+
+        ax = df.plot(kind=kind)
+
+        ax.get_figure().canvas.draw()
+        axis = ax.get_yaxis() if kind == "barh" else ax.get_xaxis()
+        labels = [t.get_text() for t in axis.get_ticklabels()]
+        assert labels == [
+            "2020-01-01 00:00:00",
+            "2020-01-02 00:00:00",
+            "2020-01-03 00:00:00",
+        ]
+
+    @pytest.mark.parametrize("kind", ["bar", "barh"])
+    def test_bar_plot_datetime_index_freq_from_axes(self, kind):
+        # GH#66771 - the index carries no freq of its own, but the axes was
+        # already decorated by a line plot; that freq is stored as a period
+        # alias string, so it has to be normalized to an offset before it
+        # reaches the converter
+        _, ax = plt.subplots()
+        Series(
+            np.arange(10.0), index=date_range("2020-01-01", periods=10, freq="D")
+        ).plot(ax=ax)
+
+        idx = DatetimeIndex(["2020-01-02", "2020-01-05"])
+        assert idx.freq is None
+        assert idx.inferred_freq is None
+        Series([1.0, 2.0], index=idx).plot(kind=kind, ax=ax)
+
+        # the bars are centered on the same daily ordinals as the line
+        if kind == "bar":
+            centers = [p.get_x() + p.get_width() / 2 for p in ax.patches]
+        else:
+            centers = [p.get_y() + p.get_height() / 2 for p in ax.patches]
+        assert centers == [
+            Period("2020-01-02", freq="D").ordinal,
+            Period("2020-01-05", freq="D").ordinal,
+        ]
+
 
 def _check_plot_works(f, freq=None, series=None, *args, **kwargs):
     fig = plt.gcf()


### PR DESCRIPTION
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Split out of #62992 for easier review (per @jbrockmendel's request); that PR is the GH#1918 enhancement and will be rebased on top of this one.

`BarPlot.__init__` passes `data.index.freq` straight to `PeriodConverter.convert_from_freq`, but `_is_ts_plot()` only requires that a freq be *resolvable*: `use_dynamic_x` falls back to the index's inferred freq (`_inferred_freq_str`) and to the freq of an already-decorated axes. A regularly spaced `DatetimeIndex` constructed without an explicit `freq` therefore reaches the converter with `freq=None`:

```python
import pandas as pd

idx = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"])
assert idx.freq is None
pd.DataFrame({"A": [1, 2, 3]}, index=idx).plot(kind="bar")
```

```
AttributeError: 'NoneType' object has no attribute '_period_dtype_code'
```

This resolves the freq the same way `use_dynamic_x` does. The two freq helpers in `timeseries.py` lose their leading underscore so they can be used from `core.py` (the "private functions across modules" pre-commit check rejects the underscored names).
