### PR TITLE
BUG: Fix silent wrong results in groupby with sort=True Grouper in list

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -854,6 +854,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
 - Bug in :meth:`.Rolling.sum`, :meth:`.Rolling.mean`, :meth:`.Rolling.median`, :meth:`.Rolling.min`, and :meth:`.Rolling.max` with ``method="table"``, ``engine="numba"``, and ``engine_kwargs={"parallel": True}`` could cause a segfault (:issue:`40454`)
 - Bug in :meth:`.SeriesGroupBy.ohlc` ignoring ``as_index=False`` (:issue:`65140`)
+- Bug in :meth:`DataFrame.groupby` and :meth:`Series.groupby` where :class:`Grouper` defaulted to ``sort=False`` and could return incorrect results when ``sort=True`` was specified (:issue:`61943`)
 - Bug in :meth:`DataFrame.groupby` with a :class:`Grouper` with ``freq`` raising ``AttributeError`` when all grouping keys are ``NaT`` (:issue:`43486`)
 - Bug in :meth:`DataFrame.resample` and :meth:`Series.resample` with a timezone-naive index where using a ``Day`` frequency (e.g. ``"7D"``) produced different bin edges than the equivalent ``Hour`` frequency (e.g. ``"168h"``), and where ``origin`` and ``offset`` were ignored (:issue:`44996`, :issue:`62200`)
 - Bug in :meth:`DataFrame.resample` dropping the result index name when resampling ``on`` a column with a pyarrow-backed datetime or duration dtype (:issue:`59823`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -854,7 +854,7 @@ Groupby/resample/rolling
 - Bug in :meth:`.Rolling.skew` and :meth:`.Rolling.kurt` returning ``NaN`` for low-variance windows (:issue:`62946`)
 - Bug in :meth:`.Rolling.sum`, :meth:`.Rolling.mean`, :meth:`.Rolling.median`, :meth:`.Rolling.min`, and :meth:`.Rolling.max` with ``method="table"``, ``engine="numba"``, and ``engine_kwargs={"parallel": True}`` could cause a segfault (:issue:`40454`)
 - Bug in :meth:`.SeriesGroupBy.ohlc` ignoring ``as_index=False`` (:issue:`65140`)
-- Bug in :meth:`DataFrame.groupby` and :meth:`Series.groupby` where :class:`Grouper` defaulted to ``sort=False`` and could return incorrect results when ``sort=True`` was specified (:issue:`61943`)
+- Bug in :meth:`DataFrame.groupby` and :meth:`Series.groupby` where :class:`Grouper` did not inherit the groupby sort setting when its own ``sort`` was unspecified and could return incorrect results when ``sort=True`` was specified (:issue:`61943`)
 - Bug in :meth:`DataFrame.groupby` with a :class:`Grouper` with ``freq`` raising ``AttributeError`` when all grouping keys are ``NaT`` (:issue:`43486`)
 - Bug in :meth:`DataFrame.resample` and :meth:`Series.resample` with a timezone-naive index where using a ``Day`` frequency (e.g. ``"7D"``) produced different bin edges than the equivalent ``Hour`` frequency (e.g. ``"168h"``), and where ``origin`` and ``offset`` were ignored (:issue:`44996`, :issue:`62200`)
 - Bug in :meth:`DataFrame.resample` dropping the result index name when resampling ``on`` a column with a pyarrow-backed datetime or duration dtype (:issue:`59823`)

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -101,7 +101,7 @@ class Grouper:
         This will groupby the specified frequency if the target selection
         (via key or level) is a datetime-like object. For full specification
         of available frequencies, please see :ref:`here<timeseries.offset_aliases>`.
-    sort : bool, default False
+    sort : bool, default True
         Whether to sort the resulting labels.
     closed : {'left' or 'right'}
         Closed end of interval. Only when `freq` parameter is passed.
@@ -279,7 +279,7 @@ class Grouper:
         key=None,
         level=None,
         freq=None,
-        sort: bool = False,
+        sort: bool = True,
         dropna: bool = True,
     ) -> None:
         self.key = key
