### PR TITLE
BUG: Parse GMT as UTC regardless of system timezone (GH#66827)

### DIFF
--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -744,16 +744,17 @@ cdef datetime dateutil_parse(
             "not supported"
         )
     if not ignoretz:
-        if res.tzname and res.tzname in time.tzname:
-            # GH#50791
-            if res.tzname != "UTC":
-                raise ValueError(
-                    f"Parsing '{res.tzname}' as tzlocal (dependent on system timezone) "
-                    "is no longer supported. Pass the 'tz' "
-                    "keyword or call tz_localize after construction instead",
-                )
-            ret = ret.replace(tzinfo=timezone.utc)
-        elif res.tzoffset == 0:
+        if res.tzoffset == 0:
+            # GH#66827 - unambiguous zero offset (UTC, GMT, Z, z)
+            ret = ret.replace(tzinfo=_dateutil_tzutc())
+        elif res.tzname and res.tzname in time.tzname:
+            # GH#50791 - system-dependent timezone abbreviation
+            raise ValueError(
+                f"Parsing '{res.tzname}' as tzlocal (dependent on system timezone) "
+                "is no longer supported. Pass the 'tz' "
+                "keyword or call tz_localize after construction instead",
+            )
+        elif res.tzoffset:
             ret = ret.replace(tzinfo=_dateutil_tzutc())
         elif res.tzoffset:
             ret = ret.replace(tzinfo=tzoffset(res.tzname, res.tzoffset))

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -755,8 +755,6 @@ cdef datetime dateutil_parse(
                 "keyword or call tz_localize after construction instead",
             )
         elif res.tzoffset:
-            ret = ret.replace(tzinfo=_dateutil_tzutc())
-        elif res.tzoffset:
             ret = ret.replace(tzinfo=tzoffset(res.tzname, res.tzoffset))
 
             # dateutil can return a datetime with a tzoffset outside of (-24h, 24h)

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -811,15 +811,16 @@ class TestTimestampConstructors:
         with pytest.raises(ValueError, match=msg):
             Timestamp("2023 Sept Thu")
 
-
     def test_gmt_parsed_as_utc_independent_of_system_tz(self):
         # GH#66827 - GMT should be parsed as UTC, not system-dependent tzlocal
         # dateutil's parserinfo.UTCZONE is ["UTC", "GMT", "Z", "z"]
         # and all four should be treated as unambiguous zero-offset
-        for ts_str in ["Wed, 15 Jan 2020 08:30:00 GMT",
-                       "Wed, 15 Jan 2020 08:30:00 UTC",
-                       "Wed, 15 Jan 2020 08:30:00 Z",
-                       "Wed, 15 Jan 2020 08:30:00 z"]:
+        for ts_str in [
+            "Wed, 15 Jan 2020 08:30:00 GMT",
+            "Wed, 15 Jan 2020 08:30:00 UTC",
+            "Wed, 15 Jan 2020 08:30:00 Z",
+            "Wed, 15 Jan 2020 08:30:00 z",
+        ]:
             ts = Timestamp(ts_str)
             assert ts.tz is not None, f"{ts_str} should have tz"
             assert ts.utcoffset() == timedelta(0), f"{ts_str} should be UTC"

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -811,6 +811,19 @@ class TestTimestampConstructors:
         with pytest.raises(ValueError, match=msg):
             Timestamp("2023 Sept Thu")
 
+
+    def test_gmt_parsed_as_utc_independent_of_system_tz(self):
+        # GH#66827 - GMT should be parsed as UTC, not system-dependent tzlocal
+        # dateutil's parserinfo.UTCZONE is ["UTC", "GMT", "Z", "z"]
+        # and all four should be treated as unambiguous zero-offset
+        for ts_str in ["Wed, 15 Jan 2020 08:30:00 GMT",
+                       "Wed, 15 Jan 2020 08:30:00 UTC",
+                       "Wed, 15 Jan 2020 08:30:00 Z",
+                       "Wed, 15 Jan 2020 08:30:00 z"]:
+            ts = Timestamp(ts_str)
+            assert ts.tz is not None, f"{ts_str} should have tz"
+            assert ts.utcoffset() == timedelta(0), f"{ts_str} should be UTC"
+
     def test_construct_from_string_invalid_raises(self):
         # dateutil (weirdly) parses "200622-12-31" as
         #  datetime(2022, 6, 20, 12, 0, tzinfo=tzoffset(None, -111600)


### PR DESCRIPTION
**Issue:** GH#66827

**Problem:** `dateutil_parse` checks `res.tzname in time.tzname` before checking `res.tzoffset == 0`. When the system timezone is set to a locale whose name is "GMT" (e.g. `Europe/London`, `Africa/Abidjan`), parsing a string like `"Wed, 15 Jan 2020 08:30:00 GMT"` raises a `ValueError` because "GMT" is not in the carve-out list (which only had "UTC").

**Fix:** Reorder the branches so the unambiguous `res.tzoffset == 0` check runs first. This catches UTC, GMT, Z, and z (all four members of dateutil's `parserinfo.UTCZONE` which validate to `tzoffset=0`) before the system-dependent `tzname` check. The `tzlocal` raise no longer needs a carve-out list.

**Changes:**
1. `pandas/_libs/tslibs/parsing.pyx` — reorder the tzoffset/tzname branch order
2. `pandas/tests/scalar/timestamp/test_constructors.py` — add regression test parametrized over UTC/GMT/Z/z

AI disclosure: Fix based on analysis in GH#66827 issue body.