### PR TITLE
BUG: year truncated to 32 bits in the datetime field accessors (GH#66549)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -225,6 +225,7 @@ Other API changes
 - :meth:`DataFrame.to_hdf` no longer writes a ``pandas_version`` attribute into the HDF5 file; the value was hardcoded to ``"0.15.2"`` and never reflected the pandas version. As a consequence, ``format="table"`` files written with pandas 3.1 or later cannot be read by pandas 3.0 or earlier (:issue:`62792`)
 - APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`64483`).
 - Removed the ``freq`` and ``freqstr`` attributes from :class:`.DatetimeArray` and :class:`.TimedeltaArray`. Frequency is now stored only on :class:`DatetimeIndex` and :class:`TimedeltaIndex`; access ``Series.dt.freq`` or wrap the array in an Index to retrieve a frequency. The ``check_freq`` keyword on :func:`testing.assert_extension_array_equal` for these array types has also been removed (:issue:`24566`).
+- The ``year`` column of :meth:`DatetimeIndex.isocalendar` and :meth:`Series.dt.isocalendar` is now ``Int32`` instead of ``UInt32``, so that years before year 1 are representable (:issue:`66549`)
 -
 
 .. _whatsnew_310.api_breaking.build:
@@ -465,6 +466,7 @@ Categorical
 
 Datetimelike
 ^^^^^^^^^^^^
+- Bug in :attr:`DatetimeIndex.year` and :attr:`Series.dt.year` silently returning a wrapped year, e.g. ``219250468`` for year ``292277026596``, for second-resolution datetimes with a year beyond ``2**31``; these now raise ``ValueError``, and :attr:`DatetimeIndex.is_leap_year` no longer takes the leap-year status from the wrapped year (:issue:`66549`)
 - Bug in :attr:`Timestamp.days_in_month`, and in month-end and business-day offsets, using a wrapped year to decide whether the year is a leap year, for second-resolution datetimes with a year beyond ``2**31`` (:issue:`66549`)
 - Bug in :class:`ArrowExtensionArray` where adding a :class:`DateOffset` to a ``date32[pyarrow]`` or ``date64[pyarrow]`` Series raised an ``ArrowTypeError`` (:issue:`57168`)
 - Bug in :class:`DatetimeIndex` constructor raising ``ValueError`` when passing equivalent but not equal frequencies (e.g. ``QS-FEB`` vs ``QS-MAY``) (:issue:`61086`)
@@ -494,11 +496,13 @@ Datetimelike
 - Bug in :meth:`DataFrame.to_string` and :meth:`Series.to_string` where ``na_rep`` was ignored for datetime and timedelta columns, always displaying ``NaT`` (:issue:`55426`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)
 - Bug in :meth:`DatetimeIndex.intersection` returning incorrect results when the two indexes had matching ``freq`` but did not lie on the same grid, e.g. ranges with the same business-day frequency but different time-of-day components (:issue:`44025`)
+- Bug in :meth:`DatetimeIndex.isocalendar` and :meth:`Series.dt.isocalendar` returning a wrapped year for dates before year 1, e.g. ``4294967196`` for year ``-100``; a year beyond ``2**31`` now raises ``ValueError`` instead of being silently truncated (:issue:`66549`)
 - Bug in :meth:`DatetimeIndex.tz_localize`, :meth:`Series.dt.tz_localize`, and the :class:`Timestamp` constructor with a timezone that observes DST, where a wall time whose shift to UTC lands exactly on the ``NaT`` sentinel read out of bounds and reported a spurious "nonexistent time" ``ValueError`` instead of raising :class:`OutOfBoundsDatetime` (:issue:`66550`)
 - Bug in :meth:`DatetimeIndex.union` and :meth:`TimedeltaIndex.union` with ``sort=False`` silently dropping values from the other index that fell after the end of ``self`` (:issue:`66322`)
 - Bug in :meth:`Series.dt.isocalendar` with a pyarrow-backed datetime or date dtype not preserving the original index, resetting it to a default :class:`RangeIndex` (:issue:`65894`)
 - Bug in :meth:`Series.dt.to_pydatetime` not preserving the original index and name (:issue:`66443`)
 - Bug in ``day_of_week``, :meth:`Timestamp.weekday` and :meth:`Timestamp.day_name` returning a wrong weekday, or raising ``OverflowError``, for second-resolution datetimes with a year beyond ``2**31`` (:issue:`66549`)
