### PR TITLE
CLN: cibuildwheel 4.2.0 cleanups

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -516,7 +516,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.12'
+          python-version: '3.15-dev'
 
       - name: Install pyodide-build
         run: python -m pip install pyodide-build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -516,7 +516,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.14'
+          python-version: '3.12'
 
       - name: Install pyodide-build
         run: python -m pip install pyodide-build
@@ -535,7 +535,7 @@ jobs:
 
       - name: Set up Pyodide virtual environment
         run: |
-          pyodide xbuildenv install 315.0.0a2
+          pyodide xbuildenv install 0.27.1
           pyodide venv .venv-pyodide
           source .venv-pyodide/bin/activate
           python -m pip install dist/*.whl

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -535,7 +535,7 @@ jobs:
 
       - name: Set up Pyodide virtual environment
         run: |
-          pyodide xbuildenv install 0.27.1
+          pyodide xbuildenv install 315.0.0a2
           pyodide venv .venv-pyodide
           source .venv-pyodide/bin/activate
           python -m pip install dist/*.whl

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -516,7 +516,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.15-dev'
+          python-version: '3.14'
 
       - name: Install pyodide-build
         run: python -m pip install pyodide-build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,7 +102,7 @@ jobs:
         python: ["cp311", "cp312", "cp313", "cp314", "cp314t", "cp315", "cp315t"]
         include:
           - buildplat: [ubuntu-24.04, pyodide_wasm32]
-            python: cp315
+            python: cp314
 
     steps:
       - name: Download sdist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,7 +102,7 @@ jobs:
         python: ["cp311", "cp312", "cp313", "cp314", "cp314t", "cp315", "cp315t"]
         include:
           - buildplat: [ubuntu-24.04, pyodide_wasm32]
-            python: cp314
+            python: cp312
 
     steps:
       - name: Download sdist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -78,7 +78,7 @@ jobs:
     needs: build_sdist
     permissions:
       contents: read
-    name: Build wheel for ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+    name: Build wheel for ${{ matrix.python }}-${{ matrix.buildplat[1] }}
     if: >-
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
@@ -99,23 +99,12 @@ jobs:
           - [macos-15, macosx_arm64]
           - [windows-2025, win_amd64]
           - [windows-11-arm, win_arm64]
-        python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp314", "3.14"], ["cp314t", "3.14"], ["cp315", "3.15"], ["cp315t", "3.15"]]
+        python: ["cp311", "cp312", "cp313", "cp314", "cp314t", "cp315", "cp315t"]
         include:
           - buildplat: [ubuntu-24.04, pyodide_wasm32]
-            python: ["cp315", "3.15"]
+            python: cp315
 
     steps:
-      - name: Checkout pandas
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 1
-
-      - name: Set up MSVC environment for Windows ARM64
-        if: matrix.buildplat[1] == 'win_arm64'
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
-        with:
-          arch: arm64
-
       - name: Download sdist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -129,7 +118,7 @@ jobs:
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         with:
           package-dir: ./dist/${{ env.sdist_name }}
-          only: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+          only: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
 
       - name: Set up Python for validation
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -144,7 +133,7 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
+          name: ${{ matrix.python }}-${{ matrix.buildplat[1] }}
           path: ./wheelhouse/*.whl
 
   upload_nightly:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -102,7 +102,7 @@ jobs:
         python: [["cp311", "3.11"], ["cp312", "3.12"], ["cp313", "3.13"], ["cp314", "3.14"], ["cp314t", "3.14"], ["cp315", "3.15"], ["cp315t", "3.15"]]
         include:
           - buildplat: [ubuntu-24.04, pyodide_wasm32]
-            python: ["cp312", "3.12"]
+            python: ["cp315", "3.15"]
 
     steps:
       - name: Checkout pandas
@@ -129,9 +129,7 @@ jobs:
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         with:
           package-dir: ./dist/${{ env.sdist_name }}
-        env:
-          CIBW_BUILD: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
-          CIBW_PLATFORM: ${{ (matrix.buildplat[1] == 'pyodide_wasm32' && 'pyodide') || 'auto' }}
+          only: ${{ matrix.python[0] }}-${{ matrix.buildplat[1] }}
 
       - name: Set up Python for validation
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,7 @@ dist = ['--include-subprojects']
 
 [tool.cibuildwheel]
 skip = ["*_i686", "*_ppc64le", "*_s390x"]
+enable = ["pyodide-eol"]
 build-verbosity = 1
 config-settings = { compile-args = ["-v"] }
 environment = {LDFLAGS="-Wl,--strip-all"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,9 +163,7 @@ dist = ['--include-subprojects']
 
 [tool.cibuildwheel]
 skip = ["*_i686", "*_ppc64le", "*_s390x"]
-enable = ["pyodide-eol"]
 build-verbosity = 1
-build-frontend = "pip"
 config-settings = { compile-args = ["-v"] }
 environment = {LDFLAGS="-Wl,--strip-all"}
 test-extras = "test"
@@ -195,11 +193,6 @@ environment = {CFLAGS="-g0"}
 
 [[tool.cibuildwheel.overrides]]
 select = "*pyodide*"
-# Pyodide repairs wheels on its own, using auditwheel-emscripten
-repair-wheel-command = ""
-# https://github.com/pyodide/pyodide/issues/5805
-build-verbosity = 1
-build-frontend = "build"
 # pytest-xdist cannot be used on Pyodide
 # OSError: [Errno 138] emscripten does not support processes
 # nocacheprovider is needed to avoid cleaning up pytest cache failing with PermissionError


### PR DESCRIPTION
Some cleanups to wheel building now that we use cibuildwheel 4.2.0

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

Used Cursor Grok 4.6 to research and implement the changes.