### PR TITLE
BUG: bare DateOffset(n) leaves stale pytz offset near DST transition (GH#61862)

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2025,40 +2025,40 @@ cdef class RelativeDeltaOffset(BaseOffset):
                 other_nanos = other.nanosecond
                 other = other.to_pydatetime(warn=False)
 
-        if len(self.kwds) > 0:
-            tzinfo = getattr(other, "tzinfo", None)
-            if tzinfo is not None and self._use_relativedelta:
-                # perform calculation in UTC
-                other = other.replace(tzinfo=None)
+        # GH#61870 Do not shortcut the empty-kwds case: a bare DateOffset(n)
+        #  carries its n-days default in self._offset, and adding that outside
+        #  the tz round-trip below left pytz results on the stale UTC offset.
+        tzinfo = getattr(other, "tzinfo", None)
+        if tzinfo is not None and self._use_relativedelta:
+            # perform calculation in UTC
+            other = other.replace(tzinfo=None)
 
-            other = other + (self._offset * self._n)
+        other = other + (self._offset * self._n)
 
-            if hasattr(self, "nanoseconds"):
-                other = self._n * Timedelta(nanoseconds=self.nanoseconds) + other
-            if other_nanos != 0:
-                other = Timedelta(nanoseconds=other_nanos) + other
+        if hasattr(self, "nanoseconds"):
+            other = self._n * Timedelta(nanoseconds=self.nanoseconds) + other
+        if other_nanos != 0:
+            other = Timedelta(nanoseconds=other_nanos) + other
 
-            if tzinfo is not None and self._use_relativedelta:
-                # bring tz back from UTC calculation
-                other = localize_pydatetime(other, tzinfo)
+        if tzinfo is not None and self._use_relativedelta:
+            # bring tz back from UTC calculation
+            other = localize_pydatetime(other, tzinfo)
 
-            result = Timestamp(other)
-            # GH#64806 The computation above uses Python timedelta /
-            # relativedelta, which floor sub-second components to microseconds
-            # and lose the offset's declared resolution (e.g. milliseconds).
-            # Coerce to that resolution when lossless so the scalar result
-            # matches the vectorized DatetimeIndex/Series path; apply_wraps
-            # then narrows back to ``other``'s unit where that is also lossless.
-            try:
-                offset_unit = self._pd_timedelta.unit
-            except NotImplementedError:
-                return result
-            result2 = result.as_unit(offset_unit)
-            if result == result2:
-                result = result2
+        result = Timestamp(other)
+        # GH#64806 The computation above uses Python timedelta /
+        # relativedelta, which floor sub-second components to microseconds
+        # and lose the offset's declared resolution (e.g. milliseconds).
+        # Coerce to that resolution when lossless so the scalar result
+        # matches the vectorized DatetimeIndex/Series path; apply_wraps
+        # then narrows back to ``other``'s unit where that is also lossless.
+        try:
+            offset_unit = self._pd_timedelta.unit
+        except NotImplementedError:
             return result
-        else:
-            return other + timedelta(self._n)
+        result2 = result.as_unit(offset_unit)
+        if result == result2:
+            result = result2
+        return result
 
     @cache_readonly
     def _pd_timedelta(self) -> Timedelta:

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -1352,13 +1352,17 @@ def test_multiply_dateoffset_typeerror(left, right):
         left * right
 
 
-def test_dateoffset_days_vs_n_near_dst_transition():
-    # GH#61862
-    ts = Timestamp("2022-10-30", tz="Europe/Brussels")
+@pytest.mark.parametrize("n", [1, 2, -1])
+def test_dateoffset_days_vs_n_near_dst_transition(warsaw, n):
+    # GH#61862, GH#61870
+    ts = Timestamp("2022-10-30", tz=warsaw)
 
-    offset_days = ts + offsets.DateOffset(days=1)
-    offset_n = ts + offsets.DateOffset(1)
+    offset_days = ts + offsets.DateOffset(days=n)
+    offset_n = ts + offsets.DateOffset(n)
     assert offset_days == offset_n
+    # the scalar result also agrees with the vectorized one
+    expected = DatetimeIndex([ts]) + offsets.DateOffset(n)
+    assert offset_n == expected[0]
 
 
 @pytest.mark.parametrize("n", [1, 2, -1])


### PR DESCRIPTION
Follow-up to GH-61870, which fixed GH-61862 (`DateOffset(1)` vs `DateOffset(days=1)` near a DST transition) only on the zoneinfo/dateutil axis. `RelativeDeltaOffset._apply` gated the relativedelta/tz round-trip behind `len(self.kwds) > 0`, and a bare `DateOffset(n)` has empty `kwds`, so it fell through to a plain `other + timedelta(self._n)`. Because GH-61870 also set `_use_relativedelta=True` for the empty-kwds case, `other` is now converted to a `pydatetime` first — making that a naive wall-clock addition that keeps a pytz operand's pre-transition `tzinfo`:

```python
ts = pd.Timestamp("2022-10-30", tz=pytz.timezone("Europe/Brussels"))   # 00:00+02:00

ts + pd.offsets.DateOffset(1)         # 2022-10-31 00:00:00+02:00  <- stale CEST, UTC 22:00
ts + pd.offsets.DateOffset(days=1)    # 2022-10-31 00:00:00+01:00
pd.DatetimeIndex([ts]) + pd.offsets.DateOffset(1)   # 2022-10-31 00:00:00+01:00
```

So GH-61862 was still live for pytz tzinfos, and the scalar path disagreed with the vectorized one.

A bare `DateOffset(n)` already carries `relativedelta(days=1)` in `self._offset`, so the gate can simply go: `self._offset * self._n` produces the same shift while going through the naive-UTC / `localize_pydatetime` round-trip. `_pd_timedelta` already handles the empty-kwds case (GH-66242), so scalar and vectorized agree again.

The dropped `else` branch was unreachable except via pickles written before GH-61870 (`_use_relativedelta=False` with empty `kwds`); that path is byte-identical through the surviving branch, since `timedelta(days=1) * n == timedelta(n)` and the tz round-trip is itself gated on `_use_relativedelta`.

No whatsnew entry: `v3.1.0.rst` already carries the GH-61862 entry from GH-61870, and 3.1.0 is unreleased — this makes that entry accurate rather than warranting a second one.

The existing regression test is extended to the `warsaw` fixture (pytz/dateutil/zoneinfo) over `n in (1, 2, -1)`, plus a scalar-vs-vectorized assertion; the pytz variants fail on main. I also diffed before/after over ~18 edge cases (`date`/`datetime` operands, `normalize`, nanoseconds, negative and zero `n`, all four units, `-off` and `__sub__`, pickle round-trip, both overflow paths, `date_range(freq=off)`) — no behavior change outside the pytz DST case.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the defect, wrote the patch and test, and ran the before/after edge-case differential.