### PR TITLE
DEV: add default envs for common pixi tasks

### DIFF
--- a/.github/workflows/docbuild-and-upload.yml
+++ b/.github/workflows/docbuild-and-upload.yml
@@ -98,28 +98,23 @@ jobs:
     - name: Test website
       run: |
         pixi run \
-          --environment docs-and-web \
           ci-test-website
 
     - name: Test build single page doc
       run: |
         pixi run \
-          --environment docs-and-web \
           ci-test-single-page-doc pandas.Series.value_counts
         pixi run \
-          --environment docs-and-web \
           ci-test-single-page-doc pandas.Series.str.split
 
     - name: Test nbconvert doc notebooks
       run: |
         pixi run \
-          --environment docs-and-web \
           ci-test-nbconvert-doc-notebooks "$(find doc/source -name '*.ipynb')"
 
     - name: Build website
       run: |
         pixi run \
-          --environment docs-and-web \
           ci-build-website
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -127,20 +122,17 @@ jobs:
     - name: Build documentation
       run: |
         pixi run \
-          --environment docs-and-web \
           ci-build-documentation \
           html
 
     - name: Build the interactive terminal
       run: |
         pixi run \
-          --environment docs-and-web \
           ci-build-interactive_terminal
 
     - name: Build documentation zip
       run: |
         pixi run \
-          --environment docs-and-web \
           ci-build-documentation \
           zip_html
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -288,6 +288,7 @@ cmd = [
   "manual",
   "--all-files",
 ]
+default-environment = "typing"
 
 [tasks.ci-scripts-tests]
 cmd = [
@@ -368,6 +369,7 @@ cmd = [
   "--warnings-are-errors",
   "{{ doc_type }}",
 ]
+default-environment = "docs-and-web"
 
 [tasks.ci-test-website]
 cmd = [
@@ -394,3 +396,4 @@ cmd = [
   "build",
 ]
 cwd = "web/interactive_terminal/"
+default-environment = "docs-and-web"

--- a/pixi.toml
+++ b/pixi.toml
@@ -324,6 +324,7 @@ cmd = [
   "--python=same",
   "--show-stderr",
 ]
+default-environment = "asv"
 
 [tasks.ci-test-single-page-doc]
 args = [
@@ -341,6 +342,7 @@ cmd = [
   "doc/make.py",
   "clean",
 ]
+default-environment = "docs-and-web"
 
 [tasks.ci-test-nbconvert-doc-notebooks]
 args = [
@@ -358,6 +360,7 @@ cmd = [
   "--stdout",
   ">/dev/null",
 ]
+default-environment = "docs-and-web"
 
 [tasks.ci-build-documentation]
 args = [
@@ -378,6 +381,7 @@ cmd = [
   "pytest",
   "web",
 ]
+default-environment = "docs-and-web"
 
 [tasks.ci-build-website]
 cmd = [
@@ -386,6 +390,7 @@ cmd = [
   "web/pandas",
   "--target-path=web/build",
 ]
+default-environment = "docs-and-web"
 
 [tasks.ci-build-interactive_terminal]
 cmd = [


### PR DESCRIPTION
When using pixi locally to e.g. run the type checks or build the documentation, it is a bit more convenient that the tasks defines a default environment, to avoid having to specify it each time.

cc @mroeschke I added it now to a few tasks that I have used locally, but I could also just add it to every task (where it makes sense, probably all except build and test)?