+- Bug in ``day_of_year`` and ``week``, on :class:`Timestamp` as well as on :class:`DatetimeIndex` and :class:`Series`, taking the leap-year status from a wrapped year for second-resolution datetimes with a year beyond ``2**31`` (:issue:`66549`)
 - Bug in adding a :class:`BusinessDay` offset to a :class:`DatetimeIndex` or :class:`Series` where an out-of-bounds result silently wrapped to an unrelated date, and a result landing exactly on the ``NaT`` sentinel came back as a missing value, instead of raising ``OverflowError`` (:issue:`66552`)
 - Bug in adding a :class:`BusinessDay` offset with ``n`` of magnitude ``2**31`` or more to a :class:`DatetimeIndex` or :class:`Series` silently shifting by a wrapped number of business days, e.g. ``n=2**32`` behaving like ``n=0`` (:issue:`66549`)
 - Bug in adding a :class:`DateOffset` to a :class:`DatetimeIndex` or :class:`Series` where a result landing exactly on the ``NaT`` sentinel came back as a missing value, and where promoting the values to the offset's finer resolution silently wrapped to an unrelated date, instead of raising as the equivalent :class:`Timedelta` operations already did (:issue:`66552`)

--- a/pandas/_libs/tslibs/ccalendar.pxd
+++ b/pandas/_libs/tslibs/ccalendar.pxd
@@ -4,14 +4,14 @@ from numpy cimport (
     int64_t,
 )
 
-ctypedef (int32_t, int32_t, int32_t) iso_calendar_t
+ctypedef (int64_t, int32_t, int32_t) iso_calendar_t
 
 cdef int dayofweek(int64_t y, int m, int d) noexcept nogil
 cdef bint is_leapyear(int64_t year) noexcept nogil
 cpdef int32_t get_days_in_month(int64_t year, Py_ssize_t month) noexcept nogil
-cpdef int32_t get_week_of_year(int year, int month, int day) noexcept nogil
-cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) noexcept nogil
-cpdef int32_t get_day_of_year(int year, int month, int day) noexcept nogil
+cpdef int32_t get_week_of_year(int64_t year, int month, int day) noexcept nogil
+cpdef iso_calendar_t get_iso_calendar(int64_t year, int month, int day) noexcept nogil
+cpdef int32_t get_day_of_year(int64_t year, int month, int day) noexcept nogil
 cpdef int get_lastbday(int64_t year, int month) noexcept nogil
 cpdef int get_firstbday(int64_t year, int month) noexcept nogil
 

--- a/pandas/_libs/tslibs/ccalendar.pyx
+++ b/pandas/_libs/tslibs/ccalendar.pyx
@@ -153,13 +153,13 @@ cdef bint is_leapyear(int64_t year) noexcept nogil:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef int32_t get_week_of_year(int year, int month, int day) noexcept nogil:
+cpdef int32_t get_week_of_year(int64_t year, int month, int day) noexcept nogil:
     """
     Return the ordinal week-of-year for the given day.
 
     Parameters
     ----------
-    year : int
+    year : int64_t
     month : int
     day : int
 
@@ -176,19 +176,19 @@ cpdef int32_t get_week_of_year(int year, int month, int day) noexcept nogil:
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) noexcept nogil:
+cpdef iso_calendar_t get_iso_calendar(int64_t year, int month, int day) noexcept nogil:
     """
     Return the year, week, and day of year corresponding to ISO 8601
 
     Parameters
     ----------
-    year : int
+    year : int64_t
     month : int
     day : int
 
     Returns
     -------
-    year : int32_t
+    year : int64_t
     week : int32_t
     day : int32_t
 
