### PR TITLE
BUG: remaining ujson_dumps segfaults from unchecked C-API returns (GH#66356)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -708,6 +708,9 @@ I/O
 - Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
 - Fixed several segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing python objects that are very abnormal, including massive :class:`int` values, and strings that cannot be encoded as utf-8 (:issue:`66356`)
+- Fixed segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing dictionary keys or labels that cannot be encoded as UTF-8 or that are integers too large to stringify under ``sys.get_int_max_str_digits()``, and when serializing objects with a raising ``__dir__`` or ``set`` subclasses with a raising ``__iter__``; these now raise instead (:issue:`66356`, :issue:`66489`)
+- Fixed :meth:`DataFrame.to_json` and :meth:`Series.to_json` silently returning invalid or incorrect JSON when the error raised while serializing one element of a ``list``, ``tuple``, ``set``, or ``dict`` was discarded while serializing a later element (:issue:`66356`)
+- Fixed memory leaks in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serialization failed, particularly for large outputs and for index or column labels that could not be encoded (:issue:`66356`)
 - Fixed :func:`read_json` with ``lines=True`` and ``chunksize`` to respect ``nrows``
   when the requested row count is not a multiple of the chunk size (:issue:`64025`)
 - :meth:`HDFStore.put` and :meth:`HDFStore.append` now support storing :class:`Series` and :class:`DataFrame` columns with :class:`PeriodDtype` in both ``"fixed"`` and ``"table"`` formats (:issue:`41978`)

--- a/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
+++ b/pandas/_libs/src/vendored/ujson/lib/ultrajsonenc.c
@@ -378,11 +378,14 @@ void Buffer_Realloc(JSONObjectEncoder *enc, size_t cbNeeded) {
   }
 
   if (enc->heap) {
-    enc->start = (char *)enc->realloc(enc->start, newSize);
-    if (!enc->start) {
+    // realloc does not free the original block when it fails, so keep the old
+    // pointer until it succeeds
+    char *newStart = (char *)enc->realloc(enc->start, newSize);
+    if (!newStart) {
       SetError(NULL, enc, "Could not reserve memory block");
       return;
     }
+    enc->start = newStart;
   } else {
     char *oldStart = enc->start;
     enc->heap = 1;
@@ -1196,6 +1199,12 @@ char *JSON_EncodeObject(JSOBJ obj, JSONObjectEncoder *enc, char *_buffer,
 
   Buffer_Reserve(enc, 1);
   if (enc->errorMsg) {
+    if (enc->heap) {
+      // the caller only frees the buffer it passed in, so a buffer we grew
+      // onto the heap has to be released here
+      enc->free(enc->start);
+      enc->start = NULL;
+    }
     return NULL;
   }
   Buffer_AppendCharUnchecked(enc, '\0');

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -162,6 +162,7 @@ typedef struct __PyObjectEncoder {
 enum PANDAS_FORMAT { SPLIT, RECORDS, INDEX, COLUMNS, VALUES };
 
 static int PdBlock_iterNext(JSOBJ, JSONTypeContext *);
+static void Object_endTypeContext(JSOBJ, JSONTypeContext *);
 
 static TypeContext *createTypeContext(void) {
   TypeContext *pc = PyObject_Malloc(sizeof(TypeContext));
@@ -542,6 +543,13 @@ static const char *PyDecimalToUTF8Callback(JSOBJ _obj, JSONTypeContext *tc,
                                            size_t *len) {
   PyObject *obj = (PyObject *)_obj;
   PyObject *format_spec = PyUnicode_FromStringAndSize("f", 1);
+  if (format_spec == NULL) {
+    // PyObject_Format would treat NULL as an empty spec and silently format
+    // the decimal a different way, on top of masking the pending exception
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    *len = 0;
+    return NULL;
+  }
   PyObject *str = PyObject_Format(obj, format_spec);
   Py_DECREF(format_spec);
 
@@ -971,6 +979,11 @@ static void Tuple_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
 }
 
 static int Tuple_iterNext(JSOBJ obj, JSONTypeContext *tc) {
+  if (PyErr_Occurred()) {
+    // stop rather than encode the next item with an exception pending, which
+    // would mask it
+    return 0;
+  }
 
   if (GET_TC(tc)->index >= GET_TC(tc)->size) {
     return 0;
@@ -1009,6 +1022,17 @@ static int Set_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (GET_TC(tc)->itemValue) {
     Py_DECREF(GET_TC(tc)->itemValue);
     GET_TC(tc)->itemValue = NULL;
+  }
+
+  if (!GET_TC(tc)->iterator) {
+    // __iter__ raised in Set_iterBegin
+    return 0;
+  }
+
+  if (PyErr_Occurred()) {
+    // stop rather than encode the next item with an exception pending, which
+    // would mask it
+    return 0;
   }
 
   PyObject *item = PyIter_Next(GET_TC(tc)->iterator);
@@ -1051,7 +1075,10 @@ static const char *Set_iterGetName(JSOBJ Py_UNUSED(obj),
 static void Dir_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
   GET_TC(tc)->attrList = PyObject_Dir(obj);
   GET_TC(tc)->index = 0;
-  GET_TC(tc)->size = PyList_GET_SIZE(GET_TC(tc)->attrList);
+  // A raising __dir__ leaves attrList NULL; Dir_iterNext bails on the
+  // pending exception before it reaches the list.
+  GET_TC(tc)->size =
+      GET_TC(tc)->attrList ? PyList_GET_SIZE(GET_TC(tc)->attrList) : 0;
 }
 
 static void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
@@ -1065,7 +1092,7 @@ static void Dir_iterEnd(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
     GET_TC(tc)->itemName = NULL;
   }
 
-  Py_DECREF((PyObject *)GET_TC(tc)->attrList);
+  Py_XDECREF((PyObject *)GET_TC(tc)->attrList);
 }
 
 static int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
@@ -1090,7 +1117,16 @@ static int Dir_iterNext(JSOBJ _obj, JSONTypeContext *tc) {
   for (; GET_TC(tc)->index < GET_TC(tc)->size; GET_TC(tc)->index++) {
     PyObject *attrName =
         PyList_GET_ITEM(GET_TC(tc)->attrList, GET_TC(tc)->index);
+    if (!PyUnicode_Check(attrName)) {
+      PyErr_Format(PyExc_TypeError, "__dir__() must return str entries, not %s",
+                   Py_TYPE(attrName)->tp_name);
+      return 0;
+    }
     PyObject *attr = PyUnicode_AsUTF8String(attrName);
+    if (attr == NULL) {
+      // e.g. __dir__ returned a name holding a lone surrogate
+      return 0;
+    }
     const char *attrStr = PyBytes_AS_STRING(attr);
 
     if (attrStr[0] == '_') {
@@ -1151,6 +1187,12 @@ static void List_iterBegin(JSOBJ obj, JSONTypeContext *tc) {
 }
 
 static int List_iterNext(JSOBJ obj, JSONTypeContext *tc) {
+  if (PyErr_Occurred()) {
+    // stop rather than encode the next item with an exception pending, which
+    // would mask it
+    return 0;
+  }
+
   if (GET_TC(tc)->index >= GET_TC(tc)->size) {
     return 0;
   }
@@ -1360,6 +1402,12 @@ static void Dict_iterBegin(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
 }
 
 static int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
+  if (PyErr_Occurred()) {
+    // stop rather than encode the next item with an exception pending, which
+    // would mask it
+    return 0;
+  }
+
   if (GET_TC(tc)->itemName) {
     Py_DECREF(GET_TC(tc)->itemName);
     GET_TC(tc)->itemName = NULL;
@@ -1373,12 +1421,21 @@ static int Dict_iterNext(JSOBJ Py_UNUSED(obj), JSONTypeContext *tc) {
   if (PyUnicode_Check(GET_TC(tc)->itemName)) {
     GET_TC(tc)->itemName = PyUnicode_AsUTF8String(GET_TC(tc)->itemName);
   } else if (!PyBytes_Check(GET_TC(tc)->itemName)) {
-    GET_TC(tc)->itemName = PyObject_Str(GET_TC(tc)->itemName);
-    PyObject *itemNameTmp = GET_TC(tc)->itemName;
-    GET_TC(tc)->itemName = PyUnicode_AsUTF8String(GET_TC(tc)->itemName);
+    PyObject *itemNameTmp = PyObject_Str(GET_TC(tc)->itemName);
+    if (itemNameTmp == NULL) {
+      // e.g. a key whose str() exceeds sys.get_int_max_str_digits()
+      GET_TC(tc)->itemName = NULL;
+      return 0;
+    }
+    GET_TC(tc)->itemName = PyUnicode_AsUTF8String(itemNameTmp);
     Py_DECREF(itemNameTmp);
   } else {
     Py_INCREF(GET_TC(tc)->itemName);
+  }
+
+  if (GET_TC(tc)->itemName == NULL) {
+    // the key, or its str(), could not be encoded as utf-8
+    return 0;
   }
   return 1;
 }
@@ -1518,6 +1575,13 @@ static char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
       if (i8date == get_nat()) {
         len = 4;
         cLabel = PyObject_Malloc(len + 1);
+        if (cLabel == NULL) {
+          PyErr_NoMemory();
+          Py_DECREF(item);
+          NpyArr_freeLabels(ret, num);
+          ret = 0;
+          break;
+        }
         strncpy(cLabel, "null", len + 1);
       } else {
         if (enc->datetimeIso) {
@@ -1539,6 +1603,13 @@ static char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
         } else {
           int size_of_cLabel = 21; // 21 chars for int 64
           cLabel = PyObject_Malloc(size_of_cLabel);
+          if (cLabel == NULL) {
+            PyErr_NoMemory();
+            Py_DECREF(item);
+            NpyArr_freeLabels(ret, num);
+            ret = 0;
+            break;
+          }
           // numpy values are scaled from the array's own unit; datetime and
           // timedelta objects were converted to nanos above and keep the
           // conversion they have always used
@@ -1566,26 +1637,33 @@ static char **NpyArr_encodeLabels(PyArrayObject *labels, PyObjectEncoder *enc,
       }
 
       cLabel = (char *)PyUnicode_AsUTF8(item);
+      if (cLabel == NULL) {
+        // e.g. a label whose str() holds a lone surrogate
+        Py_DECREF(item);
+        NpyArr_freeLabels(ret, num);
+        ret = 0;
+        break;
+      }
       len = strlen(cLabel);
     }
 
     // Add 1 to include NULL terminator
     ret[i] = PyObject_Malloc(len + 1);
-    memcpy(ret[i], cLabel, len + 1);
+    if (ret[i]) {
+      memcpy(ret[i], cLabel, len + 1);
+    }
     Py_DECREF(item);
 
     if (is_datetimelike) {
       PyObject_Free(cLabel);
     }
 
-    if (PyErr_Occurred()) {
-      NpyArr_freeLabels(ret, num);
-      ret = 0;
-      break;
-    }
-
     if (!ret[i]) {
       PyErr_NoMemory();
+    }
+
+    if (PyErr_Occurred()) {
+      NpyArr_freeLabels(ret, num);
       ret = 0;
       break;
     }
@@ -2135,8 +2213,9 @@ ISITERABLE:
 
 INVALID:
   tc->type = JT_INVALID;
-  PyObject_Free(tc->prv);
-  tc->prv = NULL;
+  // JT_INVALID makes the encoder return without calling endTypeContext, so
+  // anything already stored on the context has to be released here
+  Object_endTypeContext(_obj, tc);
   return;
 }
 
@@ -2184,6 +2263,13 @@ static const char *Object_getBigNumStringValue(JSOBJ obj, JSONTypeContext *tc,
     return NULL;
   }
   char *bytes = PyObject_Malloc(*_outLen + 1);
+  if (bytes == NULL) {
+    Py_DECREF(repr);
+    PyErr_NoMemory();
+    ((JSONObjectEncoder *)tc->encoder)->errorMsg = "";
+    *_outLen = 0;
+    return NULL;
+  }
   memcpy(bytes, str, *_outLen + 1);
   GET_TC(tc)->cStr = bytes;
 
@@ -2360,6 +2446,9 @@ PyObject *objToJSON(PyObject *Py_UNUSED(self), PyObject *args,
   char buffer[65536];
   char *ret = JSON_EncodeObject(oinput, encoder, buffer, sizeof(buffer));
   if (PyErr_Occurred()) {
+    if (ret != buffer) {
+      encoder->free(ret);
+    }
     return NULL;
   }
 

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -1,12 +1,15 @@
 import calendar
 import datetime
 import decimal
+import gc
 import json
 import locale
 import math
 import re
 import sys
 import time
+import tracemalloc
+import weakref
 
 import dateutil
 import numpy as np
@@ -1106,3 +1109,195 @@ class TestPandasJSONTests:
         p = PeriodIndex(["2022-04-06", "2022-04-07"], freq="D")
         df = DataFrame(index=p)
         assert df.to_json() == "{}"
+
+
+LONE_SURROGATE = "\ud800"
+
+
+class _LoneSurrogateStr:
+    def __str__(self) -> str:
+        return LONE_SURROGATE
+
+    def __hash__(self) -> int:
+        return 1
+
+
+def test_encode_dict_key_lone_surrogate():
+    # GH#66356
+    with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+        ujson.ujson_dumps({LONE_SURROGATE: "value"})
+
+
+def test_encode_dict_key_str_lone_surrogate():
+    # GH#66356
+    with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+        ujson.ujson_dumps({_LoneSurrogateStr(): "value"})
+
+
+def test_encode_dict_key_large_int():
+    # GH#66356
+    # the key has more digits than sys.get_int_max_str_digits() allows, so
+    # str() on it raises. Set the limit explicitly so the test does not depend
+    # on the interpreter default (PYTHONINTMAXSTRDIGITS can disable it).
+    cur_limit = sys.get_int_max_str_digits()
+    sys.set_int_max_str_digits(1000)
+    try:
+        with pytest.raises(ValueError, match="Exceeds the limit"):
+            ujson.ujson_dumps({1 << 1_000_000: "value"})
+    finally:
+        sys.set_int_max_str_digits(cur_limit)
+
+
+def test_encode_object_dir_raises():
+    # GH#66356
+    class _TestObj:
+        def __dir__(self):
+            raise TypeError("I raise you one exception")
+
+    with pytest.raises(TypeError, match="I raise you one exception"):
+        ujson.ujson_dumps(_TestObj())
+
+
+def test_encode_object_dir_lone_surrogate():
+    # GH#66356
+    class _TestObj:
+        def __dir__(self):
+            return [LONE_SURROGATE]
+
+    with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+        ujson.ujson_dumps(_TestObj())
+
+
+def test_encode_object_dir_non_str():
+    # GH#66356
+    class _TestObj:
+        def __dir__(self):
+            return [42]
+
+    with pytest.raises(TypeError, match="must return str entries, not int"):
+        ujson.ujson_dumps(_TestObj())
+
+
+def test_encode_set_iter_raises():
+    # GH#66356
+    class _TestSet(set):
+        def __iter__(self):
+            raise TypeError("I raise you one exception")
+
+    with pytest.raises(TypeError, match="I raise you one exception"):
+        ujson.ujson_dumps(_TestSet([1, 2, 3]))
+
+
+def test_encode_labels_lone_surrogate():
+    # GH#66356
+    df = DataFrame({_LoneSurrogateStr(): [1, 2, 3]})
+    with pytest.raises(UnicodeEncodeError, match="surrogates not allowed"):
+        ujson.ujson_dumps(df)
+
+
+def test_encode_set_iter_raises_midway():
+    # GH#66489
+    class _TestSet(set):
+        def __iter__(self):
+            yield 1
+            raise TypeError("I raise you one exception")
+
+    with pytest.raises(TypeError, match="I raise you one exception"):
+        ujson.ujson_dumps([_TestSet([1, 2]), _TestSet([1, 2])])
+
+
+class _Plain:
+    attr = 1
+
+
+class _OrderedSet(set):
+    # a plain one-element set would be exhausted before the guard in
+    # Set_iterNext is reached, so drive the iteration order explicitly
+    def __iter__(self):
+        return iter([np.complex128(1 + 2j), _Plain()])
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        [np.complex128(1 + 2j), _Plain()],
+        (np.complex128(1 + 2j), _Plain()),
+        {"first": np.complex128(1 + 2j), "second": _Plain()},
+        _OrderedSet([1, 2]),
+    ],
+)
+def test_encode_error_not_masked_by_sibling(container):
+    # GH#66356
+    # the plain object encoded after the unserializable one clears the pending
+    # exception while looking for a to_dict/__json__ attribute, so iteration
+    # has to stop instead; otherwise ujson_dumps returned invalid JSON such as
+    # '[,{"attr":1}]' without raising
+    with pytest.raises(TypeError, match="is not JSON serializable"):
+        ujson.ujson_dumps(container)
+
+
+def test_to_json_error_not_masked_by_sibling():
+    # GH#66356
+    ser = Series([[np.complex128(1 + 2j), _Plain()]])
+    with pytest.raises(TypeError, match="is not JSON serializable"):
+        ser.to_json()
+
+
+def _deeply_nested():
+    outer = current = []
+    for _ in range(2000):
+        nested = []
+        current.append(nested)
+        current = nested
+    return outer
+
+
+@pytest.mark.parametrize(
+    "bad, error",
+    [
+        # raises a Python exception
+        (np.complex128(1j), TypeError),
+        # sets the encoder's own errorMsg instead
+        (_deeply_nested(), OverflowError),
+    ],
+)
+def test_encode_failure_frees_grown_buffer(bad, error):
+    # GH#66356
+    # the two failure modes leave the encoder by different exits, and both
+    # leaked the output buffer once it had outgrown the one the encoder starts
+    # with. The buffer is allocated with PyObject_Malloc, so tracemalloc sees
+    # it; a leak here would be ~50 * 256 KiB.
+    payload = ["x" * 1000] * 200 + [bad]
+    tracemalloc.start()
+    before = tracemalloc.take_snapshot()
+    for _ in range(50):
+        with pytest.raises(error):
+            ujson.ujson_dumps(payload)
+    after = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+
+    grew = sum(stat.size_diff for stat in after.compare_to(before, "filename"))
+    assert grew < 100_000
+
+
+def test_to_json_bad_label_frees_values():
+    # GH#66356
+    # the labels failed to encode, so Object_beginTypeContext bails out via
+    # JT_INVALID; that exit used to drop the reference it had taken on the
+    # values array
+    index = Index([_LoneSurrogateStr()], dtype=object)
+    ser = Series(np.arange(1), index=index)
+    values = ser._mgr.blocks[0].values
+    # the encoder reaches the values through _values_for_json; if that ever
+    # starts handing back a fresh object the check below would pass vacuously
+    assert ser.array._values_for_json() is values
+
+    ref = weakref.ref(values)
+    for _ in range(5):
+        with pytest.raises(UnicodeEncodeError):
+            ser.to_json()
+
+    del ser, values
+    gc.collect()
+    # a reference held by the failed encodes would keep this alive
+    assert ref() is None


### PR DESCRIPTION
closes #66356

Follow-up to GH-66357, which fixed four of the crashes listed in the issue. This covers the rest, all in `objToJSON.c`, by checking the CPython return values that were being used unconditionally:

- dict keys that are lone surrogates, integers too large to stringify under `sys.get_int_max_str_digits()`, or objects whose `__str__` is not encodable
- objects with a raising, non-str-returning, or surrogate-returning `__dir__`
- `set` subclasses whose `__iter__` raises, either immediately or part-way through iteration (the mid-iteration case comes from GH-66489, closed as a duplicate)
- index/column labels whose `str()` is not UTF-8 encodable
- the remaining unchecked `PyObject_Malloc`s

Returning from an iterator was not sufficient on its own. The encoder carried on to the next sibling element, and the first one falling through to the `Dir` fallback cleared the pending exception, so `ujson_dumps([np.complex128(1 + 2j), SomeObject()])` returned the invalid JSON `[,{"attr":1}]` without raising. That reproduces on main today, independently of this issue. The remaining container iterators now carry the same `PyErr_Occurred()` guard that `Dir`/`PdBlock`/`Index`/`Series`/`DataFrame_iterNext` already had.

Two memory leaks on the failure paths are fixed as well: the output buffer was leaked once it had grown off the initial stack buffer, and the values array was leaked at the `JT_INVALID` exit, which the encoder reaches without calling `endTypeContext`. The first was predicted in review on GH-66357 as a consequence of converting those crashes into raises.

Verified with ASAN/UBSAN (clean, and mutation-checked so the sanitizer demonstrably reaches the new frees), a `--werror` build, and by reverting each C hunk in turn to confirm a test catches it.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the C changes and tests under my direction and ran the sanitizer, ablation, and leak-sweep verification.