### PR TITLE
DOC: force C locale when building the docs

### DIFF
--- a/doc/make.py
+++ b/doc/make.py
@@ -148,7 +148,12 @@ class DocBuilder:
             SOURCE_PATH,
             os.path.join(BUILD_PATH, kind),
         ]
-        return subprocess.call(cmd)
+        # sphinx-build calls locale.setlocale(locale.LC_ALL, '') on startup,
+        # which adopts the system locale. We force the C locale here to ensure
+        # doc examples relying on C locale formatting (e.g. date/number formatting)
+        # build consistently regardless of the local machine.
+        env = {**os.environ, "LC_ALL": "C"}
+        return subprocess.call(cmd, env=env)
 
     def _open_browser(self, single_doc_html) -> None:
         """


### PR DESCRIPTION
Closes https://github.com/pandas-dev/pandas/issues/56740

Forcing the C locale to avoid sphinx setting the user system locale at startup of sphinx-build, and depending on your locale some of the examples in our docs might fail (resulting in a doc build failure).