### PR TITLE
CI: fix UBSan suppressions silently going inert with meson 1.12.0

### DIFF
--- a/ci/suppressions/ubsan.txt
+++ b/ci/suppressions/ubsan.txt
@@ -1,16 +1,20 @@
+# Entries are matched as a substring of the source path UBSan reports, which is
+# the Cython-generated C file inside meson's private build directory. Meson does
+# not guarantee the layout of that directory (1.12.0 stopped mirroring the source
+# tree inside it), so match on the file name only.
 function:_cyutility.c
-function:pandas/_libs/algos.pyx.c
-function:pandas/_libs/hashtable.pyx.c
-function:pandas/_libs/index.pyx.c
-function:pandas/_libs/internals.pyx.c
-function:pandas/_libs/interval.pyx.c
-function:pandas/_libs/lib.pyx.c
-function:pandas/_libs/missing.pyx.c
-function:pandas/_libs/ops.pyx.c
-function:pandas/_libs/sparse.pyx.c
-function:pandas/_libs/tslibs/np_datetime.pyx.c
-function:pandas/_libs/tslibs/offsets.pyx.c
-function:pandas/_libs/tslibs/period.pyx.c
-function:pandas/_libs/tslibs/timedeltas.pyx.c
-function:pandas/_libs/tslibs/timezones.pyx.c
-function:pandas/_libs/tslibs/vectorized.pyx.c
+function:/algos.pyx.c
+function:/hashtable.pyx.c
+function:/index.pyx.c
+function:/internals.pyx.c
+function:/interval.pyx.c
+function:/lib.pyx.c
+function:/missing.pyx.c
+function:/ops.pyx.c
+function:/sparse.pyx.c
+function:/np_datetime.pyx.c
+function:/offsets.pyx.c
+function:/period.pyx.c
+function:/timedeltas.pyx.c
+function:/timezones.pyx.c
+function:/vectorized.pyx.c


### PR DESCRIPTION
The ASAN/UBSAN job has been failing on main since GH-66793 (pixi relock), which moved meson 1.11.2 -> 1.12.0.

meson 1.12.0 no longer mirrors the source tree inside a target's private build directory, so the Cython-generated C moved:

- 1.11.2: `pandas/_libs/tslibs/timezones.cpython-313-….so.p/pandas/_libs/tslibs/timezones.pyx.c`
- 1.12.0: `pandas/_libs/tslibs/timezones.cpython-313-….so.p/timezones.pyx.c`

Sanitizer suppressions are matched as a plain substring of the reported source path — there are no implicit wildcards — so every directory-qualified entry in `ci/suppressions/ubsan.txt` stopped matching. With `halt_on_error=1`, the job now dies on the first Cython function-pointer cast it hits during import:

```
timezones.pyx.c:20622:12: runtime error: call to function (unknown) through pointer to incorrect function type
    'struct _object *(*)(struct _object *, struct _object *const *, long, struct _object *)'
```

Matching on the file name only works under either layout. Verified the matching semantics with a standalone `-fsanitize=function` reproducer: a directory-qualified entry that does not literally appear in the reported path does not suppress, while `function:/mod.c` does.

Two notes for reviewers:

- The suppressions stay scoped as before. `function:` is a check name, so only `-fsanitize=function` is affected for those files; all other UBSan checks and ASAN still apply. It is also keyed on the call site, not the callee's file. Hand-written and vendored C (ujson, the tokenizer, `src/vendored/numpy/datetime/np_datetime.c`) remains fully checked — `function:/np_datetime.pyx.c` matches only the Cython wrapper.
- Since the same relock also moved Python 3.13.14 -> 3.13.15, it is possible a report surfaces in a module not on the list. That would be a genuine new finding rather than a regression from this PR.

A per-file list is arguably the wrong shape for what is really a blanket "Cython codegen casts function pointers, as the CPython C API requires" exemption — it grows one entry at a time and, as here, can silently degrade to suppressing nothing. Compiling the generated sources with `-fno-sanitize=function` would express that directly, but that is a larger change than unbreaking main.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which bisected the CI failure to the meson bump, confirmed the suppression-matching semantics with a standalone reproducer, and wrote the patch.