### PR TITLE
WEB: correct doc links for previous versions (use major.micro links)

### DIFF
--- a/web/pandas/index.html
+++ b/web/pandas/index.html
@@ -112,8 +112,8 @@
                         {% for release in releases[1:5] %}
                             <li class="small">
                                 {{ release.name }} ({{ release.published.strftime("%b %d, %Y") }})<br/>
-                                <a href="https://pandas.pydata.org/pandas-docs/stable/whatsnew/{{ release.tag }}.html">changelog</a> |
-                                <a href="https://pandas.pydata.org/pandas-docs/version/{{ release.name }}/">docs</a> |
+                                <a href="https://pandas.pydata.org/docs/whatsnew/{{ release.tag }}.html">changelog</a> |
+                                <a href="https://pandas.pydata.org/pandas-docs/version/{{ release.short_name }}/">docs</a> |
                                 <a href="{{ release.url }}">code</a>
                             </li>
                         {% endfor %}
@@ -127,8 +127,8 @@
                         {% for release in releases[5:] %}
                             <li class="small">
                                 {{ release.name }} ({{ release.published.strftime("%b %d, %Y") }})<br/>
-                                <a href="https://pandas.pydata.org/pandas-docs/stable/whatsnew/{{ release.tag }}.html">changelog</a> |
-                                <a href="https://pandas.pydata.org/pandas-docs/version/{{ release.name }}/">docs</a> |
+                                <a href="https://pandas.pydata.org/docs/whatsnew/{{ release.tag }}.html">changelog</a> |
+                                <a href="https://pandas.pydata.org/pandas-docs/version/{{ release.short_name }}/">docs</a> |
                                 <a href="{{ release.url }}">code</a>
                             </li>
                         {% endfor %}

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -240,13 +240,16 @@ class Preprocessors:
         for release in releases:
             if release["prerelease"]:
                 continue
+            name = release["tag_name"].lstrip("v")
+            parsed_version = version.parse(name)
             published = datetime.datetime.strptime(
                 release["published_at"], "%Y-%m-%dT%H:%M:%SZ"
             )
             context["releases"].append(
                 {
-                    "name": release["tag_name"].lstrip("v"),
-                    "parsed_version": version.parse(release["tag_name"].lstrip("v")),
+                    "name": name,
+                    "parsed_version": parsed_version,
+                    "short_name": f"{parsed_version.major}.{parsed_version.minor}",
                     "tag": release["tag_name"],
                     "published": published,
                     "url": (


### PR DESCRIPTION
Addressing a comment from @rhshadrach at https://github.com/pandas-dev/pandas/pull/66809#pullrequestreview-4954777323

We have always had `pandas-docs/version/major.micro/` links in addition to specific versions (`/major.minor.micro/`), but going forward we want to only have the major.minor ones to reduce the size of the hosted content (we already do so for 3.0, but for older versions I kept symlinks for now). 

This updates the main home page of the website to use those shorter links.