### PR TITLE
BUG: make duplicated hashtable test levels distinct

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -852,7 +852,6 @@ Other
 - Bug in :meth:`DataFrame.select_dtypes` with an :class:`~pandas.api.extensions.ExtensionDtype` subclass such as :class:`ArrowDtype` or :class:`DatetimeTZDtype` raising ``TypeError``, emitting a spurious ``UserWarning``, or selecting the wrong columns; passing such a class now selects every column whose dtype is an instance of that class (:issue:`65366`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
 - Bug in ``register_option`` where registering an option whose name was a prefix of an existing option (e.g. ``"a.b"`` when ``"a.b.c"`` was already registered) silently overwrote the existing option's namespace instead of raising (:issue:`29242`)
-- Fixed ``MultiIndex`` duplicate detection tests instantiating a fresh RNG for every level, so each level received identical code arrays and the index collapsed to only ``n`` distinct label tuples (:issue:`66774`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -852,6 +852,7 @@ Other
 - Bug in :meth:`DataFrame.select_dtypes` with an :class:`~pandas.api.extensions.ExtensionDtype` subclass such as :class:`ArrowDtype` or :class:`DatetimeTZDtype` raising ``TypeError``, emitting a spurious ``UserWarning``, or selecting the wrong columns; passing such a class now selects every column whose dtype is an instance of that class (:issue:`65366`)
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
 - Bug in ``register_option`` where registering an option whose name was a prefix of an existing option (e.g. ``"a.b"`` when ``"a.b.c"`` was already registered) silently overwrote the existing option's namespace instead of raising (:issue:`29242`)
+- Fixed ``MultiIndex`` duplicate detection tests instantiating a fresh RNG for every level, so each level received identical code arrays and the index collapsed to only ``n`` distinct label tuples (:issue:`66774`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -259,7 +259,8 @@ def test_duplicated_hashtable_impl(keep, monkeypatch):
     # GH 9125
     n, k = 6, 10
     levels = [np.arange(n), [str(i) for i in range(n)], 1000 + np.arange(n)]
-    codes = [np.random.default_rng(2).choice(n, k * n) for _ in levels]
+    rng = np.random.default_rng(2)
+    codes = [rng.choice(n, k * n) for _ in levels]
     with monkeypatch.context() as m:
         m.setattr(libindex, "_SIZE_CUTOFF", 50)
         mi = MultiIndex(levels=levels, codes=codes)


### PR DESCRIPTION
- [x] closes #66774
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

## What this changes

`test_duplicated_hashtable_impl` instantiated `np.random.default_rng(2)` *inside* the comprehension, so a new generator with the same seed was created on every iteration and each level received the identical code sequence. The `MultiIndex` then collapsed to only `n` distinct label tuples, so the test exercised duplicate detection over a far narrower input than intended (it regressed in #54209, which used to draw once per level from a shared RNG).

This reuses a single generator across levels, restoring distinct codes per level (53 distinct tuples vs 6 for the same seed) while keeping the parametrized `keep` assertions intact.

## How I used AI

I used an AI coding agent (opencode, Anthropic Claude model family) to help analyze the issue, verify the RNG behavior against a source build, and draft this change. I reviewed and understood the final diff (a one-line RNG refactor) and validated it by running the full `test_duplicates.py` module against a local source build — all 51 tests pass.

Closes: #66774

