### PR TITLE
BUG: secondary_y hid the primary y-axis over collection-drawn data

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -759,6 +759,7 @@ Period
 Plotting
 ^^^^^^^^
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
+- Bug in :meth:`DataFrame.plot` and :meth:`Series.plot` with ``secondary_y`` hiding the primary y-axis when the data already on the axes was drawn as a collection rather than as lines, e.g. by :meth:`DataFrame.plot.scatter` (:issue:`66789`)
 - Bug in :meth:`Series.plot`, :meth:`DataFrame.plot`, :meth:`DataFrame.plot.scatter`, :meth:`Series.hist`, :meth:`DataFrame.hist`, :func:`plotting.lag_plot` and :func:`plotting.parallel_coordinates` with timezone-aware data labelling the axis in UTC instead of in the data's own timezone (:issue:`64613`)
 -
 

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -532,7 +532,14 @@ class MPLPlot(ABC):
     @staticmethod
     def _has_plotted_object(ax: Axes) -> bool:
         """check whether ax has data"""
-        return len(ax.lines) != 0 or len(ax.artists) != 0 or len(ax.containers) != 0
+        return (
+            len(ax.lines) != 0
+            or len(ax.artists) != 0
+            or len(ax.containers) != 0
+            # scatter and area plots draw their data into a collection rather
+            # than into lines
+            or len(ax.collections) != 0
+        )
 
     @final
     def _maybe_right_yaxis(self, ax: Axes, axes_num: int) -> Axes:

--- a/pandas/tests/plotting/test_series.py
+++ b/pandas/tests/plotting/test_series.py
@@ -493,6 +493,18 @@ class TestSeriesPlots:
         assert ax.get_yaxis().get_visible()
         assert ax.right_ax.get_yaxis().get_visible()
 
+    def test_df_scatter_series_secondary_y_axis_visible(self):
+        # GH#66789 the scatter's data is a collection, which used to read as
+        # nothing having been plotted, hiding the primary y-axis
+        df = DataFrame({"x": np.arange(10.0), "y": np.arange(10.0)})
+        s = Series(np.random.default_rng(2).standard_normal(10), name="x")
+
+        _, ax = mpl.pyplot.subplots()
+        df.plot.scatter(x="x", y="y", ax=ax)
+        s.plot(secondary_y=True, ax=ax)
+        assert ax.get_yaxis().get_visible()
+        assert ax.right_ax.get_yaxis().get_visible()
+
     def test_df_series_secondary_legend_both(self):
         # GH 9779
         df = DataFrame(


### PR DESCRIPTION
`_has_plotted_object` decides whether an axes already holds data, and it only
looked at `ax.lines`, `ax.artists` and `ax.containers`. A scatter plot draws its
data into a collection, so plotting a secondary-y series onto the same axes read
as "no data on the left" and hid the primary y-axis:

```python
fig, ax = plt.subplots()
df.plot.scatter(x="x", y="y", ax=ax)
pd.Series(range(10)).plot(secondary_y=True, ax=ax)
ax.get_yaxis().get_visible()   # False on main, True here
```

| left-axis plot | before | after |
|---|---|---|
| scatter | hidden | visible |
| area | visible | visible |
| line | visible | visible |

Area and line plots were unaffected because both also add a `Line2D`.

Found while working on GH-66769, which draws wide line plots into a collection
and so runs into the same check. Splitting it out because it reproduces on main
today and stands on its own: the whole plotting suite passes with this change and
no test updates.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which found the
bug, wrote the fix and test, and verified it in isolation against main, all
reviewed by me.
