### PR TITLE
BUG: assert_*_equal ignored rtol/atol for interval dtype

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -440,6 +440,7 @@ Bug fixes
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :class:`Series` where empty frozensets were formatted incorrectly (:issue:`66192`)
 - Fixed bug in :func:`testing.assert_frame_equal`, :func:`testing.assert_index_equal`, :func:`testing.assert_series_equal` and :func:`testing.assert_extension_array_equal` where ``rtol`` and ``atol`` were applied after casting to ``float64``, so integers above ``2**53`` could compare equal while differing by more than the tolerance, or unequal while within it (:issue:`66400`)
+- Fixed bug in :func:`testing.assert_frame_equal`, :func:`testing.assert_index_equal`, :func:`testing.assert_series_equal` and :func:`testing.assert_extension_array_equal` where ``rtol`` and ``atol`` were ignored for interval dtype, so the interval endpoints were always compared exactly; ``check_exact=True`` is also now honored for extension dtypes, which it previously was not (:issue:`43913`)
 - Fixed bug in :func:`testing.assert_series_equal` showing a misleading class mismatch message when Series values were backed by different :class:`numpy.ndarray` subclasses (:issue:`65770`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
 

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -19,6 +19,8 @@ from pandas._libs.util cimport (
 )
 
 
+from pandas._libs.interval import Interval
+
 from pandas.core.dtypes.missing import array_equivalent
 
 
@@ -222,6 +224,15 @@ cpdef assert_almost_equal(a, b,
         if not cmath.isclose(a, b, rel_tol=rtol, abs_tol=atol):
             assert False, (f"expected {b:.5f} but got {a:.5f}, "
                            f"with rtol={rtol}, atol={atol}")
+        return True
+
+    if isinstance(a, Interval) and isinstance(b, Interval):
+        # GH#43913 the tolerance applies to the endpoints; the closed side is
+        #  not numeric and has to match exactly
+        if a.closed != b.closed:
+            raise AssertionError(f"{a} != {b}")
+        assert_almost_equal(a.left, b.left, rtol=rtol, atol=atol)
+        assert_almost_equal(a.right, b.right, rtol=rtol, atol=atol)
         return True
 
     raise AssertionError(f"{a} != {b}")

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -431,6 +431,9 @@ def assert_index_equal(
         assert_interval_array_equal(
             cast("IntervalArray", left._values),
             cast("IntervalArray", right._values),
+            check_exact=check_exact,
+            rtol=rtol,
+            atol=atol,
         )
 
     # freq is not preserved by sorting, so when check_order=False the freqs
@@ -640,6 +643,10 @@ def assert_interval_array_equal(
     right: IntervalArray,
     exact: bool | Literal["equiv"] = "equiv",
     obj: str = "IntervalArray",
+    *,
+    check_exact: bool = True,
+    rtol: float = 1.0e-5,
+    atol: float = 1.0e-8,
 ) -> None:
     """
     Test that two IntervalArrays are equivalent.
@@ -655,11 +662,27 @@ def assert_interval_array_equal(
     obj : str, default 'IntervalArray'
         Specify object name being compared, internally used to show appropriate
         assertion message
+    check_exact : bool, default True
+        Whether to compare the endpoints exactly.
+    rtol : float, default 1e-5
+        Relative tolerance. Only used when check_exact is False.
+    atol : float, default 1e-8
+        Absolute tolerance. Only used when check_exact is False.
     """
     _check_isinstance(left, right, IntervalArray)
 
-    assert_equal(left._left, right._left, obj=f"{obj}.left")
-    assert_equal(left._right, right._right, obj=f"{obj}.right")
+    if check_exact or left._left.dtype.kind not in "iuf":
+        # a tolerance is only meaningful for numeric endpoints, and the
+        #  datetimelike comparison additionally checks tz/freq
+        assert_equal(left._left, right._left, obj=f"{obj}.left")
+        assert_equal(left._right, right._right, obj=f"{obj}.right")
+    else:
+        assert_almost_equal(
+            left._left, right._left, rtol=rtol, atol=atol, obj=f"{obj}.left"
+        )
+        assert_almost_equal(
+            left._right, right._right, rtol=rtol, atol=atol, obj=f"{obj}.right"
+        )
 
     assert_attr_equal("closed", left, right, obj=obj)
 
@@ -1172,6 +1195,7 @@ def assert_series_equal(
                 left_values,
                 right_values,
                 check_dtype=check_dtype,
+                check_exact=check_exact,
                 index_values=left.index,
                 obj=str(obj),
             )
@@ -1209,7 +1233,11 @@ def assert_series_equal(
         right.dtype, IntervalDtype
     ):
         assert_interval_array_equal(
-            cast("IntervalArray", left.array), cast("IntervalArray", right.array)
+            cast("IntervalArray", left.array),
+            cast("IntervalArray", right.array),
+            check_exact=False,
+            rtol=rtol,
+            atol=atol,
         )
     elif isinstance(left.dtype, CategoricalDtype) or isinstance(
         right.dtype, CategoricalDtype

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -6,6 +6,7 @@ from pandas import (
     array,
 )
 import pandas._testing as tm
+from pandas.arrays import IntervalArray
 from pandas.core.arrays.sparse import SparseArray
 
 
@@ -123,3 +124,16 @@ def test_assert_extension_array_equal_time_units():
 
     tm.assert_extension_array_equal(naive, utc, check_dtype=False)
     tm.assert_extension_array_equal(utc, naive, check_dtype=False)
+
+
+def test_assert_extension_array_equal_interval_tolerance():
+    # GH#43913 rtol/atol were not propagated to interval dtype
+    arr1 = IntervalArray.from_tuples([(1.0, 2.0)])
+    arr2 = IntervalArray.from_tuples([(1.0000000000001, 2.0)])
+
+    tm.assert_extension_array_equal(arr1, arr2, check_exact=False, rtol=10.0, atol=10.0)
+
+    with pytest.raises(AssertionError, match="ExtensionArray are different"):
+        tm.assert_extension_array_equal(
+            arr1, arr2, check_exact=False, rtol=0, atol=1e-14
+        )

--- a/pandas/tests/util/test_assert_frame_equal.py
+++ b/pandas/tests/util/test_assert_frame_equal.py
@@ -491,3 +491,14 @@ def test_assert_frame_equal_check_like_check_freq():
     df = DataFrame({"a": [1, 2, 3]}, index=idx)
     with tm.assert_produces_warning(None):
         tm.assert_frame_equal(df.iloc[[2, 0, 1]], df, check_like=True)
+
+
+def test_frame_equal_interval_dtype_tolerance():
+    # GH#43913 rtol/atol were not propagated to interval dtype
+    df1 = DataFrame({0: pd.arrays.IntervalArray.from_tuples([(1.0, 2.0)])})
+    df2 = DataFrame({0: pd.arrays.IntervalArray.from_tuples([(1.0000000000001, 2.0)])})
+
+    tm.assert_frame_equal(df1, df2, check_exact=False, rtol=10.0, atol=10.0)
+
+    with pytest.raises(AssertionError, match="IntervalArray.left are different"):
+        tm.assert_frame_equal(df1, df2, check_exact=False, rtol=0, atol=1e-14)

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -8,6 +8,7 @@ from pandas import (
     Categorical,
     CategoricalIndex,
     Index,
+    IntervalIndex,
     MultiIndex,
     NaT,
     RangeIndex,
@@ -385,3 +386,14 @@ def test_assert_index_equal_check_freq_check_order_false(box, start):
     with tm.assert_produces_warning(None):
         tm.assert_index_equal(shuffled, idx, check_order=False)
         tm.assert_index_equal(shuffled, idx, check_order=False, check_freq=True)
+
+
+def test_index_equal_interval_dtype_tolerance():
+    # GH#43913 rtol/atol were not propagated to interval dtype
+    idx1 = IntervalIndex.from_tuples([(1.0, 2.0)])
+    idx2 = IntervalIndex.from_tuples([(1.0000000000001, 2.0)])
+
+    tm.assert_index_equal(idx1, idx2, check_exact=False, rtol=10.0, atol=10.0)
+
+    with pytest.raises(AssertionError, match="Index are different"):
+        tm.assert_index_equal(idx1, idx2, check_exact=False, rtol=0, atol=1e-14)

--- a/pandas/tests/util/test_assert_interval_array_equal.py
+++ b/pandas/tests/util/test_assert_interval_array_equal.py
@@ -2,6 +2,7 @@ import pytest
 
 from pandas import (
     Interval,
+    Timestamp,
     interval_range,
 )
 import pandas._testing as tm
@@ -98,3 +99,61 @@ IntervalArray.right values are different \\(50.0 %\\)
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_interval_array_equal(arr1, arr2)
+
+
+def test_interval_array_equal_tolerance():
+    # GH#43913 check_exact=False must apply rtol/atol to the endpoints
+    arr1 = IntervalArray.from_tuples([(1.0, 2.0)])
+    arr2 = IntervalArray.from_tuples([(1.0000000000001, 2.0)])
+
+    tm.assert_interval_array_equal(arr1, arr2, check_exact=False, rtol=10.0, atol=10.0)
+
+
+def test_interval_array_equal_tolerance_exceeded():
+    # GH#43913 a difference larger than the tolerance must still be reported
+    arr1 = IntervalArray.from_tuples([(1.0, 2.0)])
+    arr2 = IntervalArray.from_tuples([(1.5, 2.0)])
+
+    msg = "IntervalArray.left are different"
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_interval_array_equal(
+            arr1, arr2, check_exact=False, rtol=0, atol=1e-14
+        )
+
+
+def test_interval_array_equal_check_exact_default():
+    # GH#43913 the default stays exact, so a tiny difference is still reported
+    arr1 = IntervalArray.from_tuples([(1.0, 2.0)])
+    arr2 = IntervalArray.from_tuples([(1.0000000000001, 2.0)])
+
+    msg = "IntervalArray.left are different"
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_interval_array_equal(arr1, arr2)
+
+
+def test_interval_array_equal_tolerance_closed_mismatch():
+    # GH#43913 closed is not numeric, a tolerance must not make it match
+    arr1 = IntervalArray.from_tuples([(1.0, 2.0)], closed="left")
+    arr2 = IntervalArray.from_tuples([(1.0, 2.0)], closed="right")
+
+    msg = 'Attribute "closed" are different'
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_interval_array_equal(
+            arr1, arr2, check_exact=False, rtol=10.0, atol=10.0
+        )
+
+
+def test_interval_array_equal_tolerance_datetimelike():
+    # GH#43913 datetimelike endpoints keep the exact comparison
+    arr1 = IntervalArray.from_tuples([(Timestamp("2020-01-01"), Timestamp("2021"))])
+    arr2 = IntervalArray.from_tuples([(Timestamp("2020-01-02"), Timestamp("2021"))])
+
+    msg = "IntervalArray.left._ndarray are different"
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_interval_array_equal(
+            arr1, arr2, check_exact=False, rtol=10.0, atol=10.0
+        )

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -597,3 +597,14 @@ def test_assert_series_equal_check_index_false_ignores_freq():
     right = Series([1, 2, 3], index=idx._with_freq(None))
     with tm.assert_produces_warning(None):
         tm.assert_series_equal(left, right, check_index=False)
+
+
+def test_series_equal_interval_dtype_tolerance():
+    # GH#43913 rtol/atol were not propagated to interval dtype
+    ser1 = Series(pd.arrays.IntervalArray.from_tuples([(1.0, 2.0)]))
+    ser2 = Series(pd.arrays.IntervalArray.from_tuples([(1.0000000000001, 2.0)]))
+
+    tm.assert_series_equal(ser1, ser2, check_exact=False, rtol=10.0, atol=10.0)
+
+    with pytest.raises(AssertionError, match="IntervalArray.left are different"):
+        tm.assert_series_equal(ser1, ser2, check_exact=False, rtol=0, atol=1e-14)


### PR DESCRIPTION
- [x] closes #43913
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests)
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html).

`assert_interval_array_equal` never took `rtol`/`atol`, so it compared the interval
endpoints with `assert_equal`, which is exact, and the callers that do have tolerances
in scope had nothing to pass them to. It now takes `check_exact`/`rtol`/`atol` like the
other asserters, which is what was suggested in #47947. Endpoints that aren't numeric
keep the exact path so the tz check on datetimelike intervals isn't lost, and `closed`
still has to match exactly.

The Index and ExtensionArray paths don't reach that function at all. They compare
`Interval` scalars in `_libs/testing.pyx`, which had no branch for them and fell through
to the final raise, so I added one. That covers object-dtype arrays holding Intervals too.

Worth flagging separately: `assert_series_equal` wasn't forwarding `check_exact` to
`assert_extension_array_equal`, which resolves its own default from the dtype. Every
extension dtype it was previously reached with resolved to the same value, so it never
showed; interval dtype resolves it to False, so `check_exact=True` was silently compared
with the default tolerance. I've forwarded it here because otherwise this PR turns that
case from failing into passing, but it is really its own bug (`Float64` with
`check_exact=True` passes on main today) and I'm happy to split it into a separate PR if
you'd prefer.

Checked the reproducer from the issue against a clean build of main and against this
branch, along with negative controls (differences beyond the tolerance, `closed`
mismatch, datetimelike intervals, plain floats) to confirm the change doesn't just make
comparisons pass. The new tests all fail on main without the source change.

Developed with Claude Code (claude opus 5); I reviewed and tested the change locally.
