### PR TITLE
CI: Run four jobs for non-default PANDAS_FUTURE values

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -15,18 +15,19 @@ inputs:
     required: true
   pandas_future:
     description: >-
-      Which values to use for the PANDAS_FUTURE_* environment variables.
-      "default" uses the default value of every config, "legacy" sets configs
-      whose default has changed back to their old values, and "upcoming"
-      enables configs whose default has not yet changed.
+      Value for the PANDAS_FUTURE environment variable. "default" uses the
+      default value of every future config, "legacy" sets configs whose
+      default has changed back to their old values, and "upcoming" enables
+      configs whose default has not yet changed. Configs whose non-default
+      values do not yet pass the test suite are exempt; see
+      _register_future_option in pandas/core/config_init.py.
     default: 'default'
 runs:
   using: composite
   steps:
     - name: Test
       env:
-        PANDAS_FUTURE_INFER_STRING: ${{ inputs.pandas_future == 'legacy' && '0' || '1' }}
-        PANDAS_FUTURE_PYTHON_SCALARS: ${{ inputs.pandas_future == 'upcoming' && '1' || '0' }}
+        PANDAS_FUTURE: ${{ inputs.pandas_future }}
         MESONPY_EDITABLE_VERBOSE: 1
         PYTHONDEVMODE: 1
         PYTHONWARNDEFAULTENCODING: 1

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -27,8 +27,6 @@ runs:
       env:
         PANDAS_FUTURE_INFER_STRING: ${{ inputs.pandas_future == 'legacy' && '0' || '1' }}
         PANDAS_FUTURE_PYTHON_SCALARS: ${{ inputs.pandas_future == 'upcoming' && '1' || '0' }}
-        # PANDAS_FUTURE_DISTINGUISH_NAN_AND_NA is not included in "upcoming"
-        # because the test suite does not yet pass with it enabled.
         MESONPY_EDITABLE_VERBOSE: 1
         PYTHONDEVMODE: 1
         PYTHONWARNDEFAULTENCODING: 1

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -13,19 +13,22 @@ inputs:
   pytest_target:
     description: File or directory path to run tests
     required: true
-  pandas_future_infer_string:
-    description: Environment variable for infer string behavior
-    default: '1'
-  pandas_future_python_scalars:
-    description: Environment variable for Python scalar behavior
-    default: '0'
+  pandas_future:
+    description: >-
+      Which values to use for the PANDAS_FUTURE_* environment variables.
+      "default" uses the default value of every config, "legacy" sets configs
+      whose default has changed back to their old values, and "upcoming"
+      enables configs whose default has not yet changed.
+    default: 'default'
 runs:
   using: composite
   steps:
     - name: Test
       env:
-        PANDAS_FUTURE_INFER_STRING: ${{ inputs.pandas_future_infer_string }}
-        PANDAS_FUTURE_PYTHON_SCALARS: ${{ inputs.pandas_future_python_scalars }}
+        PANDAS_FUTURE_INFER_STRING: ${{ inputs.pandas_future == 'legacy' && '0' || '1' }}
+        PANDAS_FUTURE_PYTHON_SCALARS: ${{ inputs.pandas_future == 'upcoming' && '1' || '0' }}
+        # PANDAS_FUTURE_DISTINGUISH_NAN_AND_NA is not included in "upcoming"
+        # because the test suite does not yet pass with it enabled.
         MESONPY_EDITABLE_VERBOSE: 1
         PYTHONDEVMODE: 1
         PYTHONWARNDEFAULTENCODING: 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -31,8 +31,7 @@ jobs:
         environment: [py311, py312, py313, py314]
         # Prevent the include jobs from overriding other jobs
         pytest_marker_expression: [""]
-        pandas_future_infer_string: ["1"]
-        pandas_future_python_scalars: ["0"]
+        pandas_future: ["default"]
         include:
           - name: "Downstream Compat"
             environment: downstream
@@ -73,13 +72,13 @@ jobs:
             # It will be temporarily activated during tests with locale.setlocale
             extra_loc: "zh_CN"
             platform: ubuntu-24.04
-          - name: "PANDAS_FUTURE_INFER_STRING=0"
+          - name: "Future configs legacy values (Linux)"
             environment: py313
-            pandas_future_infer_string: "0"
+            pandas_future: "legacy"
             platform: ubuntu-24.04
-          - name: "PANDAS_FUTURE_PYTHON_SCALARS=1"
+          - name: "Future configs upcoming values (Linux)"
             environment: py313
-            pandas_future_python_scalars: "1"
+            pandas_future: "upcoming"
             platform: ubuntu-24.04
           - name: "Numpy Nightly"
             environment: numpy-nightly
@@ -96,7 +95,7 @@ jobs:
       LC_ALL: ${{ matrix.lc_all || '' }}
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.environment }}-${{ matrix.pytest_marker_expression }}-${{ matrix.extra_apt || '' }}-${{ matrix.pandas_future_infer_string }}-${{ matrix.platform }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.environment }}-${{ matrix.pytest_marker_expression }}-${{ matrix.extra_apt || '' }}-${{ matrix.pandas_future }}-${{ matrix.platform }}
       cancel-in-progress: true
 
     services:
