### PR TITLE
TST: skip SQL tests when no database is running (GH#50009)

### DIFF
--- a/doc/source/development/contributing_codebase.rst
+++ b/doc/source/development/contributing_codebase.rst
@@ -801,15 +801,17 @@ speed by skipping some tests using the ``-m`` mark flag:
 
 - slow: any test taking long (think seconds rather than milliseconds)
 - network: tests requiring network connectivity
-- db: tests requiring a database (mysql or postgres)
+- db: tests requiring a database (mysql or postgres); these skip themselves if
+  no database is running, so ``-m "not db"`` is only needed to avoid the cost
+  of checking for one
 - single_cpu: tests that should run on a single cpu only
 
 You might want to enable the following option if it's relevant for you:
 
 - arm_slow: any test taking long on arm64 architecture
 
-These markers are defined `in this toml file <https://github.com/pandas-dev/pandas/blob/main/pyproject.toml>`_
-, under ``[tool.pytest.ini_options]`` in a list called ``markers``, in case
+These markers are defined `in pandas/conftest.py <https://github.com/pandas-dev/pandas/blob/main/pandas/conftest.py>`_
+, in a list called ``PANDAS_MARKERS``, in case
 you want to check if new ones have been created which are of interest to you.
 
 The ``-r`` report flag will display a short summary info (see `pytest

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -10,6 +10,7 @@ from datetime import (
 )
 from decimal import Decimal
 from io import StringIO
+import os
 from pathlib import Path
 import sqlite3
 from typing import TYPE_CHECKING
@@ -597,6 +598,35 @@ def drop_view(
                 con.execute(stmt)  # type: ignore[union-attr]
 
 
+# Cache the outcome of the connection check per database so that we pay the
+# cost of a failed connection once rather than for every parametrized test.
+_db_connection_errors: dict[str, str] = {}
+
+
+def skip_if_no_db(name: str, connect) -> None:
+    """
+    Skip the test if the database `name` is not reachable.
+
+    On CI the databases are expected to be up, so we leave the connection error
+    alone there instead of silently skipping the whole test suite.
+    """
+    if os.environ.get("CI"):
+        return
+
+    if name not in _db_connection_errors:
+        try:
+            connect().close()
+        except Exception as err:
+            # only the first line; these messages tend to be several lines long
+            first_line = str(err).split("\n")[0]
+            _db_connection_errors[name] = f"{type(err).__name__}: {first_line}"
+        else:
+            _db_connection_errors[name] = ""
+
+    if err_msg := _db_connection_errors[name]:
+        pytest.skip(f"Could not connect to {name} database: {err_msg}")
+
+
 @pytest.fixture
 def mysql_pymysql_engine():
     sqlalchemy = pytest.importorskip("sqlalchemy")
@@ -606,6 +636,7 @@ def mysql_pymysql_engine():
         connect_args={"client_flag": pymysql.constants.CLIENT.MULTI_STATEMENTS},
         poolclass=sqlalchemy.pool.NullPool,
     )
+    skip_if_no_db("mysql", engine.connect)
     yield engine
     for view in get_all_views(engine):
         drop_view(view, engine)
@@ -653,6 +684,7 @@ def postgresql_psycopg2_engine():
         "postgresql+psycopg2://postgres:postgres@localhost:5432/pandas",
         poolclass=sqlalchemy.pool.NullPool,
     )
+    skip_if_no_db("postgresql", engine.connect)
     yield engine
     for view in get_all_views(engine):
         drop_view(view, engine)
@@ -687,6 +719,7 @@ def postgresql_adbc_conn():
     from adbc_driver_postgresql import dbapi
 
     uri = "postgresql://postgres:postgres@localhost:5432/pandas"
+    skip_if_no_db("postgresql (adbc)", lambda: dbapi.connect(uri))
     with dbapi.connect(uri) as conn:
         yield conn
         for view in get_all_views(conn):

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -598,14 +598,12 @@ def drop_view(
                 con.execute(stmt)  # type: ignore[union-attr]
 
 
-# Cache the outcome of the connection check per database so that we pay the
-# cost of a failed connection once rather than for every parametrized test.
-_db_connection_errors: dict[str, str] = {}
-
-
 def skip_if_no_db(name: str, connect) -> None:
     """
     Skip the test if the database `name` is not reachable.
+
+    Call this only from module-scoped fixtures, so that a failed connection is
+    paid for once rather than for every parametrized test.
 
     On CI the databases are expected to be up, so we leave the connection error
     alone there instead of silently skipping the whole test suite.
@@ -613,22 +611,18 @@ def skip_if_no_db(name: str, connect) -> None:
     if os.environ.get("CI"):
         return
 
-    if name not in _db_connection_errors:
-        try:
-            connect().close()
-        except Exception as err:
-            # only the first line; these messages tend to be several lines long
-            first_line = str(err).split("\n")[0]
-            _db_connection_errors[name] = f"{type(err).__name__}: {first_line}"
-        else:
-            _db_connection_errors[name] = ""
-
-    if err_msg := _db_connection_errors[name]:
-        pytest.skip(f"Could not connect to {name} database: {err_msg}")
+    try:
+        connect().close()
+    except Exception as err:
+        # only the first line; these messages tend to be several lines long
+        first_line = str(err).split("\n")[0]
+        pytest.skip(
+            f"Could not connect to {name} database: {type(err).__name__}: {first_line}"
+        )
 
 
-@pytest.fixture
-def mysql_pymysql_engine():
+@pytest.fixture(scope="module")
+def _mysql_pymysql_engine():
     sqlalchemy = pytest.importorskip("sqlalchemy")
     pymysql = pytest.importorskip("pymysql")
     engine = sqlalchemy.create_engine(
@@ -638,11 +632,16 @@ def mysql_pymysql_engine():
     )
     skip_if_no_db("mysql", engine.connect)
     yield engine
-    for view in get_all_views(engine):
-        drop_view(view, engine)
-    for tbl in get_all_tables(engine):
-        drop_table(tbl, engine)
     engine.dispose()
+
+
+@pytest.fixture
+def mysql_pymysql_engine(_mysql_pymysql_engine):
+    yield _mysql_pymysql_engine
+    for view in get_all_views(_mysql_pymysql_engine):
+        drop_view(view, _mysql_pymysql_engine)
+    for tbl in get_all_tables(_mysql_pymysql_engine):
+        drop_table(tbl, _mysql_pymysql_engine)
 
 
 @pytest.fixture
@@ -676,8 +675,8 @@ def mysql_pymysql_conn_types(mysql_pymysql_engine_types):
         yield conn
 
 
-@pytest.fixture
-def postgresql_psycopg2_engine():
+@pytest.fixture(scope="module")
+def _postgresql_psycopg2_engine():
     sqlalchemy = pytest.importorskip("sqlalchemy")
     pytest.importorskip("psycopg2")
     engine = sqlalchemy.create_engine(
@@ -686,11 +685,16 @@ def postgresql_psycopg2_engine():
     )
     skip_if_no_db("postgresql", engine.connect)
     yield engine
-    for view in get_all_views(engine):
-        drop_view(view, engine)
-    for tbl in get_all_tables(engine):
-        drop_table(tbl, engine)
     engine.dispose()
+
+
+@pytest.fixture
+def postgresql_psycopg2_engine(_postgresql_psycopg2_engine):
+    yield _postgresql_psycopg2_engine
+    for view in get_all_views(_postgresql_psycopg2_engine):
+        drop_view(view, _postgresql_psycopg2_engine)
+    for tbl in get_all_tables(_postgresql_psycopg2_engine):
+        drop_table(tbl, _postgresql_psycopg2_engine)
 
 
 @pytest.fixture
@@ -712,15 +716,22 @@ def postgresql_psycopg2_conn(postgresql_psycopg2_engine):
         yield conn
 
 
-@pytest.fixture
-def postgresql_adbc_conn():
+@pytest.fixture(scope="module")
+def _postgresql_adbc_uri():
     pytest.importorskip("pyarrow")
     pytest.importorskip("adbc_driver_postgresql")
     from adbc_driver_postgresql import dbapi
 
     uri = "postgresql://postgres:postgres@localhost:5432/pandas"
     skip_if_no_db("postgresql (adbc)", lambda: dbapi.connect(uri))
-    with dbapi.connect(uri) as conn:
+    return uri
+
+
+@pytest.fixture
+def postgresql_adbc_conn(_postgresql_adbc_uri):
+    from adbc_driver_postgresql import dbapi
+
+    with dbapi.connect(_postgresql_adbc_uri) as conn:
         yield conn
         for view in get_all_views(conn):
             drop_view(view, conn)


### PR DESCRIPTION
closes #50009

The `db`-marked tests in `test_sql.py` currently error out with connection-refused on a dev machine that installed the full `environment.yml` but is not running MySQL/Postgres: the drivers import fine, so `importorskip` passes and only the connection fails. That is 788 failing tests, and the run takes minutes rather than seconds because every one of them re-attempts the TCP connect (twice, since the SQLAlchemy fixture teardowns connect as well).

Probe the connection once per database, and skip with the driver's error message. The engine fixtures are split in two: a module-scoped half (`_mysql_pymysql_engine`, `_postgresql_psycopg2_engine`, `_postgresql_adbc_uri`) that creates the engine and does the reachability check, and the existing function-scoped fixture, which keeps the per-test table/view cleanup so test isolation is unchanged. pytest caches a fixture's `skip`, so the connect is attempted exactly once per database — verified by instrumenting `skip_if_no_db` across the full 1534-test module. For ADBC only the URI check is hoisted; the connection itself stays per-test rather than sharing transaction state.

Locally `pytest pandas/tests/io/test_sql.py` now finishes in ~10s with 644 passed / 803 skipped / 87 xfailed and no failures or errors.

Per GH-48060, the other half of the request is that this must not silently skip on CI. The check is bypassed entirely when `$CI` is set, so on CI the fixtures behave exactly as they do today and an unreachable database still fails loudly — there is no new code path on CI at all. GitHub Actions sets `CI=true` in every job including containers, and the pixi task the tests run through does not set `clean-env`, so the variable reaches pytest.

One thing worth a reviewer's opinion: that guard leans on the generic `CI` variable, so a future job that installs the drivers without starting the services would fail rather than skip. I think loud is the right default there, but if you'd prefer belt-and-braces I can add an explicit `PANDAS_REQUIRE_DB: 1` to the ubuntu job's `env:`, right next to the `services:` block, and require the database when either variable is set.

Also updates the marker docs, which still pointed at a `markers` list in `pyproject.toml`; those moved to `PANDAS_MARKERS` in `pandas/conftest.py`.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the failure locally, wrote the fixture change and doc update, and verified both the skip and the `CI=true` failure paths.
