### PR TITLE
TST: run the locale tests on Windows (GH#46597)

### DIFF
--- a/pandas/_config/localization.py
+++ b/pandas/_config/localization.py
@@ -116,30 +116,21 @@ def _valid_locales(locales: list[str] | str, normalize: bool) -> list[str]:
 # Windows has no "locale -a" to enumerate with.  ``locale.windows_locale``
 #  lists the ~200 names the CRT knows, but it is undocumented and its only
 #  stdlib consumer is ``locale.getdefaultlocale``, which is slated for removal
-#  in 3.15.  The tests that consume get_locales() parametrize over every entry,
-#  so a curated list also keeps that from becoming ~800 cases with no added
-#  coverage.  The names are BCP-47 and carry an encoding suffix: the CRT wants
+#  in 3.15.  The names are BCP-47 and carry an encoding suffix: the CRT wants
 #  "en-US" rather than "en_US", and ``can_set_locale`` calls
 #  ``locale.getlocale``, whose parser raises ValueError on a name without a
 #  ".".  GH#46597
+#
+# The consumers parametrize over every entry, so this holds one name per
+#  behavior a locale can change rather than a broad sample.  day_name and
+#  month_name read ``calendar.day_name`` under ``set_locale`` and then call
+#  ``str.capitalize``, so what varies between locales is the case mapping.
 _WINDOWS_LOCALES = [
-    "ar-SA.UTF-8",
-    "de-DE.UTF-8",
-    "el-GR.UTF-8",
-    "en-GB.UTF-8",
-    "en-US.UTF-8",
-    "es-ES.UTF-8",
-    "fr-FR.UTF-8",
-    "he-IL.UTF-8",
-    "hi-IN.UTF-8",
-    "it-IT.UTF-8",
-    "ja-JP.UTF-8",
-    "ko-KR.UTF-8",
-    "pt-BR.UTF-8",
-    "ru-RU.UTF-8",
-    "th-TH.UTF-8",
-    "tr-TR.UTF-8",
-    "zh-CN.UTF-8",
+    "de-DE.UTF-8",  # Latin with diacritics
+    "el-GR.UTF-8",  # Greek, where capitalize() has to handle final sigma
+    "en-US.UTF-8",  # ASCII baseline
+    "ja-JP.UTF-8",  # caseless script, capitalize() is a no-op
+    "tr-TR.UTF-8",  # dotted and dotless i
 ]
 
 

--- a/pandas/_config/localization.py
+++ b/pandas/_config/localization.py
@@ -113,18 +113,8 @@ def _valid_locales(locales: list[str] | str, normalize: bool) -> list[str]:
     ]
 
 