@@ -182,8 +181,7 @@ jobs:
         numprocesses: 'auto'
         pytest_marker_expression: ${{ matrix.pytest_marker_expression == '' && 'not single_cpu' || matrix.pytest_marker_expression }}
         pytest_target: ${{ matrix.pytest_target || 'pandas' }}
-        pandas_future_infer_string: ${{ matrix.pandas_future_infer_string || '1' }}
-        pandas_future_python_scalars: ${{ matrix.pandas_future_python_scalars || '0' }}
+        pandas_future: ${{ matrix.pandas_future || 'default' }}
 
     - name: Test (single_cpu)
       id: test-single-cpu
@@ -196,8 +194,7 @@ jobs:
         numprocesses: 0
         pytest_marker_expression: 'single_cpu'
         pytest_target: ${{ matrix.pytest_target || 'pandas' }}
-        pandas_future_infer_string: ${{ matrix.pandas_future_infer_string || '1' }}
-        pandas_future_python_scalars: ${{ matrix.pandas_future_python_scalars || '0' }}
+        pandas_future: ${{ matrix.pandas_future || 'default' }}
       if: ${{ matrix.pytest_marker_expression == '' && (always() && steps.build.outcome == 'success')}}
 
     - name: Upload test coverage to Codecov
@@ -220,12 +217,23 @@ jobs:
       matrix:
         os: [macos-15-intel, macos-15, windows-2025]
         environment: [py311, py312, py313, py314]
+        # Prevent the include jobs from overriding other jobs
+        pandas_future: ["default"]
+        include:
+          - name: "Future configs legacy values (macOS)"
+            os: macos-15
+            environment: py313
+            pandas_future: "legacy"
+          - name: "Future configs legacy values (Windows)"
+            os: windows-2025
+            environment: py313
+            pandas_future: "legacy"
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    name: ${{ format('{0} {1}', matrix.os, matrix.environment) }}
+    name: ${{ matrix.name || format('{0} {1}', matrix.os, matrix.environment) }}
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.environment }}-${{ matrix.os }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.environment }}-${{ matrix.os }}-${{ matrix.pandas_future }}
       cancel-in-progress: true
 
     steps:
@@ -260,6 +268,7 @@ jobs:
           numprocesses: 'auto'
           pytest_marker_expression: 'not slow and not db and not network and not single_cpu'
           pytest_target: 'pandas'
+          pandas_future: ${{ matrix.pandas_future || 'default' }}
 
   Linux-32-bit:
     runs-on: ubuntu-24.04

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -72,11 +72,11 @@ jobs:
             # It will be temporarily activated during tests with locale.setlocale
             extra_loc: "zh_CN"
             platform: ubuntu-24.04
-          - name: "Future configs legacy values (Linux)"
+          - name: "Future configs legacy values"
             environment: py313
             pandas_future: "legacy"
             platform: ubuntu-24.04
-          - name: "Future configs upcoming values (Linux)"
+          - name: "Future configs upcoming values"
             environment: py313
             pandas_future: "upcoming"
             platform: ubuntu-24.04
@@ -217,23 +217,12 @@ jobs:
       matrix:
         os: [macos-15-intel, macos-15, windows-2025]
         environment: [py311, py312, py313, py314]
-        # Prevent the include jobs from overriding other jobs
-        pandas_future: ["default"]
-        include:
-          - name: "Future configs legacy values (macOS)"
-            os: macos-15
-            environment: py313
-            pandas_future: "legacy"
-          - name: "Future configs legacy values (Windows)"
-            os: windows-2025
-            environment: py313
-            pandas_future: "legacy"
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.name || format('{0} {1}', matrix.os, matrix.environment) }}
+    name: ${{ format('{0} {1}', matrix.os, matrix.environment) }}
     concurrency:
       # https://github.community/t/concurrecy-not-work-for-push/183068/7
-      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.environment }}-${{ matrix.os }}-${{ matrix.pandas_future }}
+      group: ${{ github.event_name == 'push' && github.run_number || github.ref }}-${{ matrix.environment }}-${{ matrix.os }}
       cancel-in-progress: true
 
     steps:
@@ -268,7 +257,6 @@ jobs:
           numprocesses: 'auto'
           pytest_marker_expression: 'not slow and not db and not network and not single_cpu'
           pytest_target: 'pandas'
-          pandas_future: ${{ matrix.pandas_future || 'default' }}
 
   Linux-32-bit:
     runs-on: ubuntu-24.04

--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -916,11 +916,73 @@ with cf.config_prefix("styler"):
     )
 
 
