### PR TITLE
DOC: don't include source files in the html output

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -610,6 +610,10 @@ html_favicon = "../../web/pandas/static/img/favicon.ico"
 # Custom sidebar templates, maps document names to template names.
 # html_sidebars = {}
 
+# Our html theme does not have "show source" button in the sidebar, so also
+# don't copy source files to the html output to save space.
+html_copy_source = False
+
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
 


### PR DESCRIPTION
It's not a big space saver, but every bit helps I assume. 
Currently the raw text sources are included in the html output and thus in the hosted docs (e.g. https://pandas.pydata.org/docs/_sources/reference/api/pandas.DataFrame.rst.txt or https://pandas.pydata.org/docs/_sources/user_guide/10min.rst.txt), and they currently take around 4.4MB for the dev docs. Since those links are not really accessible (our html theme does not provide a link to it), it doesn't seem useful to actually host them. 

This setting avoids them being copied into the html output.

I could also remove them for prior existing versions in https://github.com/pandas-dev/pandas-dev.github.io/