### PR TITLE
BUG: Period silently returned the 1970 epoch on ordinal overflow

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -760,6 +760,7 @@ I/O
 Period
 ^^^^^^
 - Bug in :class:`Period` constructor where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
+- Bug in :class:`Period`, :class:`PeriodIndex` and :meth:`DatetimeIndex.to_period` silently returning the 1970 epoch for dates the frequency cannot represent, e.g. ``Period("2300-01-01", freq="ns")``; these now raise ``OutOfBoundsDatetime`` (:issue:`66248`)
 - Bug in :meth:`DatetimeIndex.to_period` where anchored offsets ``YS``, ``BYS``, ``QS``, ``BQS``, ``BYE``, and ``BQE`` produced incorrect period frequencies, losing the month anchor (:issue:`36939`)
 - Bug in :meth:`Period.strftime` where unknown format directives (e.g. ``"%Q"``) silently produced platform-dependent output and crashed the Python process on Windows; an ``Invalid format string`` ``ValueError`` is now raised on all platforms (:issue:`53562`)
 - Bug in :meth:`Period.to_timestamp` and :meth:`PeriodIndex.to_timestamp` returning incorrect timestamps when the target frequency normalized to nanoseconds (e.g. ``"1ns"``) or when converting a nanosecond ``Period`` to a coarser target frequency (:issue:`63760`)

--- a/pandas/_libs/tslibs/period.pxd
+++ b/pandas/_libs/tslibs/period.pxd
@@ -1,7 +1,15 @@
 from numpy cimport int64_t
 
-from .np_datetime cimport npy_datetimestruct
+from .np_datetime cimport (
+    NPY_DATETIMEUNIT,
+    npy_datetimestruct,
+)
 
 
 cdef bint is_period_object(object obj)
-cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) noexcept nogil
+cdef int64_t get_period_ordinal_unchecked(
+    npy_datetimestruct *dts, int freq
+) noexcept nogil
+cdef bint get_period_bounds(
+    int freq, NPY_DATETIMEUNIT* unit, int* min_year, int* max_year
+) noexcept nogil