+# Used by CI to run the test suite with every enrolled future
+# option set to its old ("legacy") or future ("upcoming") value.
+_FUTURE_MODE = os.environ.get("PANDAS_FUTURE", "default")
+if _FUTURE_MODE not in ("legacy", "default", "upcoming"):
+    raise ValueError(
+        "PANDAS_FUTURE environment variable must be one of 'legacy', "
+        f"'default', or 'upcoming', got {_FUTURE_MODE!r}"
+    )
+
+_future_option_behaviors: dict[str, dict[str, Any]] = {}
+
+
+def _register_future_option(
+    name: str,
+    *,
+    legacy: Any,
+    default: Any,
+    upcoming: Any,
+    doc: str,
+    validator: Callable[[object], Any],
+    enrolled: bool = True,
+) -> None:
+    """
+    Register an option under the "future" prefix.
+
+    The option's value is determined by, in order of precedence:
+
+    1. The PANDAS_FUTURE_<NAME> environment variable, if set: "0" means
+       False and "1" means True; any other value raises.
+    2. The PANDAS_FUTURE environment variable ("legacy", "default", or
+       "upcoming"), if the option is enrolled.
+    3. The ``default`` value.
+
+    ``enrolled=False`` registers the option but exempts it from
+    PANDAS_FUTURE, for options whose non-default values do not yet pass the
+    test suite.
+    """
+    env_override = os.environ.get(f"PANDAS_FUTURE_{name.upper()}")
+    if env_override is not None:
+        if env_override not in ("0", "1"):
+            raise ValueError(
+                f"PANDAS_FUTURE_{name.upper()} environment variable must be "
+                f"'0' or '1', got {env_override!r}"
+            )
+        value = env_override == "1"
+    elif enrolled:
+        value = {"legacy": legacy, "default": default, "upcoming": upcoming}[
+            _FUTURE_MODE
+        ]
+    else:
+        value = default
+    _future_option_behaviors[name] = {
+        "legacy": legacy,
+        "default": default,
+        "upcoming": upcoming,
+        "enrolled": enrolled,
+    }
+    cf.register_option(name, value, doc, validator=validator)
+
+
 with cf.config_prefix("future"):
-    cf.register_option(
+    _register_future_option(
         "infer_string",
-        False if os.environ.get("PANDAS_FUTURE_INFER_STRING", "1") == "0" else True,
-        "Whether to infer sequence of str objects as pyarrow string "
+        legacy=False,
+        default=True,
+        upcoming=True,
+        doc="Whether to infer sequence of str objects as pyarrow string "
         "dtype, which will be the default in pandas 3.0 "
         "(at which point this option will be deprecated).",
         validator=is_one_of_factory([True, False]),
@@ -934,10 +996,14 @@ with cf.config_prefix("future"):
         validator=is_one_of_factory([True, False]),
     )
 
-    cf.register_option(
+    _register_future_option(
         "distinguish_nan_and_na",
-        os.environ.get("PANDAS_FUTURE_DISTINGUISH_NAN_AND_NA", "0") == "1",
-        "Whether to treat NaN entries as distinct from pd.NA in "
+        legacy=False,
+        default=False,
+        upcoming=True,
+        # the test suite does not yet pass with the upcoming value
+        enrolled=False,
+        doc="Whether to treat NaN entries as distinct from pd.NA in "
         "numpy-nullable and pyarrow float dtypes. By default treats both "
         "interchangeable as missing values (NaN will be coerced to NA). "
         "See discussion in "
@@ -945,20 +1011,27 @@ with cf.config_prefix("future"):
         validator=is_one_of_factory([True, False]),
     )
 
-    cf.register_option(
+    _register_future_option(
         "python_scalars",
-        False if os.environ.get("PANDAS_FUTURE_PYTHON_SCALARS", "0") == "0" else True,
-        "Whether to return Python scalars instead of NumPy or PyArrow scalars. "
+        legacy=False,
+        default=False,
+        upcoming=True,
+        doc="Whether to return Python scalars instead of NumPy or PyArrow "
+        "scalars. "
         "Values from object dtype data where the operation coerces them to NumPy "
         "floats remain NumPy scalars. "
         "Currently experimental, setting to True is not recommended for end users.",
         validator=is_one_of_factory([True, False]),
     )
 
-    cf.register_option(
+    _register_future_option(
         "infer_freq_returns_offset",
-        None,
-        "Whether pd.infer_freq and .inferred_freq return a BaseOffset object "
+        legacy=False,
+        default=None,
+        upcoming=True,
+        # the test suite does not yet pass with the legacy or upcoming values
+        enrolled=False,
+        doc="Whether pd.infer_freq and .inferred_freq return a BaseOffset object "
         "instead of a string, which will be the default in a future version of "
         "pandas. Set to True to opt in to the future behavior, or False to "
         "keep the old behavior and silence the warning.",


### PR DESCRIPTION
Written by Claude Fable 5, fully reviewed and minor edits by me.

One job to test legacy and upcoming `PANDAS_FUTURE_*` values, only only Linux.

Note the above bullets mean that when following this, we will always have 4 jobs total regardless of the number of configs. Designed this way based on the following reasoning.

- Most FUTURE_PANDAS configs are orthogonal; we can test them together.
- We get the majority of value running on just one OS, others are marginal and the issues that do occur are typically minor.

This is meant as the default way to test these configs, if we have special circumstances (e.g. non-orthogonal configs) then we can stand up specific jobs for them as well.

I'm amenable to expanding on the runs, e.g. run each OS for upcoming values or run both with the oldest supported versions in addition to latest. But I do prefer to keep this lean.

cc @jorisvandenbossche @jbrockmendel @mroeschke 