### PR TITLE
BUG: coerce empty-string IEEE NaN to null for pyarrow floats

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -649,6 +649,7 @@ Missing
 - Bug in :meth:`DataFrame.fillna` with a dict value raising ``RecursionError`` when columns are a :class:`MultiIndex` with duplicate entries (:issue:`53498`)
 - Bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` with ``method`` in ``"index"``, ``"values"`` or ``"time"`` raising when the index had an :class:`ArrowDtype` timestamp or duration dtype; these now match the equivalent :class:`DatetimeIndex` or :class:`TimedeltaIndex` (:issue:`66338`)
 - Bug in :meth:`Series.combine_first` crashing when Series names are :class:`Timestamp` objects (:issue:`65333`)
+- Bug in :class:`ArrowExtensionArray` where empty strings converted to a floating PyArrow dtype stored IEEE ``NaN`` instead of null, so :meth:`Series.fillna` did not fill them (e.g. empty CSV fields with ``dtype="double[pyarrow]"`` and ``keep_default_na=False``)
 
 MultiIndex
 ^^^^^^^^^^

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -514,6 +514,12 @@ class ArrowExtensionArray(
                 scalars = strings.cast(pa_type)
             else:
                 mask = isna(strings)
+                if (
+                    is_nan_na()
+                    and isinstance(scalars, np.ndarray)
+                    and np.issubdtype(scalars.dtype, np.floating)
+                ):
+                    mask = np.asarray(mask, dtype=np.bool_) | np.isnan(scalars)
                 if mask is not None:
                     scalars = pa.array(scalars, mask=mask, type=pa_type)
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -3562,6 +3562,20 @@ def test_from_sequence_of_strings_boolean():
         ArrowExtensionArray._from_sequence_of_strings(strings, dtype=dtype)
 
 
+def test_from_sequence_of_strings_empty_string_float(using_nan_is_na):
+    strings = ["1.5", "", "2.0"]
+    dtype = ArrowDtype(pa.float64())
+    result = ArrowExtensionArray._from_sequence_of_strings(strings, dtype=dtype)
+    if using_nan_is_na:
+        expected = ArrowExtensionArray(pa.array([1.5, None, 2.0], type=pa.float64()))
+        tm.assert_extension_array_equal(result, expected)
+        filled = pd.Series(result, dtype=dtype).fillna(0)
+        tm.assert_series_equal(filled, pd.Series([1.5, 0.0, 2.0], dtype=dtype))
+    else:
+        assert not result.isna().any()
+        assert np.isnan(result.to_numpy(dtype="float64")[1])
+
+
 def test_concat_empty_arrow_backed_series(dtype):
     # GH#51734
     ser = pd.Series([], dtype=dtype)


### PR DESCRIPTION
- [x] closeshttps://github.com/pandas-dev/pandas/issues/66834
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
