### PR TITLE
BUG: read_sas column-metadata validation defeated by a late metadata page (GH#47339)

### DIFF
--- a/pandas/io/sas/sas7bdat.py
+++ b/pandas/io/sas/sas7bdat.py
@@ -316,6 +316,7 @@ class SAS7BDATReader(SASReader):
         self._column_data_lengths: list[int] = []
         self._column_data_offsets: list[int] = []
         self._column_types: list[bytes] = []
+        self._validated_state: tuple[int, int] | None = None
 
         self._current_row_in_file_index = 0
         self._current_row_on_page_index = 0
@@ -352,9 +353,19 @@ class SAS7BDATReader(SASReader):
         # The column offsets, lengths and types come straight out of the file's
         # column-attributes subheader, and every row is then read at those
         # positions out of a buffer only row_length bytes long. Validate them
-        # once here rather than per row: a corrupt or hostile file would
-        # otherwise read past the end of that buffer. These are Python ints, so
-        # unlike the int64 the parser holds them in, the sum cannot overflow.
+        # here rather than per row: a corrupt or hostile file would otherwise
+        # read past the end of that buffer. These are Python ints, so unlike
+        # the int64 the parser holds them in, the sum cannot overflow.
+        #
+        # A metadata page may appear after the one the header parse stopped on,
+        # so this runs again before each chunk's Parser. The row-size subheader
+        # only overwrites row_length and the column-attributes one only appends
+        # to the column lists, so an unchanged snapshot of those two means the
+        # columns below have all been checked already.
+        state = (self.row_length, len(self._column_data_offsets))
+        if state == self._validated_state:
+            return
+        self._validated_state = state
         for index, (offset, length, ctype) in enumerate(
             zip(
                 self._column_data_offsets,
@@ -833,6 +844,11 @@ class SAS7BDATReader(SASReader):
         self._setup_string_buffers(ns, nrows)
 
         self._current_row_in_chunk_index = 0
+        try:
+            self._validate_column_data_ranges()
+        except Exception:
+            self.close()
+            raise
         p = Parser(self)
         p.read(nrows)
         if self._str_mode != const.string_mode_object:

--- a/pandas/tests/io/sas/test_sas7bdat.py
+++ b/pandas/tests/io/sas/test_sas7bdat.py
@@ -654,6 +654,58 @@ def test_column_offset_near_int64_max_raises(datapath, bad_offset):
         pd.read_sas(io.BytesIO(data), format="sas7bdat", encoding=None)
 
 
+@pytest.mark.parametrize(
+    "test_file, rowsize_offset, rowsize_length, int_len, page_length, victim_offset",
+    [
+        # byte offset and length of the row-size subheader on the file's first
+        # metadata page, the file's word size, its page size, and the byte offset
+        # of a data page further in that the parser only reaches while reading
+        ("productsales.sas7bdat", 8736, 480, 4, 8192, 1024 + 3 * 8192),  # 32-bit
+        ("load_log.sas7bdat", 130264, 808, 8, 65536, 65536 + 3 * 65536),  # 64-bit
+    ],
+)
+def test_late_metadata_page_shrinking_row_length_raises(
+    datapath,
+    test_file,
+    rowsize_offset,
+    rowsize_length,
+    int_len,
+    page_length,
+    victim_offset,
+):
+    # GH#47339 a metadata page can also turn up past the pages the header parse
+    # walked, and shrink row_length under column offsets that were validated
+    # against the previous one. Every chunk builds a fresh Parser off those
+    # attributes, so the next one read every row out of bounds.
+    with open(datapath("io", "sas", "data", test_file), "rb") as fd:
+        data = bytearray(fd.read())
+    fmt = "<Q" if int_len == 8 else "<I"
+    subheader = data[rowsize_offset : rowsize_offset + rowsize_length]
+    struct.pack_into(fmt, subheader, const.row_length_offset_multiplier * int_len, 8)
+
+    # A metadata page carrying just that one rewritten row-size subheader,
+    # replacing a data page the parser reaches part way through the file.
+    bit_offset = 32 if int_len == 8 else 16
+    page = bytearray(page_length)
+    place = page_length - rowsize_length
+    page[place:] = subheader
+    struct.pack_into(
+        "<H", page, bit_offset + const.page_type_offset, const.page_meta_type
+    )
+    struct.pack_into("<H", page, bit_offset + const.subheader_count_offset, 1)
+    pointer = bit_offset + const.subheader_pointers_offset
+    struct.pack_into(fmt, page, pointer, place)
+    struct.pack_into(fmt, page, pointer + int_len, rowsize_length)
+    data[victim_offset : victim_offset + page_length] = page
+
+    with pd.read_sas(
+        io.BytesIO(data), format="sas7bdat", encoding=None, chunksize=1
+    ) as reader:
+        with pytest.raises(ValueError, match="the file is corrupt"):
+            for _ in reader:
+                pass
+
+
 def test_0x40_control_byte(datapath):
     # GH 31243
     fname = datapath("io", "sas", "data", "0x40controlbyte.sas7bdat")


### PR DESCRIPTION
A SAS7BDAT file can carry a metadata page past the ones the header parse walked. `Parser.read_next_page` hands it to `collect_page_subheaders`, which dispatches back into `_process_rowsize_subheader` and overwrites `row_length`, while the column offsets that were validated against the old value stay put. Every chunk builds a fresh `Parser` off both, so each chunk after such a page read past the end of the row buffer — silently in the 8-byte numeric fast path, which does an unchecked `memcpy`, and as an internal `AssertionError: Out of bounds read` in the checked paths.

Reproduced by replacing a data page of `productsales.sas7bdat` / `load_log.sas7bdat` with a metadata page whose row-size subheader declares `row_length=8`: with `chunksize=1` the read produces good rows up to that page and then trips the assert (a live out-of-bounds read once asserts are compiled out). Now it raises `ValueError: Column 1 spans bytes 8-16 of a 8-byte row; the file is corrupt`, matching the other corrupt-metadata errors added under GH-47339.

The fix re-validates before each chunk's `Parser` instead of only at open. `_validate_column_data_ranges` early-exits on an unchanged `(row_length, number of columns declared)` snapshot — the row-size subheader only overwrites `row_length` and the column-attributes subheader only appends — so the re-check costs a tuple compare per chunk (0.06 µs, flat in column count) rather than a loop over every column (21.9 µs on a 392-column file). End-to-end `chunksize=1` timings are unchanged within noise.

No whatsnew entry: the v3.1.0 bullet for column metadata that "does not fit the rows it describes" already promises this behavior, and the gap was never released.

The sibling mutation — a late metadata page inflating `column_count` via a column-size subheader — raises `IndexError` in `Parser.__init__` before any unsafe read, so it is not a memory-safety hole and is left alone here.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the out-of-bounds read with a crafted fixture, wrote the fix and the regression test, and benchmarked the per-chunk cost.