### PR TITLE
ENH: Disclose offending values in IntervalArray._validate

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -49,6 +49,7 @@ Other enhancements
 - Building from source no longer fails on a checkout with CRLF line endings, such as under WSL (:issue:`64272`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
+- Improved error message in :meth:`IntervalArray._validate` to disclose the index locations of intervals where the left side exceeds the right side (:issue:`66807`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
 - Improved type inference of comparison and arithmetic operators on :class:`Series` and :class:`DataFrame` for static type checkers (e.g. ``ser == "a"`` is now inferred as :class:`Series` instead of ``Any``) (:issue:`40762`)
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -619,7 +619,22 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             )
             raise ValueError(msg)
         if not (left[left_mask] <= right[left_mask]).all():
-            msg = "left side of interval must be <= right side"
+            offenders = left[left_mask] > right[left_mask]
+            offending_indices = offenders[offenders].index.tolist()
+            # Show at most 10 offending positions to keep the message readable
+            if len(offending_indices) > 10:
+                shown = offending_indices[:10]
+                msg = (
+                    "left side of interval must be <= right side. "
+                    f"Offending values found at index locations "
+                    f"{shown} (and {len(offending_indices) - 10} more)"
+                )
+            else:
+                msg = (
+                    "left side of interval must be <= right side. "
+                    f"Offending values found at index locations "
+                    f"{offending_indices}"
+                )
             raise ValueError(msg)
 
     def _shallow_copy(self, left, right) -> Self:


### PR DESCRIPTION
- [x] closes #66807
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

- [x] I did **not** use AI to develop this pull request.

When `IntervalArray._validate` raises because left > right, the error message now includes the index locations of the offending intervals (up to 10 shown). This helps users identify which intervals are invalid without manually scanning potentially large inputs.

**Before:**
```
ValueError: left side of interval must be <= right side
```

**After:**
```
ValueError: left side of interval must be <= right side. Offending values found at index locations [3, 7]
```