### PR TITLE
BUG: to_json wrapped unsigned numpy scalars above int64 max (GH#66142)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -714,6 +714,7 @@ I/O
 - Bug in :meth:`DataFrame.__repr__` raising ``TypeError`` for a column with a NumPy structured dtype (e.g. produced by :meth:`DataFrame.from_records` from a structured ``ndarray``) (:issue:`55011`)
 - Bug in :meth:`DataFrame.__repr__` where horizontally truncated output could exceed the terminal width by up to 4 characters (:issue:`32461`)
 - Bug in :meth:`DataFrame.to_json` and :meth:`Series.to_json` with ``orient="table"`` silently dropping the timezone of columns with a fixed-offset timezone (e.g. ``datetime.timezone(timedelta(hours=1))``), so the offset was lost on round-trip through :func:`read_json` (:issue:`39537`)
+- Bug in :meth:`DataFrame.to_json` and :meth:`Series.to_json` writing unsigned NumPy integer scalars stored in ``object`` dtype as negative numbers when they exceeded the signed ``int64`` maximum (:issue:`66142`)
 - Bug in :meth:`DataFrame.to_stata` raising ``KeyError`` when column names require renaming and ``convert_dates`` is specified for a different column (:issue:`60536`)
 - Bug in :meth:`DataFrame.to_string` where ``formatters`` dict was applied to wrong columns when output was horizontally truncated via ``max_cols`` (:issue:`35410`)
 - Fixed :func:`read_json` with ``lines=True`` and ``nrows=0`` to return an empty DataFrame (:issue:`64025`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -1815,6 +1815,25 @@ static void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
     }
     pc->longValue = value;
     return;
+  } else if (PyArray_IsScalar(obj, UnsignedInteger)) {
+    // GH#66142 casting to int64 would silently wrap values above int64 max;
+    // hand those to JT_BIGNUM, which prints the exact digits via str().
+    npy_uint64 uintValue;
+    PyArray_CastScalarToCtype(obj, &uintValue,
+                              PyArray_DescrFromType(NPY_UINT64));
+
+    if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_OverflowError)) {
+      goto INVALID;
+    }
+
+    if (uintValue > (npy_uint64)NPY_MAX_INT64) {
+      tc->type = JT_BIGNUM;
+    } else {
+      pc->longValue = (JSINT64)uintValue;
+      tc->type = JT_LONG;
+    }
+
+    return;
   } else if (PyArray_IsScalar(obj, Integer)) {
     tc->type = JT_LONG;
     PyArray_CastScalarToCtype(obj, &(pc->longValue),

--- a/pandas/tests/io/json/test_pandas.py
+++ b/pandas/tests/io/json/test_pandas.py
@@ -2629,6 +2629,15 @@ def test_large_number_string_column():
     tm.assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("scalar_type", [np.uint64, np.ulonglong])
+@pytest.mark.parametrize("value", [2**63, 2**64 - 1])
+def test_to_json_object_dtype_unsigned_scalar(scalar_type, value):
+    # GH#66142 unsigned numpy scalars above int64 max wrapped to negative
+    obj = scalar_type(value)
+    assert Series([obj], dtype=object).to_json() == f'{{"0":{value}}}'
+    assert DataFrame({"a": [obj]}, dtype=object).to_json() == f'{{"a":{{"0":{value}}}}}'
+
+
 def test_to_json_unsupported_object_gh36211():
     # GH#36211
     df = DataFrame({"a": [Path("m1")]})

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -756,13 +756,7 @@ class TestNumpyJSONTests:
             pytest.skip("Cannot test 64-bit integer on 32-bit platform")
 
         klass = np.dtype(any_int_numpy_dtype).type
-
-        # uint64 max will always overflow,
-        # as it's encoded to signed.
-        if any_int_numpy_dtype == "uint64":
-            num = np.iinfo("int64").max
-        else:
-            num = np.iinfo(any_int_numpy_dtype).max
+        num = klass(np.iinfo(any_int_numpy_dtype).max)
 
         assert klass(ujson.ujson_loads(ujson.ujson_dumps(num))) == num
 


### PR DESCRIPTION
- [x] closes #66142
- [x] Tests added and passing
- [x] All code checks passed
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file

Unsigned NumPy scalars sitting in an `object`-dtype container were cast to `int64` by the ujson encoder, so anything above the signed maximum wrapped to a negative number:

```python
pd.Series([np.uint64(2**63)], dtype=object).to_json()
# before: '{"0":-9223372036854775808}'
# after:  '{"0":9223372036854775808}'
```

Only NumPy scalars parked in object arrays were affected. A real `uint64` array was always fine, because `PyArray_GETITEM` hands back a Python `int`, which already took the `JT_BIGNUM` overflow path — as did a plain Python `int` in object dtype.

The fix gives unsigned scalars their own branch in `Object_beginTypeContext`: cast to `NPY_UINT64`, and route values above `INT64_MAX` to `JT_BIGNUM`, which writes the exact decimal digits. Values that fit keep the existing `JT_LONG` fast path, so `uint8`/`uint16`/`uint32` are byte-for-byte unchanged.

### Why `UnsignedInteger` and not `NPY_UINT64`

`NPY_UINT64` is a compile-time alias for only one of NumPy's two 64-bit unsigned types. Wherever it resolves to `NPY_ULONG` (Linux, macOS), `np.ulonglong` is a distinct sibling type that reproduces the same wraparound:

```python
np.uint64 num=8 (NPY_ULONG)    np.ulonglong num=10 (NPY_ULONGLONG)
issubclass(np.ulonglong, np.uint64)            # False
issubclass(np.ulonglong, np.unsignedinteger)   # True
```

Gating on `UnsignedInteger` covers every width and both 64-bit spellings in one branch, so both are tested here. `np.bool_` is under neither `unsignedinteger` nor `integer`, so ordering the new branch ahead of the `Bool` check is safe.

### Note on `test_int_max`

The `uint64` workaround in `test_int_max` is no longer needed, but simply deleting it does not make the test exercise this fix: `np.iinfo(dtype).max` returns a *Python* `int`, so the test never reached the NumPy-scalar path at all. It is wrapped in `klass(...)` here so it actually guards the encoder branch.

### Supersedes

This pre-empts two open PRs for the same issue, GH-66148 and GH-66149 — thanks to both authors, whose work this builds on. Both gate on the `uint64` spelling alone (`PyArray_IsScalar(obj, UInt64)` and `descr->type_num == NPY_UINT64` respectively), so `np.ulonglong` still wraps under either. The `klass(...)` wrap in `test_int_max` above is taken from GH-66149.

GH-66149 also adds `Py_DECREF` on the descriptors from `PyArray_DescrFromType`. That is deliberately not included: it is unobservable on current NumPy (builtin dtype singletons are immortal — measured zero refcount movement over 10k encodes), and it would clean up only 2 of the 5 such call sites in this function, leaving the datetime/bool/float paths inconsistent. Worth a separate sweep of all five if wanted.

closes #66148
closes #66149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
