### PR TITLE
CLN: remove class-level dateutil import in Easter offset

### DIFF
--- a/pandas/_libs/tslibs/offsets.pyx
+++ b/pandas/_libs/tslibs/offsets.pyx
@@ -2,8 +2,6 @@ import re
 import time
 import warnings
 
-from pandas.util._exceptions import find_stack_level
-
 cimport cython
 from cpython.datetime cimport (
     PyDate_Check,
@@ -33,6 +31,8 @@ cnp.import_array()
 # TODO: formalize having _libs.properties "above" tslibs in the dependency structure
 
 from typing import ClassVar
+
+from dateutil.easter import EASTER_WESTERN
 
 from pandas._libs.properties import cache_readonly
 
@@ -6588,8 +6588,6 @@ cdef class Easter(SingleConstructorOffset):
 
     cdef readonly:
         int method
-
-    from dateutil.easter import EASTER_WESTERN
 
     def __init__(self, n=1, normalize=False, method=EASTER_WESTERN):
         BaseOffset.__init__(self, n, normalize)


### PR DESCRIPTION
This was added in https://github.com/pandas-dev/pandas/pull/61666, and by putting the import inside the class like that, this causes it to become an attribute on the Easter class (noticed while refactoring how we document all the BaseOffset subclass attributes)