@@ -198,7 +198,8 @@ cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) noexcept nog
     """
     cdef:
         int32_t doy, dow
-        int32_t iso_year, iso_week
+        int32_t iso_week
+        int64_t iso_year
 
     doy = get_day_of_year(year, month, day)
     dow = dayofweek(year, month, day)
@@ -230,13 +231,13 @@ cpdef iso_calendar_t get_iso_calendar(int year, int month, int day) noexcept nog
 
 @cython.wraparound(False)
 @cython.boundscheck(False)
-cpdef int32_t get_day_of_year(int year, int month, int day) noexcept nogil:
+cpdef int32_t get_day_of_year(int64_t year, int month, int day) noexcept nogil:
     """
     Return the ordinal day-of-year for the given day.
 
     Parameters
     ----------
-    year : int
+    year : int64_t
     month : int
     day : int
 

--- a/pandas/_libs/tslibs/fields.pyi
+++ b/pandas/_libs/tslibs/fields.pyi
@@ -7,7 +7,7 @@ def build_field_sarray(
     reso: int,  # NPY_DATETIMEUNIT
 ) -> np.ndarray: ...
 def month_position_check(
-    fields: np.ndarray,  # structured ndarray with "Y", "M", "D" int32 fields
+    fields: np.ndarray,  # structured ndarray with int64 "Y", int32 "M"/"D" fields
     weekdays: npt.NDArray[np.integer],
 ) -> str | None: ...
 def get_date_name_field(

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -7,6 +7,10 @@ from locale import LC_TIME
 
 cimport cython
 from cython cimport Py_ssize_t
+from libc.stdint cimport (
+    INT32_MAX,
+    INT32_MIN,
+)
 
 import numpy as np
 
@@ -36,6 +40,7 @@ from pandas._libs.tslibs.ccalendar cimport (
     get_iso_calendar,
     get_lastbday,
     get_week_of_year,
+    is_leapyear,
     iso_calendar_t,
 )
 from pandas._libs.tslibs.dtypes cimport periods_per_day
@@ -63,10 +68,11 @@ def build_field_sarray(const int64_t[:] dtindex, NPY_DATETIMEUNIT reso):
     cdef:
         Py_ssize_t i, count = len(dtindex)
         npy_datetimestruct dts
-        ndarray[int32_t] years, months, days, hours, minutes, seconds, mus
+        ndarray[int64_t] years
+        ndarray[int32_t] months, days, hours, minutes, seconds, mus
 
     sa_dtype = [
-        ("Y", "i4"),  # year
+        ("Y", "i8"),  # year; int64 because it can exceed int32 at non-nano reso
         ("M", "i4"),  # month
         ("D", "i4"),  # day
         ("h", "i4"),  # hour
@@ -103,13 +109,14 @@ def build_field_sarray(const int64_t[:] dtindex, NPY_DATETIMEUNIT reso):
 def month_position_check(fields, weekdays) -> str | None:
     cdef:
         Py_ssize_t i, count
-        int32_t daysinmonth, y, m, d, wd
+        int32_t daysinmonth, m, d, wd
+        int64_t y
         bint calendar_end = True
         bint business_end = True
         bint calendar_start = True
         bint business_start = True
         bint cal
-        int32_t[:] years = fields["Y"]
+        int64_t[:] years = fields["Y"]
         int32_t[:] months = fields["M"]
         int32_t[:] days = fields["D"]
         int32_t[:] wdays = np.asarray(weekdays, dtype=np.int32)
@@ -361,8 +368,10 @@ def get_date_field(
     cdef:
         Py_ssize_t i, count = len(dtindex)
         ndarray[int32_t] out
+        ndarray[int8_t] out_bool
         npy_datetimestruct dts
         int64_t perday, perhour, permin, persec
+        int64_t bad_year = 0
 
     out = np.empty(count, dtype="i4")
     try:
@@ -385,7 +394,16 @@ def get_date_field(
                     )
                 else:
                     pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                if not INT32_MIN <= dts.year <= INT32_MAX:
+                    # year 0 is in range, so it is available as a sentinel
+                    bad_year = dts.year
+                    break
                 out[i] = dts.year
+        if bad_year != 0:
+            raise ValueError(
+                f"year {bad_year} is out of range for the int32 result; get the "
+                "year of the individual entries with Timestamp.year instead"
+            )
         return out
 
     elif field == "M":
@@ -578,7 +596,19 @@ def get_date_field(
         return out
 
     elif field == "is_leap_year":
-        return isleapyear_arr(get_date_field(dtindex, "Y", reso=reso))
+        out_bool = np.zeros(count, dtype="i1")
+        with nogil:
+            for i in range(count):
+                if dtindex[i] == NPY_NAT:
+                    continue
+                if perday > 0:
+                    set_datetimestruct_days(
+                        dtindex[i] // perday, &dts
+                    )
+                else:
+                    pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
+                out_bool[i] = is_leapyear(dts.year)
+        return out_bool.view(bool)
 
     raise ValueError(f"Field {field} not supported")
 
@@ -687,11 +717,13 @@ def build_isocalendar_sarray(const int64_t[:] dtindex, NPY_DATETIMEUNIT reso):
     cdef:
         Py_ssize_t i, count = len(dtindex)
         npy_datetimestruct dts
-        ndarray[uint32_t] iso_years, iso_weeks, days
+        ndarray[int32_t] iso_years
+        ndarray[uint32_t] iso_weeks, days
         iso_calendar_t ret_val
+        int64_t bad_year = 0
 
     sa_dtype = [
-        ("year", "u4"),
+        ("year", "i4"),
         ("week", "u4"),
         ("day", "u4"),
     ]
@@ -709,10 +741,20 @@ def build_isocalendar_sarray(const int64_t[:] dtindex, NPY_DATETIMEUNIT reso):
             else:
                 pandas_datetime_to_datetimestruct(dtindex[i], reso, &dts)
                 ret_val = get_iso_calendar(dts.year, dts.month, dts.day)
+                if not INT32_MIN <= ret_val[0] <= INT32_MAX:
+                    # year 0 is in range, so it is available as a sentinel
+                    bad_year = ret_val[0]
+                    break
 
             iso_years[i] = ret_val[0]
             iso_weeks[i] = ret_val[1]
             days[i] = ret_val[2]
+    if bad_year != 0:
+        # Timestamp.isocalendar is no help for these years either, as it goes
+        #  through datetime.date, so there is no alternative to point at
+        raise ValueError(
+            f"ISO year {bad_year} is out of range for the int32 result"
+        )
     return out
 
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -1644,8 +1644,8 @@ default 'raise'
 
         values = self._local_timestamps()
         sarray = fields.build_isocalendar_sarray(values, reso=self._creso)
-        iso_calendar_df = DataFrame(
-            sarray, columns=["year", "week", "day"], dtype="UInt32"
+        iso_calendar_df = DataFrame(sarray, columns=["year", "week", "day"]).astype(
+            {"year": "Int32", "week": "UInt32", "day": "UInt32"}
         )
         if self._hasna:
             iso_calendar_df.iloc[self._isnan] = None

--- a/pandas/tests/indexes/datetimes/methods/test_isocalendar.py
+++ b/pandas/tests/indexes/datetimes/methods/test_isocalendar.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from pandas import (
     DataFrame,
     DatetimeIndex,
@@ -16,8 +18,7 @@ def test_isocalendar_returns_correct_values_close_to_new_year_with_tz():
         [[2013, 52, 7], [2014, 1, 1], [2014, 1, 2]],
         columns=["year", "week", "day"],
         index=dates,
-        dtype="UInt32",
-    )
+    ).astype({"year": "Int32", "week": "UInt32", "day": "UInt32"})
     tm.assert_frame_equal(result, expected_data_frame)
 
 
@@ -26,3 +27,16 @@ def test_dti_timestamp_isocalendar_fields():
     expected = tuple(idx.isocalendar().iloc[-1].to_list())
     result = idx[-1].isocalendar()
     assert result == expected
+
+
+def test_isocalendar_year_before_year_one():
+    # GH#66549 the year column was unsigned, so BC years wrapped, e.g. year -100
+    #  came out as 4294967196
+    dti = DatetimeIndex(np.array(["-0100-03-05", "0001-01-01"], dtype="M8[s]"))
+    result = dti.isocalendar()
+    expected = DataFrame(
+        [[-100, 10, 1], [1, 1, 1]],
+        columns=["year", "week", "day"],
+        index=dti,
+    ).astype({"year": "Int32", "week": "UInt32", "day": "UInt32"})
+    tm.assert_frame_equal(result, expected)

--- a/pandas/tests/indexes/datetimes/test_scalar_compat.py
+++ b/pandas/tests/indexes/datetimes/test_scalar_compat.py
@@ -506,3 +506,41 @@ def test_day_of_week_year_beyond_int32(value):
     assert Series(dti).dt.day_of_week[0] == expected
     # scalar day_name goes through the same ccalendar helper
     assert dti[0].day_name() == calendar.day_name[expected]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (np.iinfo(np.int64).max, 292277026596),
+        (2**32 * 86400 * 365, 4292117654),
+        (np.iinfo(np.int64).min + 1, -292277022657),
+    ],
+)
+def test_year_beyond_int32_raises(value, expected):
+    # GH#66549 the vectorized year is int32, and used to come back truncated,
+    #  e.g. 219250468 for year 292277026596
+    dti = DatetimeIndex(np.array([value], dtype="M8[s]"))
+    assert dti[0].year == expected
+
+    msg = f"year {expected} is out of range for the int32 result"
+    with pytest.raises(ValueError, match=msg):
+        dti.year
+    with pytest.raises(ValueError, match=msg):
+        Series(dti).dt.year
+    with pytest.raises(ValueError, match=f"ISO year {expected}"):
+        dti.isocalendar()
+
+
+def test_day_of_year_and_is_leap_year_beyond_int32():
+    # GH#66549 ccalendar.get_day_of_year took the year as a C int, so both the
+    #  scalar and the array path read the leap status off a truncated year.
+    #  10143198492 is a leap year, its int32 truncation 1553263900 is not.
+    dti = DatetimeIndex(np.array(["10143198492-12-29"], dtype="M8[s]"))
+
+    assert dti[0].day_of_year == 364
+    assert dti.day_of_year[0] == 364
+    assert Series(dti).dt.day_of_year[0] == 364
+
+    assert dti[0].is_leap_year
+    assert dti.is_leap_year[0]
+    assert Series(dti).dt.is_leap_year[0]

--- a/pandas/tests/series/accessors/test_dt_accessor.py
+++ b/pandas/tests/series/accessors/test_dt_accessor.py
@@ -907,8 +907,8 @@ class TestSeriesDatetimeValues:
     def test_isocalendar(self, input_series, expected_output):
         result = pd.to_datetime(Series(input_series)).dt.isocalendar()
         expected_frame = DataFrame(
-            expected_output, columns=["year", "week", "day"], dtype="UInt32"
-        )
+            expected_output, columns=["year", "week", "day"]
+        ).astype({"year": "Int32", "week": "UInt32", "day": "UInt32"})
         tm.assert_frame_equal(result, expected_frame)
 
     def test_hour_index(self):


### PR DESCRIPTION
closes #66549

Last live item of the GH-66549 inventory, in conjunction with #66589, #66597, #66602, #66638, #66689, #66739 and #66826 — the year truncation in the field accessors, reachable at second (and ms/us) resolution.

- `DatetimeIndex.year` / `Series.dt.year` wrote the year into an int32 array, so year 292277026596 came back as 219250468. The accessor keeps its int32 dtype — doubling it for years no one has is not worth the memory — and instead raises `ValueError` naming the year that does not fit.
- `is_leap_year` was `isleapyear_arr(get_date_field(..., "Y"))`, i.e. it took the leap status from that wrapped year. It is now computed in the loop from the untruncated year, which also makes it a single pass instead of two.
- `ccalendar.get_day_of_year`, `get_week_of_year` and `get_iso_calendar` still took the year as a C `int`, so `day_of_year` and the ISO week were computed from a wrapped year on the **scalar** path too: `Timestamp("10143198492-12-29").day_of_year` returned 363 rather than 364. Comparing the scalar against the vectorized result cannot detect this, since both sides truncated identically.
- The `isocalendar()` year column was unsigned, so years before year 1 wrapped: year -100 came out as 4294967196. It is now `Int32` — same width, and negative years are representable; an ISO year beyond the int32 range raises.

Not addressed here: `period.pyx`'s `cdef int pyear()` truncates the same way (`Period(ordinal=2**40, freq="D").year` gives -1284604737 for year 3010362559), and `Timestamp.isocalendar()` raises a bare `OverflowError` above year 9999 because it goes through `datetime.date`.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the remaining truncation sites, wrote the fix and tests, and ran the suite.