-# Windows has no "locale -a" to enumerate with.  ``locale.windows_locale``
-#  lists the ~200 names the CRT knows, but it is undocumented and its only
-#  stdlib consumer is ``locale.getdefaultlocale``, which is slated for removal
-#  in 3.15.  The names are BCP-47 and carry an encoding suffix: the CRT wants
-#  "en-US" rather than "en_US", and ``can_set_locale`` calls
-#  ``locale.getlocale``, whose parser raises ValueError on a name without a
-#  ".".  GH#46597
-#
-# The consumers parametrize over every entry, so this holds one name per
-#  behavior a locale can change rather than a broad sample.  day_name and
-#  month_name read ``calendar.day_name`` under ``set_locale`` and then call
-#  ``str.capitalize``, so what varies between locales is the case mapping.
+# Windows has no "locale -a" to enumerate with, so we hardcode a few values.
+#  GH#46597
 _WINDOWS_LOCALES = [
     "de-DE.UTF-8",  # Latin with diacritics
     "el-GR.UTF-8",  # Greek, where capitalize() has to handle final sigma

--- a/pandas/_config/localization.py
+++ b/pandas/_config/localization.py
@@ -122,7 +122,12 @@ def _windows_locale_candidates() -> list[str]:
     """
     return [
         f"{name.replace('_', '-')}.UTF-8"
-        for name in sorted(set(locale.windows_locale.values()))
+        # Names without a region ("ar") are settable too, but they resolve to a
+        #  region-qualified name that is already in the list, so they would only
+        #  duplicate its coverage.
+        for name in sorted(
+            {name for name in locale.windows_locale.values() if "_" in name}
+        )
     ]
 
 
@@ -177,6 +182,9 @@ def get_locales(
         # Windows doesn't define "locale -a", so probe the names it may know
         #  Note: is_platform_windows causes circular import here
         out_locales = _windows_locale_candidates()
+        # These are already spelled the way the CRT wants them; running them
+        #  through the POSIX alias table would rename them ("ar-SA" -> "ar_AA").
+        normalize = False
     else:
         return []
 

--- a/pandas/_config/localization.py
+++ b/pandas/_config/localization.py
@@ -7,6 +7,7 @@ Name `localization` is chosen to avoid overlap with builtin `locale` module.
 from __future__ import annotations
 
 from contextlib import contextmanager
+import functools
 import locale
 import platform
 import re
@@ -112,23 +113,71 @@ def _valid_locales(locales: list[str] | str, normalize: bool) -> list[str]:
     ]
 
 
-def _windows_locale_candidates() -> list[str]:
-    """
-    Locale names to test for availability on platforms without "locale -a".
+# Windows has no "locale -a" to enumerate with.  ``locale.windows_locale``
+#  lists the ~200 names the CRT knows, but it is undocumented and its only
+#  stdlib consumer is ``locale.getdefaultlocale``, which is slated for removal
+#  in 3.15.  The tests that consume get_locales() parametrize over every entry,
+#  so a curated list also keeps that from becoming ~800 cases with no added
+#  coverage.  The names are BCP-47 and carry an encoding suffix: the CRT wants
+#  "en-US" rather than "en_US", and ``can_set_locale`` calls
+#  ``locale.getlocale``, whose parser raises ValueError on a name without a
+#  ".".  GH#46597
+_WINDOWS_LOCALES = [
+    "ar-SA.UTF-8",
+    "de-DE.UTF-8",
+    "el-GR.UTF-8",
+    "en-GB.UTF-8",
+    "en-US.UTF-8",
+    "es-ES.UTF-8",
+    "fr-FR.UTF-8",
+    "he-IL.UTF-8",
+    "hi-IN.UTF-8",
+    "it-IT.UTF-8",
+    "ja-JP.UTF-8",
+    "ko-KR.UTF-8",
+    "pt-BR.UTF-8",
+    "ru-RU.UTF-8",
+    "th-TH.UTF-8",
+    "tr-TR.UTF-8",
+    "zh-CN.UTF-8",
+]
 
-    The Windows CRT accepts BCP-47 names such as "en-US", while
-    ``locale.getlocale`` can only parse the name that ``locale.setlocale``
-    echoes back if it carries an encoding suffix.  GH#46597
-    """
-    return [
-        f"{name.replace('_', '-')}.UTF-8"
-        # Names without a region ("ar") are settable too, but they resolve to a
-        #  region-qualified name that is already in the list, so they would only
-        #  duplicate its coverage.
-        for name in sorted(
-            {name for name in locale.windows_locale.values() if "_" in name}
-        )
-    ]
+
+@functools.cache
+def _get_locales(prefix: str | None, normalize: bool) -> tuple[str, ...]:
+    if platform.system() in ("Linux", "Darwin"):
+        raw_locales = subprocess.check_output(["locale", "-a"])
+        # raw_locales is "\n" separated list of locales
+        # it may contain non-decodable parts, so split
+        # extract what we can and then rejoin.
+        out_locales = []
+        for raw_locale in raw_locales.split(b"\n"):
+            try:
+                out_locales.append(
+                    str(raw_locale, encoding=cast("str", options.display.encoding))
+                )
+            except UnicodeError:
+                # 'locale -a' is used to populated 'raw_locales' and on
+                # Redhat 7 Linux (and maybe others) prints locale names
+                # using windows-1252 encoding.  Bug only triggered by
+                # a few special characters and when there is an
+                # extensive list of installed locales.
+                out_locales.append(str(raw_locale, encoding="windows-1252"))
+    elif platform.system() == "Windows":
+        # Note: is_platform_windows causes circular import here
+        out_locales = _WINDOWS_LOCALES
+        # These are already spelled the way the CRT wants them; running them
+        #  through the POSIX alias table would rename them ("ar-SA" -> "ar_AA").
+        normalize = False
+    else:
+        return ()
+
+    if prefix is None:
+        return tuple(_valid_locales(out_locales, normalize))
+
+    pattern = re.compile(f"{prefix}.*")
+    found = pattern.findall("\n".join(out_locales))
+    return tuple(_valid_locales(found, normalize))
 
 
 def get_locales(
@@ -160,37 +209,6 @@ def get_locales(
     On error will return an empty list (no locale available)
 
     """
-    if platform.system() in ("Linux", "Darwin"):
-        raw_locales = subprocess.check_output(["locale", "-a"])
-        # raw_locales is "\n" separated list of locales
-        # it may contain non-decodable parts, so split
-        # extract what we can and then rejoin.
-        out_locales = []
-        for raw_locale in raw_locales.split(b"\n"):
-            try:
-                out_locales.append(
-                    str(raw_locale, encoding=cast("str", options.display.encoding))
-                )
-            except UnicodeError:
-                # 'locale -a' is used to populated 'raw_locales' and on
-                # Redhat 7 Linux (and maybe others) prints locale names
-                # using windows-1252 encoding.  Bug only triggered by
-                # a few special characters and when there is an
-                # extensive list of installed locales.
-                out_locales.append(str(raw_locale, encoding="windows-1252"))
-    elif platform.system() == "Windows":
-        # Windows doesn't define "locale -a", so probe the names it may know
-        #  Note: is_platform_windows causes circular import here
-        out_locales = _windows_locale_candidates()
-        # These are already spelled the way the CRT wants them; running them
-        #  through the POSIX alias table would rename them ("ar-SA" -> "ar_AA").
-        normalize = False
-    else:
-        return []
-
-    if prefix is None:
-        return _valid_locales(out_locales, normalize)
-
-    pattern = re.compile(f"{prefix}.*")
-    found = pattern.findall("\n".join(out_locales))
-    return _valid_locales(found, normalize)
+    # Every candidate is probed with setlocale, and several test modules call
+    #  this at collection time, so the result is cached.
+    return list(_get_locales(prefix, normalize))

--- a/pandas/_config/localization.py
+++ b/pandas/_config/localization.py
@@ -112,6 +112,20 @@ def _valid_locales(locales: list[str] | str, normalize: bool) -> list[str]:
     ]
 
 
