### PR TITLE
ENH: to_time support a space before AM/PM (GH#18793)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -52,6 +52,7 @@ Other enhancements
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
 - Improved type inference of comparison and arithmetic operators on :class:`Series` and :class:`DataFrame` for static type checkers (e.g. ``ser == "a"`` is now inferred as :class:`Series` instead of ``Any``) (:issue:`40762`)
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)
+- Time strings with a space before ``AM``/``PM`` (e.g. ``"3:25:00 PM"``) are now recognized; :meth:`Series.between_time` and :meth:`DataFrame.between_time` previously raised on them, and :meth:`Series.at_time` and :meth:`DataFrame.at_time` warned that they would raise in a future version. Casting such strings to a pyarrow time dtype (``time32``/``time64``) no longer silently gives a missing value (:issue:`18793`)
 - Building from source no longer fails when compiling the windowing extensions against C++ standard libraries that provide only ``std::signbit`` (:issue:`50979`, :issue:`51047`)
 - Setting values with :meth:`DataFrame.at` or :meth:`Series.at` using a non-scalar indexer (e.g. a boolean mask, list, or array) now raises a clearer ``InvalidIndexError`` directing users to ``.loc`` (:issue:`51866`)
 

--- a/pandas/core/tools/times.py
+++ b/pandas/core/tools/times.py
@@ -28,8 +28,8 @@ def to_time(
 ):
     """
     Parse time strings to time objects using fixed strptime formats ("%H:%M",
-    "%H%M", "%I:%M%p", "%I%M%p", "%H:%M:%S", "%H%M%S", "%I:%M:%S%p",
-    "%I%M%S%p")
+    "%H%M", "%I:%M%p", "%I:%M %p", "%I%M%p", "%I%M %p", "%H:%M:%S", "%H%M%S",
+    "%I:%M:%S%p", "%I:%M:%S %p", "%I%M%S%p", "%I%M%S %p")
 
     Use infer_time_format if all the strings are in the same format to speed
     up conversion.
@@ -130,11 +130,15 @@ _time_formats = [
     "%H:%M",
     "%H%M",
     "%I:%M%p",
+    "%I:%M %p",
     "%I%M%p",
+    "%I%M %p",
     "%H:%M:%S",
     "%H%M%S",
     "%I:%M:%S%p",
+    "%I:%M:%S %p",
     "%I%M%S%p",
+    "%I%M%S %p",
 ]
 
 

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -48,6 +48,7 @@ from pandas.errors import (
     OutOfBoundsTimedelta,
     Pandas4Warning,
 )
+import pandas.util._test_decorators as td
 
 from pandas.core.dtypes.common import pandas_dtype
 from pandas.core.dtypes.dtypes import (
@@ -4693,6 +4694,15 @@ def test_string_to_time_parsing_cast():
     expected = pd.Series(
         ArrowExtensionArray(pa.array([time(11, 41, 43, 76160)], from_pandas=True))
     )
+    tm.assert_series_equal(result, expected)
+
+
+@td.skip_if_not_us_locale
+@pytest.mark.parametrize("dtype", ["time32[s][pyarrow]", "time64[us][pyarrow]"])
+def test_string_to_time_parsing_cast_meridiem(dtype):
+    # GH#18793 the space before AM/PM used to make these coerce to null
+    result = pd.Series(["3:25:00 PM"], dtype=dtype)
+    expected = pd.Series(["15:25:00"], dtype=dtype)
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/frame/methods/test_between_time.py
+++ b/pandas/tests/frame/methods/test_between_time.py
@@ -225,3 +225,14 @@ class TestBetweenTime:
         msg = "Inclusive has to be either 'both', 'neither', 'left' or 'right'"
         with pytest.raises(ValueError, match=msg):
             ts.between_time(stime, etime, inclusive=inclusive)
+
+
+@td.skip_if_not_us_locale
+def test_between_time_space_before_meridiem():
+    # GH#18793 the space before AM/PM used to make these unparsable
+    index = date_range("2012-01-01", periods=48, freq="h")
+    df = DataFrame({"A": range(len(index))}, index=index)
+
+    result = df.between_time("3:00 PM", "5:00 PM")
+    expected = df.between_time(time(15, 0), time(17, 0))
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/tools/test_to_time.py
+++ b/pandas/tests/tools/test_to_time.py
@@ -22,12 +22,24 @@ class TestToTime:
             "141500",
             pytest.param("2:15:00pm", marks=td.skip_if_not_us_locale),
             pytest.param("021500pm", marks=td.skip_if_not_us_locale),
+            pytest.param("2:15 pm", marks=td.skip_if_not_us_locale),
+            pytest.param("0215 pm", marks=td.skip_if_not_us_locale),
+            pytest.param("2:15:00 pm", marks=td.skip_if_not_us_locale),
+            pytest.param("021500 pm", marks=td.skip_if_not_us_locale),
             time(14, 15),
         ],
     )
     def test_parsers_time(self, time_string):
         # GH#11818
         assert to_time(time_string) == time(14, 15)
+
+    @td.skip_if_not_us_locale
+    def test_parsers_time_space_before_meridiem(self):
+        # GH#18793 the space before AM/PM used to make these unparsable
+        arg = ["3:25:00 AM", "3:25:00 PM", "12:30:00 AM", "12:30:00 PM"]
+        expected = [time(3, 25), time(15, 25), time(0, 30), time(12, 30)]
+        assert to_time(arg) == expected
+        assert to_time(arg, infer_time_format=True) == expected
 
     def test_odd_format(self):
         new_string = "14.15"


### PR DESCRIPTION
Addresses the `to_time` half of GH-18793 (the `Timedelta` half, where the agreed resolution is to raise, is being handled separately).

`strptime` maps whitespace in a format string to `\s+`, so the existing `"%I:%M:%S%p"` family only ever matched `"3:25:00PM"` — never the `"3:25:00 PM"` spelling in the OP's data. This adds the four space-separated variants to `_time_formats`, each next to its no-space sibling. There is no ambiguity with the 24-hour formats, which do not accept a meridiem token, so nothing that parsed before changes meaning.

Three public surfaces reach `to_time`, all previously broken on these strings:

| surface | before |
| --- | --- |
| `Series`/`DataFrame`/`DatetimeIndex.between_time` | raised `ValueError` |
| `Series`/`DataFrame`/`DatetimeIndex.at_time` | `Pandas4Warning` + dateutil fallback |
| string cast to a pyarrow `time32`/`time64` dtype | silently `<NA>` |

The arrow branch gates on `pa.types.is_time`, so `time32[s]`, `time32[ms]`, `time64[us]`, and `time64[ns]` are all affected.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the `strptime` whitespace behavior, wrote the format additions and tests, and verified the pre-fix behavior of each affected surface.