--- a/pandas/_libs/tslibs/period.pyx
+++ b/pandas/_libs/tslibs/period.pyx
@@ -57,7 +57,9 @@ from pandas._libs.tslibs.np_datetime cimport (
     NPY_DATETIMEUNIT,
     NPY_FR_D,
     astype_overflowsafe,
+    check_dts_bounds,
     dts_to_iso_string,
+    get_implementation_bounds,
     import_pandas_datetime,
     npy_datetimestruct,
     npy_datetimestruct_to_datetime,
@@ -776,9 +778,18 @@ cdef int get_anchor_month(int freq, int freq_group) noexcept nogil:
 # specifically _dont_ use cdvision or else ordinals near -1 are assigned to
 # incorrect dates GH#19643
 @cython.cdivision(False)
-cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) noexcept nogil:
+cdef int64_t get_period_ordinal_unchecked(
+    npy_datetimestruct *dts, int freq
+) noexcept nogil:
     """
-    Generate an ordinal in period space
+    Generate an ordinal in period space, assuming the caller has checked that
+    the ordinal fits in int64.
+
+    Being noexcept, this discards the OverflowError the C conversion raises
+    for a value that does not fit and returns ordinal 0 -- the epoch -- in its
+    place, so only call it after get_period_bounds says the value is in range
+    (which is what get_period_ordinal does). It exists for the loops, which
+    take that decision once for the whole array instead of per element.
 
     Parameters
     ----------
@@ -814,6 +825,84 @@ cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) noexcept nogi
 
     unit = freq_group_code_to_npy_unit(freq)
     return npy_datetimestruct_to_datetime(unit, dts)
+
+
+# Years for which the ordinal cannot overflow, indexed by NPY_DATETIMEUNIT,
+#  so that get_period_ordinal costs one comparison for all but the
+#  handful of years at the edge of a unit's range.
+cdef int[16] SAFE_MIN_YEAR
+cdef int[16] SAFE_MAX_YEAR
+
+
+cdef void _fill_safe_years() noexcept:
+    cdef:
+        npy_datetimestruct lower, upper
+        Py_ssize_t i
+        NPY_DATETIMEUNIT unit
+
+    for i in range(16):
+        SAFE_MIN_YEAR[i] = INT32_MIN
+        SAFE_MAX_YEAR[i] = INT32_MAX
+
+    for unit in [
+        NPY_DATETIMEUNIT.NPY_FR_m,
+        NPY_DATETIMEUNIT.NPY_FR_s,
+        NPY_DATETIMEUNIT.NPY_FR_ms,
+        NPY_DATETIMEUNIT.NPY_FR_us,
+        NPY_DATETIMEUNIT.NPY_FR_ns,
+    ]:
+        get_implementation_bounds(unit, &lower, &upper)
+        # +/- 1 because only part of a boundary year is representable, so
+        #  those years still need the exact check
+        SAFE_MIN_YEAR[<int>unit] = lower.year + 1
+        SAFE_MAX_YEAR[<int>unit] = upper.year - 1
+
+
+_fill_safe_years()
+
+
+cdef bint get_period_bounds(
+    int freq, NPY_DATETIMEUNIT* unit, int* min_year, int* max_year
+) noexcept nogil:
+    """
+    Whether ordinals at frequency `freq` can overflow int64 and, if so, the
+    npy unit they must be in bounds for and the years that are in bounds
+    whatever the rest of the date is.
+
+    Everything here depends only on `freq`, so loops call this once and then
+    only compare years, taking the exact check for the boundary years.
+    """
+    cdef:
+        int freq_group = get_freq_group(freq)
+
+    if not (freq_group == FR_MIN or freq_group == FR_SEC or freq_group == FR_MS
+            or freq_group == FR_US or freq_group == FR_NS):
+        # Hourly and coarser ordinals stay well inside int64 for any year
+        #  that fits the int32 npy_datetimestruct.year field.
+        return False
+
+    # For the rest the ordinal *is* the datetime64 value in the matching
+    #  unit, so the datetime64 bounds are exactly the periods that fit.
+    unit[0] = freq_group_code_to_npy_unit(freq)
+    min_year[0] = SAFE_MIN_YEAR[<int>unit[0]]
+    max_year[0] = SAFE_MAX_YEAR[<int>unit[0]]
+    return True
+
+
+cdef int64_t get_period_ordinal(npy_datetimestruct *dts, int freq) except? -1:
+    """
+    Generate an ordinal in period space, raising OutOfBoundsDatetime for a
+    value whose ordinal does not fit in int64.
+    """
+    cdef:
+        NPY_DATETIMEUNIT unit = NPY_FR_D
+        int min_year = 0, max_year = 0
+
+    if get_period_bounds(freq, &unit, &min_year, &max_year):
+        if not min_year <= dts.year <= max_year:
+            check_dts_bounds(dts, unit)
+
+    return get_period_ordinal_unchecked(dts, freq)
 
 
 cdef void get_date_info(int64_t ordinal,
@@ -1128,7 +1217,7 @@ cdef void _period_asfreq(
 
 
 cpdef int64_t period_ordinal(int y, int m, int d, int h, int min,
-                             int s, int us, int ps, int freq):
+                             int s, int us, int ps, int freq) except? -1:
     """
     Find the ordinal representation of the given datetime components at the
     frequency `freq`.
