### PR TITLE
DEPR: Index.fillna casting deprecation missed ExtensionArray dtypes (GH#25288)

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2876,9 +2876,20 @@ class Index(IndexOpsMixin, PandasObject):
             raise TypeError(f"'value' must be a scalar, passed: {type(value).__name__}")
 
         if self.hasnans:
-            if not can_hold_element(self._values, value) and not is_valid_na_for_dtype(
-                value, self.dtype
-            ):
+            values = self._values
+            validate = getattr(values, "_validate_setitem_value", None)
+            if validate is not None and not isinstance(self.dtype, np.dtype):
+                # GH#25288 can_hold_element is permissive for most ExtensionArrays;
+                #  the array's own setitem validation is authoritative.
+                try:
+                    validate(value)
+                    can_hold = True
+                except (ValueError, TypeError):
+                    can_hold = False
+            else:
+                can_hold = can_hold_element(values, value)
+
+            if not can_hold and not is_valid_na_for_dtype(value, self.dtype):
                 # GH#45153 fillna with incompatible value requiring any
                 #  dtype casting is deprecated.
                 warnings.warn(

--- a/pandas/tests/indexes/categorical/test_fillna.py
+++ b/pandas/tests/indexes/categorical/test_fillna.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
 
+from pandas.errors import Pandas4Warning
+
 import pandas as pd
 from pandas import CategoricalIndex
 import pandas._testing as tm
@@ -21,7 +23,9 @@ class TestFillNA:
         with pytest.raises(TypeError, match=msg):
             cat.fillna(2.0)
 
-        result = idx.fillna(2.0)
+        depr_msg = "'float' is not supported as a fill value for category dtype"
+        with tm.assert_produces_warning(Pandas4Warning, match=depr_msg):
+            result = idx.fillna(2.0)
         expected = idx.astype(object).fillna(2.0)
         tm.assert_index_equal(result, expected)
 
@@ -48,7 +52,9 @@ class TestFillNA:
         tm.assert_index_equal(result, expected)
 
         # tuple not in categories -> casts to object, same as scalar behavior
-        result = ci.fillna((9, 9))
+        msg = "'tuple' is not supported as a fill value for category dtype"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
+            result = ci.fillna((9, 9))
         expected = pd.Index([(0, 1), (1, 2), (9, 9)], tupleize_cols=False)
         tm.assert_index_equal(result, expected)
 

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -528,3 +528,33 @@ def test_join_series_deprecated():
         Pandas4Warning, match="Passing .* to .* is deprecated"
     ):
         idx.join(ser)
+
+
+@pytest.mark.parametrize(
+    "data, dtype",
+    [
+        ([1, None], "Int64"),
+        ([1.0, None], "Float64"),
+        ([True, None], "boolean"),
+        ([1, None], "int64[pyarrow]"),
+        ([1.0, None], "category"),
+    ],
+)
+def test_fillna_incompatible_value_deprecated_ea_dtype(data, dtype):
+    # GH#25288 the casting deprecation also applies to Index with an
+    #  ExtensionArray dtype, which used to cast to object silently
+    if "pyarrow" in dtype:
+        pytest.importorskip("pyarrow")
+    idx = pd.Index(data, dtype=dtype)
+
+    msg = "'str' is not supported as a fill value"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = idx.fillna("x")
+
+    expected = pd.Index([data[0], "x"], dtype=object)
+    tm.assert_index_equal(result, expected)
+
+    # a value the dtype can hold is unaffected
+    with tm.assert_produces_warning(None):
+        result = idx.fillna(data[0])
+    tm.assert_index_equal(result, pd.Index([data[0], data[0]], dtype=dtype))


### PR DESCRIPTION
Noticed while investigating GH-25288. The GH-45153 deprecation (fillna with an incompatible value that requires dtype casting) never fired for an `Index` with an ExtensionArray dtype:

```python
idx = pd.Index([1, 2, None], dtype="Int64")
idx.fillna("x")   # silently -> Index([1, 2, 'x'], dtype='object'), no warning
```

`Series([1, 2, None], dtype="Int64").fillna("x")` already raises `TypeError`, and a float64 `Index` already warns — only the EA-dtype `Index` path was silent. The gate in `Index.fillna` uses `can_hold_element`, which returns `True` unconditionally for EA dtypes outside its special-cased list (the "technically incorrect, but maintains the behavior of `ExtensionBlock._can_hold_element`" branch), so masked, arrow, and categorical dtypes never reached the warning. Use the array's own `_validate_setitem_value` instead; third-party EAs, which do not implement that private hook, keep the old permissive behavior.

Affected: `Int64`/`Float64`/`boolean`, `int64[pyarrow]`, and `category` — all now warn and will raise in 4.0 alongside the numpy dtypes. Filling with a value the dtype can hold is unchanged.

No new whatsnew entry: the existing 3.1.0 deprecation note already names `Index.fillna`, and 3.1 is unreleased — this makes that entry true for EA dtypes.

Two existing CategoricalIndex tests were pinning the silent cast and now assert the warning.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the gap while investigating GH-25288, wrote the fix and tests, and ran the indexes/extension/arrays suites.