### PR TITLE
CI (DOC/WEB): replace upload to server with push to github pages repo

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -159,8 +159,9 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         repository: pandas-dev/pandas-dev.github.io
-        token: ${{ secrets.PANDAS_DEV_GITHUB_IO_TOKEN }}
+        ssh-key: ${{ secrets.PANDAS_DEV_GITHUB_IO_DEPLOY_KEY }}
         path: pandas-dev.github.io
+        persist-credentials: true
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || env.PUBLISH_PROD == 'true'
 
     - name: Upload web
@@ -172,7 +173,7 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload prod docs
-      run: rsync -a --delete doc/build/html/ pandas-dev.github.io/pandas-docs/version/${{ env.PANDAS_DOCS_VERSION }}
+      run: rsync -a --delete doc/build/html/ pandas-dev.github.io/pandas-docs/version/${PANDAS_DOCS_VERSION}
       if: env.PUBLISH_PROD == 'true'
 
     - name: Commit and push to pandas-dev.github.io

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -77,6 +77,13 @@ jobs:
           exit 1
         fi
 
+        # Docs for all patch releases of a minor series are published under
+        # the same major.minor path, e.g. 3.0.5 -> pandas-docs/version/3.0
+        if [[ -n "$PANDAS_VERSION" ]]; then
+          PANDAS_DOCS_VERSION=$(echo "$PANDAS_VERSION" | grep -oE '^[0-9]+\.[0-9]+')
+          echo "PANDAS_DOCS_VERSION=$PANDAS_DOCS_VERSION" >> "$GITHUB_ENV"
+        fi
+
     - name: Checkout
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -145,28 +152,42 @@ jobs:
           ci-build-documentation \
           zip_html
 
-    - name: Install ssh key
-      run: |
-        mkdir -m 700 -p ~/.ssh
-        echo "${{ secrets.server_ssh_key }}" > ~/.ssh/id_rsa
-        chmod 600 ~/.ssh/id_rsa
-        echo "${{ secrets.server_ip }} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFjYkJBk7sos+r7yATODogQc3jUdW1aascGpyOD4bohj8dWjzwLJv/OJ/fyOQ5lmj81WKDk67tGtqNJYGL9acII=" > ~/.ssh/known_hosts
-      if: (github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))) || github.event_name == 'workflow_dispatch'
-
     - name: Copy cheatsheets into site directory
       run: cp doc/cheatsheet/Pandas_Cheat_Sheet* web/build/
 
+    - name: Checkout pandas-dev.github.io
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: pandas-dev/pandas-dev.github.io
+        token: ${{ secrets.PANDAS_DEV_GITHUB_IO_TOKEN }}
+        path: pandas-dev.github.io
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || env.PUBLISH_PROD == 'true'
+
     - name: Upload web
-      run: rsync -az --delete --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ web@${{ secrets.server_ip }}:/var/www/html
-      if: false # github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: rsync -a --delete --exclude='.git' --exclude='README.md' --exclude='CNAME' --exclude='.nojekyll' --exclude='pandas-docs' --exclude='docs' --exclude='benchmarks' web/build/ pandas-dev.github.io/
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload dev docs
-      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/dev
-      if: false # github.event_name == 'push' && github.ref == 'refs/heads/main'
+      run: rsync -a --delete doc/build/html/ pandas-dev.github.io/pandas-docs/dev
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     - name: Upload prod docs
-      run: rsync -az --delete doc/build/html/ web@${{ secrets.server_ip }}:/var/www/html/pandas-docs/version/${{ env.PANDAS_VERSION }}
-      if: false # ${{ env.PUBLISH_PROD == 'true' }}
+      run: rsync -a --delete doc/build/html/ pandas-dev.github.io/pandas-docs/version/${{ env.PANDAS_DOCS_VERSION }}
+      if: env.PUBLISH_PROD == 'true'
+
+    - name: Commit and push to pandas-dev.github.io
+      working-directory: pandas-dev.github.io
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git add -A
+        if git diff --cached --quiet; then
+          echo "No changes to publish"
+          exit 0
+        fi
+        git commit -m "Update site from pandas-dev/pandas@${GITHUB_SHA}"
+        git push
+      if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || env.PUBLISH_PROD == 'true'
 
     - name: Move docs into site directory
       run: mv doc/build/html web/build/docs

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -178,6 +178,8 @@ jobs:
 
     - name: Commit and push to pandas-dev.github.io
       working-directory: pandas-dev.github.io
