### PR TITLE
CI: Don't label approved PRs and block /take on Needs Info and Closing Candidate

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -9,10 +9,9 @@ env:
   DOCS_URL: https://pandas.pydata.org/docs/dev/development/contributing.html#issue-assignment-and-the-pull-request-lifecycle
   TAKE_BLOCKED: >-
     Thanks for your interest, @{user}! This issue is still labeled
-    `{blocking}`, which means a maintainer needs to review it before work
-    starts — so it isn't open to claim just yet. Please hold off on a PR
-    until that label is removed. See the [contributing guide]({docs}) for
-    more.
+    `{blocking}`, which means it needs another look before work starts — so
+    it isn't open to claim just yet. Please hold off on a PR until that
+    label is removed. See the [contributing guide]({docs}) for more.
   TAKE_ALREADY_YOURS: >-
     You already have this one, @{user} — it's assigned to you and you're all
     set to work on it.
@@ -66,7 +65,8 @@ jobs:
             const user = context.payload.comment.user.login;
             const labels = issue.labels.map(label => typeof label === 'string' ? label : label.name);
             const assignees = issue.assignees.map(assignee => assignee.login);
-            const blocking = ['Needs Triage', 'Needs Discussion'].find(label => labels.includes(label));
+            const blocking = ['Needs Triage', 'Needs Discussion', 'Needs Info', 'Closing Candidate']
+              .find(label => labels.includes(label));
             const comment = body => github.rest.issues.createComment({
               owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, body,
             });

--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -69,8 +69,9 @@ If you are brand new to pandas or open-source development, we recommend searchin
 the `GitHub "issues" tab <https://github.com/pandas-dev/pandas/issues>`_
 to find issues that interest you and are available to work on. Issues available to work on are:
 
-* Issues without the label ``Needs Triage`` or ``Needs Discussion``. These issues require clarification and confirmation
-  from a maintainer before proceeding.
+* Issues without the labels ``Needs Triage``, ``Needs Discussion``, ``Needs Info``,
+  or ``Closing Candidate``. These issues require clarification or confirmation from
+  a maintainer before proceeding.
 * Issues that are not already assigned to another contributor.
 
 Once you've found an interesting, available issue, claim it by commenting ``/take``
@@ -113,8 +114,9 @@ The bot will assign the issue to you.
 
 An issue is available to claim if it is:
 
-* **not** labeled ``Needs Triage`` or ``Needs Discussion`` — these still need a
-  maintainer's review before work begins, and ``/take`` will be declined; and
+* **not** labeled ``Needs Triage``, ``Needs Discussion``, ``Needs Info``, or
+  ``Closing Candidate`` — these still need attention from a maintainer or the
+  reporter before work begins, and ``/take`` will be declined; and
 * **not** already assigned to someone else.
 
 If you change your mind, comment ``/untake`` to release the issue so others can

--- a/scripts/issue_assignment/client.py
+++ b/scripts/issue_assignment/client.py
@@ -89,6 +89,7 @@ query($owner: String!, $name: String!, $cursor: String) {
         ) {
           nodes { ... on ReviewRequestedEvent { createdAt actor { login } } }
         }