+def _windows_locale_candidates() -> list[str]:
+    """
+    Locale names to test for availability on platforms without "locale -a".
+
+    The Windows CRT accepts BCP-47 names such as "en-US", while
+    ``locale.getlocale`` can only parse the name that ``locale.setlocale``
+    echoes back if it carries an encoding suffix.  GH#46597
+    """
+    return [
+        f"{name.replace('_', '-')}.UTF-8"
+        for name in sorted(set(locale.windows_locale.values()))
+    ]
+
+
 def get_locales(
     prefix: str | None = None,
     normalize: bool = True,
@@ -138,26 +152,19 @@ def get_locales(
 
             locale.setlocale(locale.LC_ALL, locale_string)
 
-    On error will return an empty list (no locale available, e.g. Windows)
+    On error will return an empty list (no locale available)
 
     """
     if platform.system() in ("Linux", "Darwin"):
         raw_locales = subprocess.check_output(["locale", "-a"])
-    else:
-        # Other platforms e.g. windows platforms don't define "locale -a"
-        #  Note: is_platform_windows causes circular import here
-        return []
-
-    try:
         # raw_locales is "\n" separated list of locales
         # it may contain non-decodable parts, so split
         # extract what we can and then rejoin.
-        split_raw_locales = raw_locales.split(b"\n")
         out_locales = []
-        for x in split_raw_locales:
+        for raw_locale in raw_locales.split(b"\n"):
             try:
                 out_locales.append(
-                    str(x, encoding=cast("str", options.display.encoding))
+                    str(raw_locale, encoding=cast("str", options.display.encoding))
                 )
             except UnicodeError:
                 # 'locale -a' is used to populated 'raw_locales' and on
@@ -165,10 +172,13 @@ def get_locales(
                 # using windows-1252 encoding.  Bug only triggered by
                 # a few special characters and when there is an
                 # extensive list of installed locales.
-                out_locales.append(str(x, encoding="windows-1252"))
-
-    except TypeError:
-        pass
+                out_locales.append(str(raw_locale, encoding="windows-1252"))
+    elif platform.system() == "Windows":
+        # Windows doesn't define "locale -a", so probe the names it may know
+        #  Note: is_platform_windows causes circular import here
+        out_locales = _windows_locale_candidates()
+    else:
+        return []
 
     if prefix is None:
         return _valid_locales(out_locales, normalize)

--- a/pandas/tests/config/test_localization.py
+++ b/pandas/tests/config/test_localization.py
@@ -20,8 +20,6 @@ import pandas as pd
 
 _all_locales = get_locales()
 
-# Only the tests that need a locale out of _all_locales are skipped when there
-#  are too few of them; the rest run everywhere, Windows included. GH#46597
 _skip_if_only_one_locale = pytest.mark.skipif(
     len(_all_locales) <= 1, reason="Need multiple locales for meaningful test"
 )

--- a/pandas/tests/config/test_localization.py
+++ b/pandas/tests/config/test_localization.py
@@ -10,7 +10,10 @@ from pandas._config.localization import (
     set_locale,
 )
 
-from pandas.compat import ISMUSL
+from pandas.compat import (
+    ISMUSL,
+    WASM,
+)
 
 import pandas as pd
 
@@ -56,7 +59,8 @@ def test_can_set_locale_valid_set(lc_var):
         pytest.param(
             locale.LC_TIME,
             marks=pytest.mark.skipif(
-                ISMUSL, reason="MUSL allows setting invalid LC_TIME."
+                ISMUSL or WASM,
+                reason="MUSL and Emscripten allow setting invalid LC_TIME.",
             ),
         ),
     ),

--- a/pandas/tests/config/test_localization.py
+++ b/pandas/tests/config/test_localization.py
@@ -1,6 +1,7 @@
 import codecs
 import locale
 import os
+import platform
 
 import pytest
 
@@ -19,10 +20,8 @@ import pandas as pd
 
 _all_locales = get_locales()
 
-# Only the tests that need a locale from _all_locales are skipped when there
-#  are none available; the rest run everywhere, Windows included. GH#46597
-_skip_if_no_locale = pytest.mark.skipif(not _all_locales, reason="Need locales")
-
+# Only the tests that need a locale out of _all_locales are skipped when there
+#  are too few of them; the rest run everywhere, Windows included. GH#46597
 _skip_if_only_one_locale = pytest.mark.skipif(
     len(_all_locales) <= 1, reason="Need multiple locales for meaningful test"
 )
@@ -104,9 +103,15 @@ def test_can_set_locale_invalid_get(monkeypatch):
         assert not can_set_locale("")
 
 
-@_skip_if_no_locale
+@pytest.mark.skipif(
+    platform.system() not in ("Linux", "Darwin", "Windows"),
+    reason="get_locales does not enumerate on this platform",
+)
 def test_get_locales_at_least_one():
     # see GH#9744
+    # Gated on the platform rather than on _all_locales: where get_locales
+    #  knows how to enumerate, an empty result is the bug, not a reason to
+    #  skip.  Skipping on it is what let Windows return nothing.  GH#46597
     assert len(_all_locales) > 0
 
 

--- a/pandas/tests/config/test_localization.py
+++ b/pandas/tests/config/test_localization.py
@@ -16,8 +16,9 @@ import pandas as pd
 
 _all_locales = get_locales()
 
-# Don't run any of these tests if we have no locales.
-pytestmark = pytest.mark.skipif(not _all_locales, reason="Need locales")
+# Only the tests that need a locale from _all_locales are skipped when there
+#  are none available; the rest run everywhere, Windows included. GH#46597
+_skip_if_no_locale = pytest.mark.skipif(not _all_locales, reason="Need locales")
 
 _skip_if_only_one_locale = pytest.mark.skipif(
     len(_all_locales) <= 1, reason="Need multiple locales for meaningful test"
@@ -99,6 +100,7 @@ def test_can_set_locale_invalid_get(monkeypatch):
         assert not can_set_locale("")
 
 
+@_skip_if_no_locale
 def test_get_locales_at_least_one():
     # see GH#9744
     assert len(_all_locales) > 0


### PR DESCRIPTION
closes #46597

`locale -a` does not exist on Windows, so `get_locales()` returned an empty list there. That emptied out the locale parametrization of the `day_name`/`month_name` tests and, via the module-level `skipif`, disabled *every* test in `pandas/tests/config/test_localization.py`.

- `get_locales()` now falls back to a fixed list of locale names on Windows. `locale.windows_locale` would enumerate all ~200 names the CRT knows, but it is undocumented and its only stdlib consumer is `locale.getdefaultlocale`, whose deprecation carries `remove=(3, 15)`.
- The list is five names, not a broad sample of scripts. `day_name`/`month_name` read `calendar.day_name` under `set_locale` and then call `str.capitalize`, so the axis that varies between locales is the case mapping: `en-US` (ASCII), `de-DE` (Latin with diacritics), `el-GR` (final sigma), `tr-TR` (dotted/dotless i), `ja-JP` (caseless, `capitalize()` is a no-op). Every name is also pinned to `.UTF-8`, so a wider list would not have bought codepage coverage either.
- The names are BCP-47 (`en-US`, not `en_US`) and carry an encoding suffix, because `can_set_locale` calls `locale.getlocale()`, whose `_parse_localename` raises `ValueError` for any name without a `.` — so a bare `en-US` reports as unsettable even when `setlocale` succeeded. They also skip `locale.normalize`, whose POSIX alias table does not describe Windows and would rewrite them (`ar-SA` -> `ar_AA`). Platforms that are neither Linux/Darwin nor Windows still short-circuit to `[]` rather than paying the `setlocale` probes.
- `get_locales()` is cached. Every candidate is probed with `setlocale`, and four test modules call it at collection time.
- The module-level `pytestmark` skip is replaced by a per-test mark, so the six tests that never needed an enumerated locale run everywhere. One of them, `test_can_set_locale_invalid_set[LC_TIME]`, now also has to skip on WASM: Emscripten accepts an invalid `LC_TIME` exactly like MUSL does, but `ISMUSL` is a `HOST_GNU_TYPE` check and reports False there.
- `test_get_locales_at_least_one` is gated on the platform rather than on the result. It used to carry a `skipif(not _all_locales)`, which made it skip-or-pass — an empty enumeration was indistinguishable from a green run, which is exactly how this bug stayed invisible. On Linux/Darwin/Windows an empty result is now a failure, so CI keeps answering "does the Windows path still enumerate?" without anyone re-probing by hand.

The Windows path cannot be validated off Windows — every candidate is rejected by the glibc/macOS CRT, so the path degrades to `[]` locally. A temporary probe commit was pushed to read the result back off Windows CI, since a green Windows job was otherwise indistinguishable from "still skipping everything". It reported 198 of the 200 enumerated names as settable with the rest of the suite green ([run 32424271262, `windows-2025 py312`](https://github.com/pandas-dev/pandas/actions/runs/32424271262/job/96602798823)), and the five kept here are a subset of that enumeration. The probe commit has since been dropped in favor of the permanent assertion above.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the issue and wrote the patch and PR description.