+      env:
+        COMMIT_MSG: ${{ env.PUBLISH_PROD == 'true' && format('Update site for pandas {} (pandas-dev/pandas@{})', env.PANDAS_DOCS_VERSION, github.sha) || format('Update site from pandas-dev/pandas@{}', github.sha) }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -186,8 +188,8 @@ jobs:
           echo "No changes to publish"
           exit 0
         fi
-        git commit -m "Update site from pandas-dev/pandas@${GITHUB_SHA}"
-        git push
+        git commit -m "${COMMIT_MSG}"
+        git push || (git pull --rebase && git push)
       if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || env.PUBLISH_PROD == 'true'
 
     - name: Move docs into site directory

--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -179,7 +179,7 @@ jobs:
     - name: Commit and push to pandas-dev.github.io
       working-directory: pandas-dev.github.io
       env:
-        COMMIT_MSG: ${{ env.PUBLISH_PROD == 'true' && format('Update site for pandas {} (pandas-dev/pandas@{})', env.PANDAS_DOCS_VERSION, github.sha) || format('Update site from pandas-dev/pandas@{}', github.sha) }}
+        COMMIT_MSG: ${{ env.PUBLISH_PROD == 'true' && format('Update site for pandas {0} (pandas-dev/pandas@{1})', env.PANDAS_DOCS_VERSION, github.sha) || format('Update site from pandas-dev/pandas@{0}', github.sha) }}
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -194,7 +194,14 @@ class Preprocessors:
                 break
 
             resp.raise_for_status()
-            maintainers_info[user] = resp.json()
+            # only keep the fields used in the templates; the full response also
+            # includes other fields that change independently (e.g. follower
+            # count), causing a diff on every rebuild
+            user_json = resp.json()
+            maintainers_info[user] = {
+                key: user_json[key]
+                for key in ("name", "login", "avatar_url", "html_url", "blog")
+            }
 
         context["maintainers"]["github_info"] = maintainers_info
 
@@ -230,6 +237,23 @@ class Preprocessors:
             resp.raise_for_status()
             releases = resp.json()
 
+            # only keep the fields actually used when rendering the site; the full
+            # response also includes fields like download_count, causing the file
+            # to change on every rebuild
+            releases = [
+                {
+                    "tag_name": release["tag_name"],
+                    "published_at": release["published_at"],
+                    "prerelease": release["prerelease"],
+                    "browser_download_url": (
+                        release["assets"][0]["browser_download_url"]
+                        if release["assets"]
+                        else ""
+                    ),
+                }
+                for release in releases
+            ]
+
         with open(
             pathlib.Path(context["target_path"]) / "releases.json",
             "w",
@@ -249,11 +273,7 @@ class Preprocessors:
                     "parsed_version": version.parse(release["tag_name"].lstrip("v")),
                     "tag": release["tag_name"],
                     "published": published,
-                    "url": (
-                        release["assets"][0]["browser_download_url"]
-                        if release["assets"]
-                        else ""
-                    ),
+                    "url": release["browser_download_url"],
                 }
             )
         # sorting out obsolete versions


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/issues/64703

This updates the doc build workflow to rsync to a checkout of https://github.com/pandas-dev/pandas-dev.github.io instead of to the (no longer running) server. And then creates a commit and pushes that to the repo.

Pushing to a different repo will need an access token or deploy key (to be saved as `PANDAS_DEV_GITHUB_IO_TOKEN`) that can write to `pandas-dev/pandas-dev.github.io` (still have to set this up, and check that pushing to the pages repo will be allowed that way). 
It seems that the deploy key is regarded as a safer option than the personal access token. And I don't think there is a way around using one of those two (except for creating a custom github app)