### PR TITLE
BUG: Timedelta silently ignored AM/PM in strings (GH#18793)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -212,6 +212,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Other API changes
 ^^^^^^^^^^^^^^^^^
 - :attr:`Index.values` and :attr:`Index.array` now return read-only arrays for all dtypes, so an :class:`Index` can no longer be silently corrupted by mutating the returned array in place (previously this left the Index displaying the new value while lookups still used the old one) (:issue:`38547`)
+- :class:`Timedelta` and :func:`to_timedelta` now raise on strings with trailing characters after an ``hh:mm:ss`` field, such as the AM/PM marker in ``"3:25:00 PM"``. Previously those characters were silently discarded, so ``"3:25:00 PM"`` parsed as three hours rather than fifteen (:issue:`18793`)
 - :func:`infer_freq` on quarter-start data now reports the equivalent anchor from the first calendar quarter, e.g. ``QS-JAN`` instead of ``QS-OCT`` (:issue:`36939`)
 - :func:`testing.assert_frame_equal` with ``check_freq=True`` now also checks the ``freq`` of :class:`DatetimeIndex` and :class:`TimedeltaIndex` *columns*; previously only the ``freq`` of the index was checked (:issue:`51920`)
 - :func:`testing.assert_series_equal` with ``check_index=False`` no longer checks the ``freq`` attribute of a :class:`DatetimeIndex` or :class:`TimedeltaIndex`, as ``freq`` is an attribute of the index (:issue:`51920`)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -762,16 +762,13 @@ cdef int64_t parse_timedelta_string(
         if current_unit != "m":
             raise ValueError("expected hh:mm:ss format")
         if len(unit):
-            # trailing characters after the seconds field, e.g. the "AM" in
-            #  "3:25:00 AM".  Silently ignoring these means "3:25:00 PM"
+            # trailing characters after the seconds field, e.g. the "PM" in
+            #  "3:25:00 PM".  Silently ignoring these means "3:25:00 PM"
             #  parses as three hours rather than fifteen (GH#18793).
             leftover = "".join(unit)
-            if leftover.upper() in ("AM", "PM"):
-                raise ValueError(
-                    f"AM/PM is not supported by Timedelta, received: {ts}"
-                )
             raise ValueError(
-                f"unexpected characters after hh:mm:ss format, received: {ts}"
+                f"unexpected characters, {leftover}, after hh:mm:ss format, "
+                f"received: {ts}"
             )
         m = 1000000000
         r = <int64_t>int("".join(number)) * m

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -761,6 +761,18 @@ cdef int64_t parse_timedelta_string(
     elif current_unit is not None:
         if current_unit != "m":
             raise ValueError("expected hh:mm:ss format")
+        if len(unit):
+            # trailing characters after the seconds field, e.g. the "AM" in
+            #  "3:25:00 AM".  Silently ignoring these means "3:25:00 PM"
+            #  parses as three hours rather than fifteen (GH#18793).
+            leftover = "".join(unit)
+            if leftover.upper() in ("AM", "PM"):
+                raise ValueError(
+                    f"AM/PM is not supported by Timedelta, received: {ts}"
+                )
+            raise ValueError(
+                f"unexpected characters after hh:mm:ss format, received: {ts}"
+            )
         m = 1000000000
         r = <int64_t>int("".join(number)) * m
         result += timedelta_as_neg(r, neg)

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -877,12 +877,21 @@ def test_timedelta_resolution_consistent_arg_styles():
 
 
 @pytest.mark.parametrize(
-    "value", ["3:25:00 AM", "3:25:00 pm", "1 days 12:30:00 PM", "3:25:00.5 AM"]
+    "value, leftover",
+    [
+        ("3:25:00 AM", "AM"),
+        ("3:25:00 pm", "pm"),
+        ("1 days 12:30:00 PM", "PM"),
+        ("3:25:00.5 AM", "AM"),
+        ("3:25:00 foo", "foo"),
+        ("3:25:00xyz", "xyz"),
+        ("3:25:00 A", "A"),
+    ],
 )
-def test_construction_am_pm_raises(value):
-    # GH#18793 AM/PM used to be silently dropped, so that "3:25:00 PM"
-    #  parsed the same as "3:25:00"
-    msg = f"AM/PM is not supported by Timedelta, received: {value}"
+def test_construction_trailing_characters_raises(value, leftover):
+    # GH#18793 trailing characters after hh:mm:ss used to be silently dropped,
+    #  so that "3:25:00 PM" parsed the same as "3:25:00"
+    msg = f"unexpected characters, {leftover}, after hh:mm:ss format, received: {value}"
     with pytest.raises(ValueError, match=re.escape(msg)):
         Timedelta(value)
 
@@ -891,11 +900,3 @@ def test_construction_am_pm_raises(value):
 
     result = to_timedelta([value], errors="coerce")
     tm.assert_index_equal(result, TimedeltaIndex([NaT]))
-
-
-@pytest.mark.parametrize("value", ["3:25:00 foo", "3:25:00xyz", "3:25:00 A"])
-def test_construction_trailing_characters_raises(value):
-    # GH#18793 trailing characters after hh:mm:ss used to be silently dropped
-    msg = f"unexpected characters after hh:mm:ss format, received: {value}"
-    with pytest.raises(ValueError, match=re.escape(msg)):
-        Timedelta(value)

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from itertools import product
+import re
 
 import numpy as np
 import pytest
@@ -873,3 +874,28 @@ def test_timedelta_resolution_consistent_arg_styles():
     td_keyword = Timedelta(seconds=1 / 128)
     assert td_positional == td_keyword
     assert td_positional.unit == td_keyword.unit
+
+
+@pytest.mark.parametrize(
+    "value", ["3:25:00 AM", "3:25:00 pm", "1 days 12:30:00 PM", "3:25:00.5 AM"]
+)
+def test_construction_am_pm_raises(value):
+    # GH#18793 AM/PM used to be silently dropped, so that "3:25:00 PM"
+    #  parsed the same as "3:25:00"
+    msg = f"AM/PM is not supported by Timedelta, received: {value}"
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        Timedelta(value)
+
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        to_timedelta([value])
+
+    result = to_timedelta([value], errors="coerce")
+    tm.assert_index_equal(result, TimedeltaIndex([NaT]))
+
+
+@pytest.mark.parametrize("value", ["3:25:00 foo", "3:25:00xyz", "3:25:00 A"])
+def test_construction_trailing_characters_raises(value):
+    # GH#18793 trailing characters after hh:mm:ss used to be silently dropped
+    msg = f"unexpected characters after hh:mm:ss format, received: {value}"
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        Timedelta(value)


### PR DESCRIPTION
closes #18793

`parse_timedelta_string` consumed only the numeric field of a trailing `hh:mm:ss` component and silently discarded whatever characters followed it, so an AM/PM marker changed nothing:

```python
>>> pd.Timedelta("3:25:00 PM")
Timedelta("0 days 03:25:00")   # three hours, not fifteen
>>> pd.Timedelta("3:25:00 foo")
Timedelta("0 days 03:25:00")
```

Every other exit branch of the parser validates the accumulated unit characters, so this was the one path where garbage was dropped rather than reported. It now raises, naming the characters it could not interpret:

```python
>>> pd.Timedelta("3:25:00 PM")
ValueError: unexpected characters, PM, after hh:mm:ss format, received: 3:25:00 PM
```

This also replaces the confusing `invalid literal for int() with base 10: ""` that `Timedelta("3:25:00.5 AM")` raised.

Raising (rather than supporting 12-hour parsing) is what the issue settled on.

Not included, and flagged for a separate PR: `pandas.core.tools.times.to_time` — reachable via `at_time`/`between_time` and Arrow `time64` string casting — only accepts AM/PM with no preceding space (`"%I:%M:%S%p"`), so the issue's exact `"3:25:00 AM"` still fails to parse there.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the parser branch, wrote the fix and tests, and ran the test sweep.
