### PR TITLE
TST: avoid resetting RNG in MultiIndex duplicate test

### DIFF
--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -259,7 +259,8 @@ def test_duplicated_hashtable_impl(keep, monkeypatch):
     # GH 9125
     n, k = 6, 10
     levels = [np.arange(n), [str(i) for i in range(n)], 1000 + np.arange(n)]
-    codes = [np.random.default_rng(2).choice(n, k * n) for _ in levels]
+    rng = np.random.default_rng(2)
+    codes = [rng.choice(n, k * n) for _ in levels]
     with monkeypatch.context() as m:
         m.setattr(libindex, "_SIZE_CUTOFF", 50)
         mi = MultiIndex(levels=levels, codes=codes)


### PR DESCRIPTION
Closes #66774

### Description

`test_duplicated_hashtable_impl` instantiated `np.random.default_rng(2)` *inside* the comprehension, so a new generator with the same seed was created on every iteration, and each iteration ended up drawing an _identical_ sequence. Hence, the test detected duplicates over a far narrower input than intended (it regressed in https://github.com/pandas-dev/pandas/pull/54209; prior to this, the shared NumPy RNG was called once per level).

### What Changed

Each level's codes should be a distinct draw from the RNG. We do this by generating the codes as successive samples from one advancing generator:

```python
rng = np.random.default_rng(2)
codes = [rng.choice(n, k * n) for _ in levels]
```

With the fix, we obtain 53 distinct tuples for the same seed, instead of the 6 tuples returned by the current behavior.

### AI Disclosure

I didn't actually use AI to write any code or comments here, but I technically found this bug during an AI-assisted static analysis project that I've been working on. The AI assisting me was OpenAI Codex gpt-5.6-sol (xhigh). Just stating that for transparency; maintainers, feel free to tell me off if this disclosure is too pedantic.

- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