@@ -294,7 +294,11 @@ class Grouper:
         self._indexer: npt.NDArray[np.intp] | None = None
 
     def _get_grouper(
-        self, obj: NDFrameT, validate: bool = True, observed: bool = True
+        self,
+        obj: NDFrameT,
+        validate: bool = True,
+        observed: bool = True,
+        sort: bool | None = None,
     ) -> tuple[ops.BaseGrouper, NDFrameT]:
         """
         Parameters
@@ -306,17 +310,22 @@ class Grouper:
         observed : bool, default True
             Whether only observed groups should be in the result. Only
             has an impact when grouping on categorical data.
+        sort : bool or None, default None
+            Whether to sort the resulting groups. If None, use ``self.sort``.
 
         Returns
         -------
         A tuple of grouper, obj (possibly sorted)
         """
-        obj, _, _ = self._set_grouper(obj)
+        if sort is None:
+            sort = self.sort
+
+        obj, _, _ = self._set_grouper(obj, sort=sort)
         grouper, _, obj = get_grouper(
             obj,
             [self.key],
             level=self.level,
-            sort=self.sort,
+            sort=sort,
             validate=validate,
             dropna=self.dropna,
             observed=observed,
@@ -391,8 +400,17 @@ class Grouper:
                     raise ValueError(f"The level {level} is not valid")
 
         # possibly sort
+        # Only binning groupers (those with a freq, i.e. TimeGrouper) need the
+        # object itself reordered, since binning requires a monotonic axis.
+        # For a plain Grouper the group order is already handled by passing
+        # sort through to Grouping, and reordering here desynchronises the
+        # codes from the object when this result is discarded (GH#61943).
         indexer: npt.NDArray[np.intp] | None = None
-        if (self.sort or sort) and not ax.is_monotonic_increasing:
+        if (
+            self.freq is not None
+            and (self.sort or sort)
+            and not ax.is_monotonic_increasing
+        ):
             # use stable sort to support first, last, nth
             # TODO: why does putting na_position="first" fix datetimelike cases?
             indexer = self._indexer_deprecated = ax.array.argsort(
@@ -821,7 +839,12 @@ def get_grouper(
 
     # a passed-in Grouper, directly convert
     if isinstance(key, Grouper):
-        grouper, obj = key._get_grouper(obj, validate=False, observed=observed)
+        if key.freq is None:
+            grouper, obj = key._get_grouper(
+                obj, validate=False, observed=observed, sort=sort
+            )
+        else:
+            grouper, obj = key._get_grouper(obj, validate=False, observed=observed)
         if key.key is None:
             return grouper, frozenset(), obj
         else:

--- a/pandas/core/groupby/grouper.py
+++ b/pandas/core/groupby/grouper.py
@@ -101,8 +101,9 @@ class Grouper:
         This will groupby the specified frequency if the target selection
         (via key or level) is a datetime-like object. For full specification
         of available frequencies, please see :ref:`here<timeseries.offset_aliases>`.
-    sort : bool, default True
-        Whether to sort the resulting labels.
+    sort : bool or None, default None
+        Whether to sort the resulting labels. If None, inherit the sort
+        setting from :meth:`DataFrame.groupby` or :meth:`Series.groupby`.
     closed : {'left' or 'right'}
         Closed end of interval. Only when `freq` parameter is passed.
     label : {'left' or 'right'}
@@ -279,13 +280,14 @@ class Grouper:
         key=None,
         level=None,
         freq=None,
-        sort: bool = True,
+        sort: bool | None = None,
         dropna: bool = True,
     ) -> None:
         self.key = key
         self.level = level
         self.freq = freq
-        self.sort = sort
+        self._sort = sort
+        self.sort = True if sort is None else sort
         self.dropna = dropna
 
         self._indexer_deprecated: npt.NDArray[np.intp] | None = None
@@ -311,13 +313,14 @@ class Grouper:
             Whether only observed groups should be in the result. Only
             has an impact when grouping on categorical data.
         sort : bool or None, default None
-            Whether to sort the resulting groups. If None, use ``self.sort``.
+            Whether to sort the resulting groups when this Grouper does not
+            specify sort. If None, use ``self.sort``.
 
         Returns
         -------
         A tuple of grouper, obj (possibly sorted)
         """
-        if sort is None:
+        if self._sort is not None or sort is None:
             sort = self.sort
 
         obj, _, _ = self._set_grouper(obj, sort=sort)
@@ -400,17 +403,15 @@ class Grouper:
                     raise ValueError(f"The level {level} is not valid")
 
         # possibly sort
-        # Only binning groupers (those with a freq, i.e. TimeGrouper) need the
-        # object itself reordered, since binning requires a monotonic axis.
+        # Only TimeGrouper needs the object itself reordered, since binning
+        # requires a monotonic axis.
         # For a plain Grouper the group order is already handled by passing
         # sort through to Grouping, and reordering here desynchronises the
         # codes from the object when this result is discarded (GH#61943).
         indexer: npt.NDArray[np.intp] | None = None
-        if (
-            self.freq is not None
-            and (self.sort or sort)
-            and not ax.is_monotonic_increasing
-        ):
+        from pandas.core.resample import TimeGrouper
+
+        if isinstance(self, TimeGrouper) and not ax.is_monotonic_increasing:
             # use stable sort to support first, last, nth
             # TODO: why does putting na_position="first" fix datetimelike cases?
             indexer = self._indexer_deprecated = ax.array.argsort(
@@ -524,7 +525,11 @@ class Grouping:
             # check again as we have by this point converted these
             # to an actual value (rather than a pd.Grouper)
             assert self.obj is not None  # for mypy
-            newgrouper, newobj = grouping_vector._get_grouper(self.obj, validate=False)
+            if grouping_vector._sort is not None:
+                self._sort = grouping_vector.sort
+            newgrouper, newobj = grouping_vector._get_grouper(
+                self.obj, validate=False, sort=self._sort
+            )
             self.obj = newobj
 
             if isinstance(newgrouper, ops.BinGrouper):
@@ -839,12 +844,9 @@ def get_grouper(
 
     # a passed-in Grouper, directly convert
     if isinstance(key, Grouper):
-        if key.freq is None:
-            grouper, obj = key._get_grouper(
-                obj, validate=False, observed=observed, sort=sort
-            )
-        else:
-            grouper, obj = key._get_grouper(obj, validate=False, observed=observed)
+        grouper, obj = key._get_grouper(
+            obj, validate=False, observed=observed, sort=sort
+        )
         if key.key is None:
             return grouper, frozenset(), obj
         else:

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -2615,7 +2615,11 @@ class TimeGrouper(Grouper):
         )
 
     def _get_grouper(
-        self, obj: NDFrameT, validate: bool = True, observed: bool = True
+        self,
+        obj: NDFrameT,
+        validate: bool = True,
+        observed: bool = True,
+        sort: bool | None = None,
     ) -> tuple[BinGrouper, NDFrameT]:
         """
         Parameters
@@ -2625,6 +2629,8 @@ class TimeGrouper(Grouper):
         validate : bool, default True
             Unused. Only for compatibility with ``Grouper._get_grouper``.
         observed : bool, default True
+            Unused. Only for compatibility with ``Grouper._get_grouper``.
+        sort : bool or None, default None
             Unused. Only for compatibility with ``Grouper._get_grouper``.
 
         Returns

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -20,7 +20,7 @@ import pandas.core.common as com
 def test_repr():
     # GH18203
     result = repr(pd.Grouper(key="A", level="B"))
-    expected = "Grouper(key='A', level='B', sort=False, dropna=True)"
+    expected = "Grouper(key='A', level='B', sort=True, dropna=True)"
     assert result == expected
 
 

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -1301,3 +1301,44 @@ def test_groupby_monotonic_datetimelike_no_freq(klass, values, ascending, sort):
     else:
         expected = pd.DataFrame({"a": [1, 2, 12]}, index=klass(values[1:])[::-1])
     tm.assert_frame_equal(result, expected)
+
+
+def test_grouper_default_sort():
+    # GH#61943
+    ser = pd.Series([5, 7], index=["b", "a"])
+
+    result = list(ser.groupby(pd.Grouper(level=0)).groups)
+    expected = list(ser.groupby(level=0).groups)
+
+    assert result == expected
+
+
+def test_grouper_respects_groupby_sort_false():
+    # GH#61943
+    df = pd.DataFrame({"k": [3, 1, 2], "A": [1, 2, 3]})
+    expected = df.groupby("k", sort=False).sum()
+
+    for key in [pd.Grouper(key="k"), [pd.Grouper(key="k")]]:
+        result = df.groupby(key, sort=False).sum()
+
+        tm.assert_frame_equal(result, expected)
+
+
+def test_grouper_sort_true_in_list():
+    # GH#61943
+    df = pd.DataFrame({"k": [1, 2, 3, 1, 2, 3], "A": np.arange(6)})
+
+    result = df.groupby([pd.Grouper(key="k", sort=True)]).mean()
+    expected = df.groupby("k").mean()
+
+    tm.assert_frame_equal(result, expected)
+
+
+def test_grouper_sort_true_transform():
+    # GH#61943
+    df = pd.DataFrame({"k": [1, 2, 3, 1, 2, 3], "A": np.arange(6)})
+
+    result = df.groupby(pd.Grouper(key="k", sort=True)).cumsum()
+    expected = df.groupby("k").cumsum()
+
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -1342,3 +1342,39 @@ def test_grouper_sort_true_transform():
     expected = df.groupby("k").cumsum()
 
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("grouper_sort", [None, True, False])
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("as_list", [True, False])
+@pytest.mark.parametrize("level", [True, False])
+def test_grouper_sort_precedence(grouper_sort, sort, as_list, level):
+    # GH#61943
+    df = pd.DataFrame({"k": [3, 1, 2, 3], "A": [1, 2, 3, 4]})
+    kwargs = {"sort": grouper_sort}
+    if level:
+        df = df.set_index("k")
+        kwargs["level"] = 0
+        expected = df.groupby(
+            level=0, sort=sort if grouper_sort is None else grouper_sort
+        )
+    else:
+        kwargs["key"] = "k"
+        expected = df.groupby("k", sort=sort if grouper_sort is None else grouper_sort)
+    grouper = pd.Grouper(**kwargs)
+    result = df.groupby([grouper] if as_list else grouper, sort=sort)
+
+    tm.assert_frame_equal(result.sum(), expected.sum())
+    tm.assert_frame_equal(result.cumsum(), expected.cumsum())
+
+
+@pytest.mark.parametrize("as_list", [True, False])
+def test_grouper_positional_freq(as_list):
+    # GH#61943
+    df = pd.DataFrame({"k": [3, 1, 2], "A": [1, 2, 3]})
+    grouper = pd.Grouper("k", None, "D")
+
+    result = df.groupby([grouper] if as_list else grouper).sum()
+    expected = df.groupby("k").sum()
+
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
- [x] closes #61943
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

### Description
When passing a `Grouper` with `sort=True` inside a list (e.g. `df.groupby([pd.Grouper(key="k", sort=True)])`), `Grouper._set_grouper` physically reordered the underlying object for non-monotonic axes, but `get_grouper`'s list path discarded the reordered object. As a result, grouping codes calculated from the sorted axis were applied to the original unsorted data, silently returning incorrect aggregation values.

This PR gates the physical axis/object reordering in `Grouper._set_grouper` to binning groupers (`self.freq is not None`, i.e., `TimeGrouper`), since plain groupers already handle group ordering via `Grouping(..., sort=sort)`.

### AI Tooling Disclosure
Developed using Google Antigravity with Gemini 3.6 Flash (high) and Codex with Gpt 5.6 Sol (high) following `AGENTS.md`. All code changes, regression tests, and documentation edits were reviewed and verified locally against the test suite.
