### PR TITLE
DOC: fix conf.py process_class_docstrings to remove null listings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1030,20 +1030,28 @@ def process_class_docstrings(app, what, name, obj, options, lines) -> None:
         joined = "\n".join(lines)
 
         templates = [
-            """.. rubric:: Attributes
-
-.. autosummary::
-   :toctree:
-
-   None
-""",
-            """.. rubric:: Methods
-
-.. autosummary::
-   :toctree:
-
-   None
-""",
+            "\n".join(  # noqa: FLY002
+                [
+                    ".. rubric:: Attributes",
+                    "",
+                    "",
+                    "",
+                    "========  ==========",
+                    "**None**    ",
+                    "========  ==========",
+                ]
+            ),
+            "\n".join(  # noqa: FLY002
+                [
+                    ".. rubric:: Methods",
+                    "",
+                    "",
+                    "",
+                    "========  ==========",
+                    "**None**    ",
+                    "========  ==========",
+                ]
+            ),
         ]
 
         for template in templates:


### PR DESCRIPTION
The fix from https://github.com/pandas-dev/pandas/pull/19949 has not worked for a while because the exact generated content by numpydoc has changed. This fixes that to work for the current versions in our docs-and-web env.

(noticed while using this trick for the Offset API pages in https://github.com/pandas-dev/pandas/pull/66846)