### PR TITLE
BUG: preserve MultiIndex hierarchy order with list-like .loc indexers

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4492,7 +4492,16 @@ class MultiIndex(Index):
                 new_order = np.arange(n - 1, -1, -1)[indexer]
             elif isinstance(k, slice) and k.start is None and k.stop is None:
                 # slice(None) should not determine order GH#31330
-                new_order = np.ones((n,), dtype=np.intp)[indexer]
+                # But when there is a list-like indexer on a deeper level,
+                # we need to use the level codes to preserve hierarchy order
+                # (group by higher levels first, then query order within groups)
+                if any(
+                    is_list_like(k2) and len(k2) > 1  # type: ignore[arg-type]
+                    for k2 in seq[i + 1 :]
+                ):
+                    new_order = self.codes[i][indexer]
+                else:
+                    new_order = np.ones((n,), dtype=np.intp)[indexer]
             else:
                 # For all other case, use the same order as the level
                 new_order = np.arange(n)[indexer]

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4492,13 +4492,11 @@ class MultiIndex(Index):
                 new_order = np.arange(n - 1, -1, -1)[indexer]
             elif isinstance(k, slice) and k.start is None and k.stop is None:
                 # slice(None) should not determine order GH#31330
-                # But when there is a list-like indexer on a deeper level,
-                # we need to use the level codes to preserve hierarchy order
-                # (group by higher levels first, then query order within groups)
                 if any(
-                    is_list_like(k2) and len(k2) > 1  # type: ignore[arg-type]
+                    is_list_like(k2) and len(k2) > 1
                     for k2 in seq[i + 1 :]
                 ):
+                    # Preserve hierarchy when a deeper level is list-like.
                     new_order = self.codes[i][indexer]
                 else:
                     new_order = np.ones((n,), dtype=np.intp)[indexer]


### PR DESCRIPTION
Fixes #63187

## Problem
Selecting multiple labels from a MultiIndex level with `.loc[:, [labels]]` can produce inconsistent ordering depending on whether the index is lexsorted and whether the requested labels are in index order.

For example, with the original implementation:

```python
sorted_s.loc[:, ["e", "d"]]
# ["e", "e", "d", "d"]

unsorted_s.loc[:, ["d", "e"]]
# ["d", "d", "e", "e"]
```

The expected behavior is to preserve the MultiIndex hierarchy while respecting the requested label order within each higher-level group.

## Fix
Update `MultiIndex._reorder_indexer()` so that when `slice(None)` is used on a higher level and a deeper level has a list-like indexer, the higher-level codes are used to preserve the hierarchy.

The existing `np.ones()` behavior is retained when there is no deeper list-like indexer, preserving the behavior covered by GH#31330.

## Tests
- Added regression coverage for the four cases in GH#63187.
- Verified the relevant MultiIndex tests pass.
- Verified GH#31330 behavior is preserved.
- Tested additional MultiIndex edge cases including non-lexsorted indexes, slices, duplicate labels,