### PR TITLE
TST: don't generate imaginary local times in offsets property test (GH#60205)

### DIFF
--- a/pandas/_testing/_hypothesis.py
+++ b/pandas/_testing/_hypothesis.py
@@ -26,6 +26,11 @@ DATETIME_JAN_1_1900_OPTIONAL_TZ = st.datetimes(  # pyright: ignore[reportCallIss
     min_value=pd.Timestamp(1900, 1, 1).to_pydatetime(),  # pyright: ignore[reportArgumentType]
     max_value=pd.Timestamp(1900, 1, 1).to_pydatetime(),  # pyright: ignore[reportArgumentType]
     timezones=st.one_of(st.none(), dateutil_timezones(), st.timezones()),
+    # 1900-01-01 is the first transition for some zones (e.g. Indian/Cocos in
+    # tzdata builds that include "backzone"), making it a nonexistent local
+    # time there.  Such datetimes do not survive a UTC round-trip, so they
+    # break invariants like (dt + offset) - offset == dt.
+    allow_imaginary=False,
 )
 
 DATETIME_IN_PD_TIMESTAMP_RANGE_NO_TZ = st.datetimes(

--- a/pandas/tests/tseries/offsets/test_offsets_properties.py
+++ b/pandas/tests/tseries/offsets/test_offsets_properties.py
@@ -8,15 +8,11 @@ You may wish to consult the previous version for inspiration on further
 tests, or when trying to pin down the bugs exposed by the tests below.
 """
 
-import zoneinfo
-
 from hypothesis import (
     assume,
     given,
 )
 import pytest
-
-from pandas.compat import WASM
 
 import pandas as pd
 from pandas._testing._hypothesis import (
@@ -33,15 +29,6 @@ from pandas._testing._hypothesis import (
 @given(DATETIME_JAN_1_1900_OPTIONAL_TZ, YQM_OFFSET)
 def test_on_offset_implementations(dt, offset):
     assume(not offset.normalize)
-    # This case is flaky in CI 2024-11-04
-    assume(
-        not (
-            WASM
-            and isinstance(dt.tzinfo, zoneinfo.ZoneInfo)
-            and dt.tzinfo.key == "Indian/Cocos"
-            and isinstance(offset, pd.offsets.MonthBegin)
-        )
-    )
     # check that the class-specific implementations of is_on_offset match
     # the general case definition:
     #   (dt + offset) - offset == dt


### PR DESCRIPTION
closes #60205

`test_on_offset_implementations` was failing on the Pyodide build for
`datetime(1900, 1, 1, tzinfo=ZoneInfo("Indian/Cocos"))` + `MonthBegin(0)`. This is not
actually WASM-specific, and not a pandas bug.

In tzdata builds that include `backzone`, `Indian/Cocos` is a standalone zone whose first
transition is 1900-01-01 00:00 LMT (+06:27:40) -> +06:30, so wall times 00:00:00-00:02:19
on that date never occur. Per PEP 495 such a datetime reports the pre-gap offset but does
not survive a UTC round-trip:

```
>>> dt = datetime(1900, 1, 1, tzinfo=ZoneInfo("Indian/Cocos"))
>>> dt.astimezone(timezone.utc).astimezone(dt.tzinfo)
datetime.datetime(1900, 1, 1, 0, 2, 20, tzinfo=zoneinfo.ZoneInfo(key="Indian/Cocos"))
```

so `(dt + offset) - offset == dt` fails by construction. The existing
`except ValueError: assume(False)` does not catch it because the nonexistence is in the
input, not in the result of the arithmetic (`Timestamp.tz_localize` does raise for that
gap). The mainline tzdata build makes `Indian/Cocos` a Link to `Asia/Yangon`, which has no
1900 transition — that is why only Pyodide saw it.

Fix is to tell hypothesis not to generate imaginary local times at all
(`allow_imaginary=False`), replacing the zone-specific `assume` added in GH-60186.

Reproduced the original traceback locally by compiling the `backzone` rule with `zic` and
pointing `PYTHONTZPATH` at the resulting tree; the test passes there with this change and
fails without it.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the
failure, diagnosed the root cause, and wrote the patch.