### PR TITLE
CI: Close PRs with linked issues that aren't assigned

### DIFF
--- a/.github/workflows/pr-issue-gate.yml
+++ b/.github/workflows/pr-issue-gate.yml
@@ -18,10 +18,9 @@ jobs:
         with:
           sparse-checkout: scripts
           persist-credentials: false
-      # Warn-only at first; add --close-enabled to start closing flagged
-      # pull requests.
       - run: >-
           python3 -m scripts.issue_assignment.gate
           --repo "$GITHUB_REPOSITORY" --event-path "$GITHUB_EVENT_PATH"
+          --close-enabled
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -128,9 +128,9 @@ description, for example ``closes #1234``.
 
 Your pull request must be linked to an issue that is **assigned to you**. If you
 open one linked to an issue you haven't claimed, the bot adds the
-``Needs Issue Assignment`` label and comments with what to do next: comment
-``/take`` on the issue to claim it, then reopen your pull request (you can reopen
-it yourself — nothing is lost).
+``Needs Issue Assignment`` label, closes the pull request, and comments with
+what to do next: comment ``/take`` on the issue to claim it, then reopen your
+pull request (you can reopen it yourself — nothing is lost).
 
 Review and staleness
 --------------------


### PR DESCRIPTION
Follow up to https://github.com/pandas-dev/pandas/pull/65849. From what I have seen the bot is well-behaved, I think we can start automatically closing PRs.

Note that merging this will only take action going forward as the trigger is on opening/closing a PR.