### PR TITLE
DOC: clarify crosstab Notes on Categorical handling and dropna

### DIFF
--- a/pandas/core/reshape/pivot.py
+++ b/pandas/core/reshape/pivot.py
@@ -1042,9 +1042,11 @@ def crosstab(
     Any Series passed will have their name attributes used unless row or column
     names for the cross-tabulation are specified.
 
-    Any input passed containing Categorical data will have **all** of its
-    categories included in the cross-tabulation, even if the actual data does
-    not contain any instances of a particular category.
+    Any input passed containing Categorical data will have all of its
+    categories included in the cross-tabulation when ``dropna=False``, even if
+    the actual data does not contain any instances of a particular category.
+    With the default ``dropna=True``, categories with no observations are
+    excluded.
 
     Series arguments are aligned on their index before tabulating; rows where
     any value is missing after alignment (e.g. index labels not present in


### PR DESCRIPTION
Closes #66630.

The Notes section of `pd.crosstab` stated unconditionally that all categories of Categorical input are included. Since the default is `dropna=True`, unobserved categories are in fact excluded — which is already shown in the Examples section.

Updated the Notes paragraph to only claim **all** categories are included when `dropna=False`, and to note that with the default `dropna=True` categories with no observations are excluded.

Doc-only change; no code logic.