### PR TITLE
DOC: Remove See Also entries pointing at non-existent methods

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -18169,7 +18169,6 @@ class DataFrame(NDFrame, OpsMixin):
         DataFrame.min : Return the minimum over
             DataFrame axis.
         DataFrame.cummax : Return cumulative maximum over DataFrame axis.
-        DataFrame.cummin : Return cumulative minimum over DataFrame axis.
         DataFrame.cumsum : Return cumulative sum over DataFrame axis.
         DataFrame.cumprod : Return cumulative product over DataFrame axis.
 
@@ -18277,7 +18276,6 @@ class DataFrame(NDFrame, OpsMixin):
             but ignores ``NaN`` values.
         DataFrame.max : Return the maximum over
             DataFrame axis.
-        DataFrame.cummax : Return cumulative maximum over DataFrame axis.
         DataFrame.cummin : Return cumulative minimum over DataFrame axis.
         DataFrame.cumsum : Return cumulative sum over DataFrame axis.
         DataFrame.cumprod : Return cumulative product over DataFrame axis.
@@ -18388,7 +18386,6 @@ class DataFrame(NDFrame, OpsMixin):
             DataFrame axis.
         DataFrame.cummax : Return cumulative maximum over DataFrame axis.
         DataFrame.cummin : Return cumulative minimum over DataFrame axis.
-        DataFrame.cumsum : Return cumulative sum over DataFrame axis.
         DataFrame.cumprod : Return cumulative product over DataFrame axis.
 
         Examples
@@ -18491,14 +18488,11 @@ class DataFrame(NDFrame, OpsMixin):
 
         See Also
         --------
-        core.window.expanding.Expanding.prod : Similar functionality
-            but ignores ``NaN`` values.
         DataFrame.prod : Return the product over
             DataFrame axis.
         DataFrame.cummax : Return cumulative maximum over DataFrame axis.
         DataFrame.cummin : Return cumulative minimum over DataFrame axis.
         DataFrame.cumsum : Return cumulative sum over DataFrame axis.
-        DataFrame.cumprod : Return cumulative product over DataFrame axis.
 
         Examples
         --------

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -9188,8 +9188,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         See Also
         --------
         between_time : Select values between particular times of the day.
-        first : Select initial periods of time series based on a date offset.
-        last : Select final periods of time series based on a date offset.
         DatetimeIndex.indexer_at_time : Get just the index locations for
             values at particular time of the day.
 
@@ -9260,8 +9258,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         See Also
         --------
         at_time : Select values at a particular time of the day.
-        first : Select initial periods of time series based on a date offset.
-        last : Select final periods of time series based on a date offset.
         DatetimeIndex.indexer_between_time : Get just the index locations for
             values between particular times of the day.
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -10164,8 +10164,6 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         See Also
         --------
-        core.window.expanding.Expanding.prod : Similar functionality
-            but ignores ``NaN`` values.
         Series.prod : Return the product over Series.
         Series.cummax : Return cumulative maximum.
         Series.cummin : Return cumulative minimum.


### PR DESCRIPTION
Four docstrings cite `See Also` targets that do not exist, so the links do not resolve:

- `at_time` and `between_time` cite `first`/`last`, both removed in 3.0. The only surviving `first`/`last` in the API are the groupby/rolling/resample ones, which mean something else entirely ("first row of group"), so there is nothing to redirect to — the lines just go.
- `Series.cumprod` and `DataFrame.cumprod` cite `core.window.expanding.Expanding.prod`, which was never implemented. Before the docstring inlining in GH-63619 / GH-63625, these blocks came from a `make_doc` template whose See Also read ``core.window.expanding.Expanding.{accum_func_name}``, building the target from the accumulator name — so `cumsum` -> `Expanding.sum` resolves while `cumprod` -> `Expanding.prod` never did. (`Rolling.prod` was proposed in GH-48134 and never merged; `Expanding.prod` was never proposed.)

That same template listed the whole `cum*` family in every block, so `DataFrame.cummin`/`cummax`/`cumsum`/`cumprod` each link to themselves. Their `Series` counterparts list the family minus self, so this matches them up.

Verified with `numpydoc.validate.validate` on each touched docstring — no new errors, and no `SA`/`GL` errors remain.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which swept all 1973 documented API objects for unresolvable and self-referencing See Also targets and made the deletions; every target was confirmed absent via `hasattr` and git history before removal.