### PR TITLE
BUG: Fix rename_axis with tuple name for 1D Index (#66656)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2118,7 +2118,11 @@ class Index(IndexOpsMixin, PandasObject):
             level = level_list
             names = names_adjusted
 
-        if not is_list_like(names):
+        if not is_list_like(names) or (
+            not isinstance(self, ABCMultiIndex)
+            and level is None
+            and isinstance(names, tuple)
+        ):
             names = [names]  # type: ignore[assignment]
         if level is not None and not is_list_like(level):
             level = [level]

--- a/pandas/tests/frame/methods/test_rename_axis.py
+++ b/pandas/tests/frame/methods/test_rename_axis.py
@@ -121,3 +121,13 @@ class TestDataFrameRenameAxis:
         expected_columns = columns.rename(None) if rename_columns else columns
         expected = DataFrame(data, expected_index, expected_columns)
         tm.assert_frame_equal(result, expected)
+
+    def test_rename_axis_tuple_name_1d_index(self):
+        # GH#66656
+        df = DataFrame([1], index=Index([1], name=(1, 2, 3)))
+        result = df.rename_axis((1, 2, 3))
+        assert result.index.name == (1, 2, 3)
+
+        result_reset = df.reset_index().rename_axis(df.index.name)
+        assert result_reset.index.name == (1, 2, 3)
+


### PR DESCRIPTION
- [x] Closes #66656
- [x] Tests added and passed
- [x] All code checks passed

### Description
Fixes an issue where calling `df.rename_axis((1, 2, 3))` on a 1D index raised `ValueError: Length of new names must be 1, got 3`. The `set_names` method was parsing the tuple as separate level names rather than a single scalar tuple name for a 1D Index.