### PR TITLE
CI: fix working directory for the web interactive_terminal task

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -132,7 +132,6 @@ jobs:
           html
 
     - name: Build the interactive terminal
-      working-directory: web/interactive_terminal
       run: |
         pixi run \
           --environment docs-and-web \

--- a/pixi.toml
+++ b/pixi.toml
@@ -393,3 +393,4 @@ cmd = [
   "lite",
   "build",
 ]
+cwd = "web/interactive_terminal/"


### PR DESCRIPTION
I noticed that the `web/build/lite` part was missing in the recent artifacts, and seeing this warning in the "Build the interactive terminal" step on CI ([logs](https://github.com/pandas-dev/pandas/actions/runs/32033467981/job/95398445940#step:11:17)):

> [LiteBuildApp] WARNING | [lite] Skipping web/interactive_terminal/jupyter-lite.json: parent directory does not exist in output. Config files should be in the root or in app directories (lab, repl, etc.)

That is probably caused by the working directory not having any effect; the pixi tasks are always run from the project root, even when invoked from elsewhere. So moving that working directory configuration to the task itself.