### PR TITLE
DOC: add redirect for moved copy-on-write migration guide

### DIFF
--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -38,8 +38,8 @@ visualization,user_guide/visualization
 10min,user_guide/10min
 basics,user_guide/basics
 dsintro,user_guide/dsintro
-user_guide/migration-3-strings,user_guide/migration
-user_guide/copy_on_write,user_guide/migration
+user_guide/migration-3-strings,migration
+user_guide/copy_on_write,migration
 
 # development
 contributing,development/contributing

--- a/doc/redirects.csv
+++ b/doc/redirects.csv
@@ -39,6 +39,7 @@ visualization,user_guide/visualization
 basics,user_guide/basics
 dsintro,user_guide/dsintro
 user_guide/migration-3-strings,user_guide/migration
+user_guide/copy_on_write,user_guide/migration
 
 # development
 contributing,development/contributing


### PR DESCRIPTION
Same as https://github.com/pandas-dev/pandas/pull/64684 but for the copy-on-write page (moved in https://github.com/pandas-dev/pandas/pull/63971).

This should fix the short-term issue that the link in the docstring is currently wrong, related to https://github.com/pandas-dev/pandas/pull/66599