+        pendingReviewRequests: reviewRequests(first: 1) { totalCount }
         labelEvents: timelineItems(last: 50, itemTypes: [LABELED_EVENT]) {
           nodes {
             ... on LabeledEvent { createdAt actor { login } label { name } }
@@ -234,6 +235,9 @@ class GitHubClient:
                     "author_association": node.get("authorAssociation"),
                     "reviews": reviews,
                     "review_requests": review_requests,
+                    "has_pending_review_requests": (
+                        node["pendingReviewRequests"]["totalCount"] > 0
+                    ),
                     "last_commit_at": last_commit_at,
                     "comments": comments,
                     "comments_truncated": node["comments"]["totalCount"]

--- a/scripts/issue_assignment/core.py
+++ b/scripts/issue_assignment/core.py
@@ -107,8 +107,8 @@ def _current_stances(
 ) -> dict[str | None, tuple[datetime, str | None]]:
     """Each maintainer reviewer's current stance, keyed by reviewer login.
 
-    Only an ``OWNER``/``MEMBER`` review counts; a drive-by verdict from an
-    outside account doesn't move the ball. A reviewer's stance is their newest
+    Only an ``OWNER``/``MEMBER`` review counts; a review from any other
+    account is ignored. A reviewer's stance is their newest
     ``APPROVED``/``CHANGES_REQUESTED``/``DISMISSED`` review — later
     ``COMMENTED`` reviews leave the previous verdict standing, while a
     dismissal (which rewrites the review's state to ``DISMISSED`` in place)

--- a/scripts/issue_assignment/core.py
+++ b/scripts/issue_assignment/core.py
@@ -30,7 +30,12 @@ REVIEW_BLOCKING_ASSOCIATIONS = {"OWNER", "MEMBER"}
 # Review states that express a reviewer's standing verdict on the PR;
 # COMMENTED and PENDING reviews leave their previous verdict in place.
 STANCE_REVIEW_STATES = {"APPROVED", "CHANGES_REQUESTED", "DISMISSED"}
-BLOCKING_LABELS = ("Needs Triage", "Needs Discussion")
+BLOCKING_LABELS = (
+    "Needs Triage",
+    "Needs Discussion",
+    "Needs Info",
+    "Closing Candidate",
+)
 
 GATE_LABEL = "Needs Issue Assignment"
 AWAITING_REVIEW_LABEL = "Awaiting Review"
@@ -75,6 +80,7 @@ class OpenPRState(TypedDict):
     author_association: str | None
     reviews: list[Review]
     review_requests: list[ReviewRequest]
+    has_pending_review_requests: bool
     last_commit_at: datetime | None
     comments: list[Comment]
     comments_truncated: bool
@@ -96,15 +102,17 @@ def is_exempt(author_association: str | None, author_is_bot: bool) -> bool:
     return bool(author_is_bot) or (author_association or "") in EXEMPT_ASSOCIATIONS
 
 
-def outstanding_changes_requested_at(reviews: list[Review]) -> datetime | None:
-    """Newest maintainer changes-request that is still outstanding, or ``None``.
+def _current_stances(
+    reviews: list[Review],
+) -> dict[str | None, tuple[datetime, str | None]]:
+    """Each maintainer reviewer's current stance, keyed by reviewer login.
 
-    Only an ``OWNER``/``MEMBER`` review moves the ball into the contributor's
-    court; a drive-by "request changes" from an outside account doesn't count.
-    A changes-request is outstanding only while it is that reviewer's *current
-    stance*: their own later ``APPROVED`` (or a dismissal, which rewrites the
-    review's state to ``DISMISSED``) supersedes it, while ``COMMENTED`` reviews
-    leave it standing. Another reviewer's approval does not clear it.
+    Only an ``OWNER``/``MEMBER`` review counts; a drive-by verdict from an
+    outside account doesn't move the ball. A reviewer's stance is their newest
+    ``APPROVED``/``CHANGES_REQUESTED``/``DISMISSED`` review — later
+    ``COMMENTED`` reviews leave the previous verdict standing, while a
+    dismissal (which rewrites the review's state to ``DISMISSED`` in place)
+    withdraws it.
     """
     stances: dict[str | None, tuple[datetime, str | None]] = {}
     for r in reviews:
@@ -117,8 +125,40 @@ def outstanding_changes_requested_at(reviews: list[Review]) -> datetime | None:
             current = stances.get(r.get("author"))
             if current is None or submitted > current[0]:
                 stances[r.get("author")] = (submitted, r.get("state"))
-    times = [t for t, state in stances.values() if state == "CHANGES_REQUESTED"]
+    return stances
+
+
+def outstanding_changes_requested_at(reviews: list[Review]) -> datetime | None:
+    """Newest maintainer changes-request that is still outstanding, or ``None``.
+
+    A changes-request is outstanding only while it is that reviewer's *current
+    stance* (see :func:`_current_stances`): their own later ``APPROVED`` or a
+    dismissal supersedes it. Another reviewer's approval does not clear it.
+    """
+    times = [
+        submitted
+        for submitted, state in _current_stances(reviews).values()
+        if state == "CHANGES_REQUESTED"
+    ]
     return max(times) if times else None
+
+
+def all_reviewers_approved(
+    reviews: list[Review], has_pending_review_requests: bool
+) -> bool:
+    """True when the PR is fully approved and awaiting merge rather than review.
+
+    Fully approved means every standing maintainer verdict (see
+    :func:`_current_stances`) is an approval — with at least one — and no
+    review request is pending. A pending request is a review someone was asked
+    for and hasn't given, so one approval among several requested reviewers
+    isn't full approval. A ``DISMISSED`` stance is a withdrawn verdict and
+    neither satisfies nor blocks this.
+    """
+    if has_pending_review_requests:
+        return False
+    states = {state for _, state in _current_stances(reviews).values()}
+    return "APPROVED" in states and "CHANGES_REQUESTED" not in states
 
 
 def latest_review_submitted_at(
@@ -196,9 +236,14 @@ def should_label_awaiting_review(
     is_draft: bool,
     changes_requested_at: datetime | None,
     rereview_requested_at: datetime | None,
+    fully_approved: bool,
 ) -> bool:
-    """An open, non-draft PR with the ball in the maintainers' court."""
-    if not is_open or is_draft:
+    """An open, non-draft PR with the ball in the maintainers' court.
+
+    A fully approved PR (see :func:`all_reviewers_approved`) is awaiting merge,
+    not review, so it drops out even though the ball is with the maintainers.
+    """
+    if not is_open or is_draft or fully_approved:
         return False
     return not awaiting_contributor(changes_requested_at, rereview_requested_at)
 

--- a/scripts/issue_assignment/label_awaiting_review.py
+++ b/scripts/issue_assignment/label_awaiting_review.py
@@ -2,9 +2,12 @@
 
 Run once a day from the scheduled maintenance job (folded in to share a single
 runner boot rather than firing on every push). The label is informational: it
-flags PRs sitting in the maintainers' court. (The matching state — not the label
-— is what exempts a PR from the stale engine in ``unassign_inactive``.) Exempt
-authors and gated PRs are skipped. Lagging reality by up to a day is harmless
+flags PRs sitting in the maintainers' court and awaiting a *review* — a fully
+approved PR (every standing maintainer verdict an approval, no review request
+pending) is awaiting merge instead and drops the label. (The
+awaiting-contributor state — not the label — is what exempts a PR from the
+stale engine in ``unassign_inactive``.) Exempt authors and gated PRs are
+skipped. Lagging reality by up to a day is harmless
 against the 14-day stale window; current labels are read alongside the review
 state so PRs already in the right state cost no write request.
 """
@@ -46,10 +49,17 @@ def reconcile_all(client: SupportsLabelReconcile) -> None:
         rereview_requested_at = core.latest_rereview_request_at(
             pr["review_requests"], contributors
         )
+        fully_approved = core.all_reviewers_approved(
+            pr["reviews"], pr["has_pending_review_requests"]
+        )
         want = core.GATE_LABEL not in pr[
             "labels"
         ] and core.should_label_awaiting_review(
-            True, pr["is_draft"], changes_requested_at, rereview_requested_at
+            True,
+            pr["is_draft"],
+            changes_requested_at,
+            rereview_requested_at,
+            fully_approved,
         )
         has = label in pr["labels"]
         if want and not has:

--- a/scripts/tests/test_issue_assignment.py
+++ b/scripts/tests/test_issue_assignment.py
@@ -73,16 +73,28 @@ class TestAwaitingContributor:
 
 class TestShouldLabelAwaitingReview:
     def test_open_no_review(self) -> None:
-        assert core.should_label_awaiting_review(True, False, None, dt(1)) is True
+        assert (
+            core.should_label_awaiting_review(True, False, None, dt(1), False) is True
+        )
 
     def test_open_awaiting_contributor(self) -> None:
-        assert core.should_label_awaiting_review(True, False, dt(1), dt(3)) is False
+        assert (
+            core.should_label_awaiting_review(True, False, dt(1), dt(3), False) is False
+        )
 
     def test_draft_never_labeled(self) -> None:
-        assert core.should_label_awaiting_review(True, True, None, dt(1)) is False
+        assert (
+            core.should_label_awaiting_review(True, True, None, dt(1), False) is False
+        )
 
     def test_closed_never_labeled(self) -> None:
-        assert core.should_label_awaiting_review(False, False, None, dt(1)) is False
+        assert (
+            core.should_label_awaiting_review(False, False, None, dt(1), False) is False
+        )
+
+    def test_fully_approved_not_labeled(self) -> None:
+        # Awaiting merge, not review.
+        assert core.should_label_awaiting_review(True, False, None, None, True) is False
 
 
 class TestOutstandingChangesRequested:
@@ -148,6 +160,62 @@ class TestOutstandingChangesRequested:
             review("CHANGES_REQUESTED", 2),
         ]
         assert core.outstanding_changes_requested_at(reviews) == dt(2)
+
+
+class TestAllReviewersApproved:
+    def test_single_approval(self) -> None:
+        assert core.all_reviewers_approved([review("APPROVED", 1)], False) is True
+
+    def test_no_reviews(self) -> None:
+        assert core.all_reviewers_approved([], False) is False
+
+    def test_pending_request_blocks(self) -> None:
+        # One approval while another reviewer's request is still pending
+        # leaves the PR awaiting review, not merge.
+        assert core.all_reviewers_approved([review("APPROVED", 1)], True) is False
+
+    def test_outstanding_changes_request_blocks(self) -> None:
+        reviews: list[core.Review] = [
+            review("CHANGES_REQUESTED", 3, author="alpha"),
+            review("APPROVED", 1, author="beta"),
+        ]
+        assert core.all_reviewers_approved(reviews, False) is False
+
+    def test_own_approval_supersedes_changes_request(self) -> None:
+        reviews: list[core.Review] = [
+            review("CHANGES_REQUESTED", 3),
+            review("APPROVED", 1),
+        ]
+        assert core.all_reviewers_approved(reviews, False) is True
+
+    def test_later_changes_request_supersedes_approval(self) -> None:
+        reviews: list[core.Review] = [
+            review("APPROVED", 3),
+            review("CHANGES_REQUESTED", 1),
+        ]
+        assert core.all_reviewers_approved(reviews, False) is False
+
+    def test_outsider_approval_does_not_count(self) -> None:
+        reviews: list[core.Review] = [
+            review("APPROVED", 1, association="NONE", author="alice")
+        ]
+        assert core.all_reviewers_approved(reviews, False) is False
+
+    def test_dismissed_verdict_is_withdrawn(self) -> None:
+        # A dismissed stance neither satisfies nor blocks full approval.
+        assert core.all_reviewers_approved([review("DISMISSED", 1)], False) is False
+        reviews: list[core.Review] = [
+            review("DISMISSED", 3, author="alpha"),
+            review("APPROVED", 1, author="beta"),
+        ]
+        assert core.all_reviewers_approved(reviews, False) is True
+
+    def test_comment_review_leaves_approval_standing(self) -> None:
+        reviews: list[core.Review] = [
+            review("APPROVED", 3),
+            review("COMMENTED", 1),
+        ]
+        assert core.all_reviewers_approved(reviews, False) is True
 
 
 class TestLatestSelectors:
@@ -432,6 +500,7 @@ def pr(
     author_association: str | None = "NONE",
     reviews: list[core.Review] | None = None,
     review_requests: list[core.ReviewRequest] | None = None,
+    has_pending_review_requests: bool = False,
     last_commit_at: datetime | None = None,
     comments: list[core.Comment] | None = None,
     comments_truncated: bool = False,
@@ -446,6 +515,7 @@ def pr(
         "author_association": author_association,
         "reviews": reviews if reviews is not None else [],
         "review_requests": review_requests if review_requests is not None else [],
+        "has_pending_review_requests": has_pending_review_requests,
         "last_commit_at": last_commit_at,
         "comments": comments if comments is not None else [],
         "comments_truncated": comments_truncated,
@@ -555,6 +625,58 @@ class TestReconcileAll:
         label_awaiting_review.reconcile_all(client)
         assert client.added == []
         assert client.removed == []
+
+    def test_approved_pr_loses_label(self) -> None:
+        # Fully approved -> awaiting merge; a manual label removal must not
+        # be reverted by the nightly reconcile (GH#65029).
+        client = FakeClient([pr(9, reviews=[review("APPROVED", 1)], labels=[AWAITING])])
+        label_awaiting_review.reconcile_all(client)
+        assert client.removed == [(9, AWAITING)]
+        assert client.added == []
+
+    def test_approved_pr_not_relabeled(self) -> None:
+        client = FakeClient([pr(10, reviews=[review("APPROVED", 1)])])
+        label_awaiting_review.reconcile_all(client)
+        assert client.added == []
+        assert client.removed == []
+
+    def test_approval_with_pending_request_stays_labeled(self) -> None:
+        # Another reviewer's review is still requested, so the PR is not
+        # fully approved and remains awaiting review.
+        client = FakeClient(
+            [
+                pr(
+                    11,
+                    reviews=[review("APPROVED", 1)],
+                    has_pending_review_requests=True,
+                    labels=[AWAITING],
+                )
+            ]
+        )
+        label_awaiting_review.reconcile_all(client)
+        assert client.added == []
+        assert client.removed == []
+
+    def test_approval_beside_changes_request_stays_awaiting_contributor(
+        self,
+    ) -> None:
+        # One reviewer approved, another still has changes requested: the
+        # ball stays with the contributor, so no Awaiting Review label.
+        client = FakeClient(
+            [
+                pr(
+                    12,
+                    reviews=[
+                        review("CHANGES_REQUESTED", 3, author="alpha"),
+                        review("APPROVED", 1, author="beta"),
+                    ],
+                    labels=[AWAITING],
+                )
+            ]
+        )
+        label_awaiting_review.reconcile_all(client)
+        assert client.removed == [(12, AWAITING)]
+        assert client.added == []
 
 
 STALE = core.STALE_LABEL


### PR DESCRIPTION
Written by Claude Fable 5, reviewed by me.

Fixes e.g. https://github.com/pandas-dev/pandas/pull/65029 where an approved PR was labeled by the bot.