### PR TITLE
DOC: fix dark mode text contrast in getting started tutorial cards

### DIFF
--- a/doc/source/_static/css/getting_started.css
+++ b/doc/source/_static/css/getting_started.css
@@ -39,6 +39,7 @@
 }
 
 .gs-data .card-body {
+  --bs-card-color: var(--pst-color-text-base);
   color: var(--pst-color-text-base);
 }
 


### PR DESCRIPTION
- [x] closes #66764
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [ ] All code checks passed.
- [ ] Added type annotations to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines

Check exactly one of the following, per the automated contributions policy:
- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

## Description

Fixes #66764 — text in the "Data used for this tutorial" card was unreadable (near-black on a near-black background) across the Getting Started tutorial pages when viewing the docs in dark mode.

**Root cause:** `.gs-data .card-body` text color was ultimately resolved via Bootstrap's own `--bs-card-color` custom property, which is set to a fixed dark value and is not dark-mode aware. A pandas-specific override (`.gs-data .card-body { color: var(--pst-color-text-base); }`) already existed in `getting_started.css`, but never actually took effect — CSS custom-property resolution is governed by where the *variable itself* is defined/inherited, not by selector specificity of the rule reading it, so Bootstrap's `color: var(--bs-card-color)` declaration kept winning regardless of pandas' more specific selector.

**Fix:** redefine `--bs-card-color` directly, scoped to `.gs-data .card-body`, so Bootstrap's existing `color` rule resolves against pandas' own theme-aware variable instead of its hardcoded default — following the same pattern already used elsewhere in this file for `.tutorial-card .card-header` / `--bs-card-cap-color`:

```css
.gs-data .card-body {
  --bs-card-color: var(--pst-color-text-base);
  color: var(--pst-color-text-base);
}
```

This class is shared across all Getting Started intro tutorial pages (`02_read_write.rst` through `10_text_data.rst`), so the fix applies to all of them, not just the page originally reported in the issue.

**Verification:** confirmed visually in Chrome DevTools (dark mode) on `06_calculate_statistics.html` that the card text and column-index badges are legible, and spot-checked a couple of the other affected tutorial pages the same way.

## How I used AI

I used Claude Sonnet 5 (via claude.ai chat) in a collaborative debugging session, not as an autonomous agent. Specifically:

- I pasted the issue and screenshots; Claude walked me through using Chrome DevTools (Elements → Styles → Computed) to identify which CSS rule was actually being applied to the invisible text, rather than guessing from the source files.
- Once the Computed panel showed `--bs-card-color` (from Bootstrap's `_card.scss`) as the winning source, Claude explained the root cause (CSS custom-property inheritance vs. selector specificity) and pointed me to an existing pattern already in `getting_started.css` (`.tutorial-card .card-header` overriding `--bs-card-cap-color`) to model the fix on.
- Claude specified the exact variable name and target value to use in the fix. I wrote and committed the actual CSS change myself, and verified the result visually in DevTools before committing.
- Claude also helped me troubleshoot my local dev environment setup (Python interpreter/pip mismatch, missing doc-build dependencies) when I tried to do a full local docs build; I ultimately verified the fix live in-browser instead, since I hit an unrelated DLL import issue building pandas' C extensions locally.

I have reviewed and understand the change; it is a one-line CSS addition and I could explain and reproduce it without AI assistance now that I understand the root cause.