@@ -1150,6 +1239,10 @@ cpdef int64_t period_ordinal(int y, int m, int d, int h, int min,
     """
     cdef:
         npy_datetimestruct dts
+
+    # memset because the bounds check reads every field, including the
+    #  attoseconds this signature has no argument for
+    memset(&dts, 0, sizeof(npy_datetimestruct))
     dts.year = y
     dts.month = m
     dts.day = d
@@ -1648,9 +1741,19 @@ def from_calendar_ordinals(const int64_t[:] values, PeriodDtypeBase dtype):
         Py_ssize_t i, n = len(values)
         int64_t[::1] result = np.empty(len(values), dtype="i8")
         int64_t val
+        npy_datetimestruct dts
+        NPY_DATETIMEUNIT unit = NPY_FR_D
+        int freq, min_year = 0, max_year = 0
+        bint check_bounds
 
     if dtype is None:
         raise ValueError("freq not specified and cannot be inferred")
+
+    freq = dtype._dtype_code
+    check_bounds = get_period_bounds(freq, &unit, &min_year, &max_year)
+    memset(&dts, 0, sizeof(npy_datetimestruct))
+    dts.month = 1
+    dts.day = 1
 
     for i in range(n):
         val = values[i]
@@ -1664,7 +1767,10 @@ def from_calendar_ordinals(const int64_t[:] values, PeriodDtypeBase dtype):
                 #  npy_datetimestruct.year field; out-of-range would silently
                 #  wrap, so raise to match the scalar Period(int) path.
                 raise OutOfBoundsDatetime(f"Out of bounds year: {val}")
-            result[i] = period_ordinal(val, 1, 1, 0, 0, 0, 0, 0, dtype._dtype_code)
+            dts.year = val
+            if check_bounds and not min_year <= val <= max_year:
+                check_dts_bounds(&dts, unit)
+            result[i] = get_period_ordinal_unchecked(&dts, freq)
 
     return result.base
 

--- a/pandas/_libs/tslibs/vectorized.pyx
+++ b/pandas/_libs/tslibs/vectorized.pyx
@@ -26,6 +26,7 @@ from .nattype cimport (
 from .np_datetime cimport (
     NPY_DATETIMEUNIT,
     NPY_FR_ns,
+    check_dts_bounds,
     import_pandas_datetime,
     npy_datetimestruct,
     pandas_datetime_to_datetimestruct,
@@ -33,7 +34,10 @@ from .np_datetime cimport (
 
 import_pandas_datetime()
 
-from .period cimport get_period_ordinal
+from .period cimport (
+    get_period_bounds,
+    get_period_ordinal_unchecked,
+)
 from .timestamps cimport create_timestamp_from_ts
 from .timezones cimport is_utc
 from .tzconversion cimport (
@@ -403,6 +407,13 @@ def dt64arr_to_periodarr(
         ndarray result = cnp.PyArray_EMPTY(stamps.ndim, stamps.shape, cnp.NPY_INT64, 0)
         cnp.broadcast mi = cnp.PyArray_MultiIterNew2(result, stamps)
 
+        NPY_DATETIMEUNIT period_unit = NPY_FR_ns
+        int min_year = 0, max_year = 0
+        # only the fine freqs can overflow; hoisted so the loop only compares
+        bint check_bounds = get_period_bounds(
+            freq, &period_unit, &min_year, &max_year
+        )
+
     for _ in range(n):
         # Analogous to: utc_val = stamps[i]
         utc_val = (<int64_t*>cnp.PyArray_MultiIter_DATA(mi, 1))[0]
@@ -412,7 +423,9 @@ def dt64arr_to_periodarr(
         else:
             local_val = info.utc_val_to_local_val(utc_val, &pos)
             pandas_datetime_to_datetimestruct(local_val, reso, &dts)
-            res_val = get_period_ordinal(&dts, freq)
+            if check_bounds and not min_year <= dts.year <= max_year:
+                check_dts_bounds(&dts, period_unit)
+            res_val = get_period_ordinal_unchecked(&dts, freq)
             if res_val == NPY_NAT:
                 # GH#66550 at nanosecond freq the ordinal *is* the local i8
                 #  value, so a local time on the sentinel would be stored as NaT

--- a/pandas/tests/indexes/datetimes/methods/test_to_period.py
+++ b/pandas/tests/indexes/datetimes/methods/test_to_period.py
@@ -7,6 +7,7 @@ import pytest
 from pandas._libs.tslibs.ccalendar import MONTHS
 from pandas._libs.tslibs.offsets import MonthEnd
 from pandas._libs.tslibs.period import INVALID_FREQ_ERR_MSG
+from pandas.errors import OutOfBoundsDatetime
 
 from pandas import (
     DatetimeIndex,
@@ -209,6 +210,14 @@ class TestToPeriod:
         assert 2 == len(period)
         assert period[0] == Period("2007-01-01 10:11:12.123Z", "ms")
         assert period[1] == Period("2007-01-01 10:11:13.789Z", "ms")
+
+    def test_to_period_out_of_bounds_ordinal(self):
+        # GH#64158 the nanosecond ordinal overflows int64 for these dates; the
+        #  overflow used to be swallowed, giving 1970 epoch periods
+        dti = date_range("2300-01-01", periods=2, freq="D", unit="s")
+        msg = "Out of bounds nanosecond timestamp: 2300-01-01"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            dti.to_period("ns")
 
     def test_to_period_microsecond(self):
         index = DatetimeIndex(

--- a/pandas/tests/indexes/datetimes/methods/test_tz_convert.py
+++ b/pandas/tests/indexes/datetimes/methods/test_tz_convert.py
@@ -383,21 +383,23 @@ def dti_local_on_sentinel():
 
 
 @pytest.mark.parametrize(
-    "func",
+    "func, msg",
     [
-        lambda dti: dti.tz_localize(None),
-        lambda dti: dti.year,
-        lambda dti: dti.floor("D"),
-        lambda dti: dti.to_period("ns"),
+        (lambda dti: dti.tz_localize(None), "underflows past"),
+        (lambda dti: dti.year, "underflows past"),
+        (lambda dti: dti.floor("D"), "underflows past"),
+        # to_period rejects the wall time as out of bounds for the frequency
+        #  before it gets as far as an ordinal
+        (lambda dti: dti.to_period("ns"), "Out of bounds nanosecond timestamp"),
     ],
     ids=["tz_localize", "year", "floor", "to_period_ns"],
 )
 @pytest.mark.filterwarnings("ignore:Converting to PeriodArray:UserWarning")
-def test_dti_local_on_sentinel_raises_where_stored(dti_local_on_sentinel, func):
+def test_dti_local_on_sentinel_raises_where_stored(dti_local_on_sentinel, func, msg):
     # GH#66550 the wall time is fine to render, but these consumers store it in
     #  an i8 buffer where the sentinel reads back as NaT -- tz_localize(None) and
     #  to_period("ns") silently returned NaT, and the field accessors returned -1.
-    with pytest.raises(OutOfBoundsDatetime, match="underflows past"):
+    with pytest.raises(OutOfBoundsDatetime, match=msg):
         func(dti_local_on_sentinel)
 
 

--- a/pandas/tests/indexes/period/test_constructors.py
+++ b/pandas/tests/indexes/period/test_constructors.py
@@ -434,6 +434,19 @@ class TestPeriodIndex:
                 result = PeriodIndex(np.array([val], dtype=np.int64), freq="Y")
             assert result.asi8[0] == val - 1970
 
+    @pytest.mark.filterwarnings(
+        "ignore:Passing integer data:pandas.errors.Pandas4Warning"
+    )
+    @pytest.mark.parametrize("dtype", [np.int64, object])
+    def test_constructor_int_array_out_of_bounds_ordinal(self, dtype):
+        # GH#64158 year 2300 is representable at most freqs but its nanosecond
+        #  ordinal overflows int64; the overflow used to be swallowed, giving
+        #  a 1970 epoch entry in the middle of valid ones
+        arr = np.array([2000, 2300, 2001], dtype=dtype)
+        msg = "Out of bounds nanosecond timestamp: 2300-01-01"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            PeriodIndex(arr, freq="ns")
+
     @pytest.mark.parametrize("box", [None, "series", "index"])
     def test_constructor_datetime64arr_ok(self, box):
         # https://github.com/pandas-dev/pandas/issues/23438

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -174,6 +174,37 @@ class TestPeriodConstruction:
         rt2 = per2.to_timestamp()
         assert rt2.asm8 == dt64
 
+    @pytest.mark.parametrize(
+        "freq",
+        ["Y", "Q-DEC", "M", "W-SUN", "D", "h", "min", "s", "ms", "us", "ns"],
+    )
+    @pytest.mark.parametrize(
+        "year", [2**31 - 1, -(2**31), 300000, -300000, 9999, 2263, 1677]
+    )
+    def test_construction_extreme_years_never_silent(self, freq, year):
+        # GH#64158 an ordinal that overflows int64 used to come back as 0,
+        #  i.e. a 1970 period, instead of raising
+        try:
+            per = Period(year=year, month=1, day=1, freq=freq)
+        except (OutOfBoundsDatetime, OverflowError):
+            return
+        assert per.year == year
+
+    @pytest.mark.parametrize("value", ["2300-01-01", "1600-01-01"])
+    def test_construction_out_of_bounds_ordinal(self, value):
+        # GH#64158 the ordinal overflows int64 at nanosecond freq; the C
+        #  conversion detected it but the error was swallowed, so we got a
+        #  1970 epoch Period instead
+        msg = f"Out of bounds nanosecond timestamp: {value}"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            Period(value, freq="ns")
+
+    def test_construction_out_of_bounds_ordinal_from_fields(self):
+        # GH#64158 same, for the year/month/day keywords
+        msg = "Out of bounds microsecond timestamp: 300000-01-01"
+        with pytest.raises(OutOfBoundsDatetime, match=msg):
+            Period(year=300000, month=1, day=1, freq="us")
+
     @pytest.mark.parametrize("freq", ["ms", "us", "ns"])
     def test_construction_from_min_timestamp(self, freq):
         # GH-63278


### PR DESCRIPTION
`get_period_ordinal` is `noexcept`, so the `OverflowError` that `np_datetime.c` raises for an ordinal that does not fit in int64 was discarded — Cython printed `Exception ignored in: 'pandas._libs.tslibs.period.get_period_ordinal'` to stderr — and ordinal 0 was returned in its place:

```python
>>> pd.Period("2300-01-01", freq="ns")
Period('1970-01-01 00:00:00.000000000', 'ns')

>>> pd.PeriodIndex(["2000-01-01", "2300-01-01", "2001-01-01"], freq="ns").asi8
array([946684800000000000,                  0, 978307200000000000])

>>> pd.date_range("2300-01-01", periods=2, freq="D", unit="s").to_period("ns")
PeriodIndex(['1970-01-01 00:00:00.000000000', '1970-01-01 00:00:00.000000000'], dtype='period[ns]')
```

All three now raise `OutOfBoundsDatetime`. Found while working through the follow-up on GH-66248, whose int32 year guard covers a different half of the same problem.

Validating before converting rather than propagating the error out of the conversion: making it `except? -1 nogil` costs ~50% on `PeriodIndex(integer_array)` and ~30% on `to_period`, which is more than this is worth. `get_period_ordinal` is now the validating one, so the obvious name is the safe one; the raw conversion is `get_period_ordinal_unchecked` and is only called where the bounds have already been established. Whether a freq is fine enough to overflow at all, and which years are in bounds whatever the rest of the date is, depend only on the freq, so `from_calendar_ordinals` and `dt64arr_to_periodarr` hoist that out of their loops and pay one year comparison per element; only the boundary years take the full `check_dts_bounds`. On 1M values:

| | main | PR |
|---|---|---|
| `PeriodIndex(int_array, freq="D")` | 6.6 ms | 6.5 ms |
| `to_period("M")` | 12.1 ms | 13.0 ms |
| `to_period("D")` | 14.8 ms | 15.2 ms |
| `to_period("s")` | 16.3 ms | 16.7 ms |
| `to_period("ns")` | 18.2 ms | 18.3 ms |

Two notes on the diff:

- `period_ordinal` never initialized `dts.as` — harmless while nothing read it, but the bounds check does, so it needs a `memset` (Cython cannot name an `as` field).
- The GH-66550 test for `to_period("ns")` on a wall time sitting exactly on the NaT sentinel now gets `Out of bounds nanosecond timestamp` instead of `underflows past`: the value is rejected as out of bounds for the freq before it reaches an ordinal. Still `OutOfBoundsDatetime`, so the guarantee that test was written for holds.
