### PR TITLE
PERF: avoid redundant cond preparation in NDFrame._where (GH#51547)

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -840,6 +840,16 @@ class Where:
         self.df.where(self.mask, other=0.0, inplace=inplace)
 
 
+class WhereMisalignedCond:
+    def setup(self):
+        N = 100_000
+        self.df = DataFrame(np.random.randn(N, 10))
+        self.mask = (self.df < 0).iloc[: N // 2]
+
+    def time_where_misaligned(self):
+        self.df.where(self.mask, other=0.0)
+
+
 class FindValidIndex:
     param_names = ["dtype"]
     params = [

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -385,6 +385,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.to_hdf` and :meth:`HDFStore.append` for table format when appending to an existing wide table with many ``data_columns`` (:issue:`25839`)
 - Performance improvement in :meth:`DataFrame.to_stata` when writing object-dtype datetime columns with date formats that require year/month extraction (:issue:`64555`)
 - Performance improvement in :meth:`DataFrame.unstack` and :meth:`Series.unstack` when the :class:`MultiIndex` is already sorted and the unstacked level is the last level (:issue:`65107`)
+- Performance improvement in :meth:`DataFrame.where`, :meth:`DataFrame.mask`, :meth:`DataFrame.clip`, :meth:`Series.where`, :meth:`Series.mask`, :meth:`Series.clip`, and boolean-mask ``__setitem__`` with a boolean ``cond``; largest when ``cond`` does not share the object's index (:issue:`51547`)
 - Performance improvement in :meth:`DataFrame.xs` and :meth:`Series.xs` with a partial key on a :class:`MultiIndex` (:issue:`38650`)
 - Performance improvement in :meth:`DataFrame` reductions (e.g. :meth:`DataFrame.any`, :meth:`DataFrame.sum`, :meth:`DataFrame.idxmax`) with ``axis=1`` on extension array dtypes such as :class:`BooleanDtype`, nullable integer/float, and :class:`ArrowDtype` (:issue:`56903`)
 - Performance improvement in :meth:`DatetimeIndex.month_name` and :meth:`DatetimeIndex.day_name` when using the default string dtype by using PyArrow compute instead of going through an intermediate object array (:issue:`65104`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -211,6 +211,20 @@ if TYPE_CHECKING:
     from pandas.core.resample import Resampler
 
 
+def _is_np_bool_backed(obj: NDFrame) -> bool:
+    """
+    Is obj backed entirely by numpy bool arrays?
+
+    Such an object needs neither filling nor casting to be used as a `where`
+    condition, so we can skip that machinery altogether (GH#51547).
+    """
+    if isinstance(obj, ABCDataFrame):
+        dtypes: list[DtypeObj] = [block.dtype for block in obj._mgr.blocks]
+    else:
+        dtypes = [obj.dtype]
+    return all(lib.is_np_dtype(dtype, "b") for dtype in dtypes)
+
+
 class NDFrame(PandasObject, indexing.IndexingMixin):
     """
     N-dimensional analogue of DataFrame. Store multi-dimensional in a
@@ -10262,6 +10276,8 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         if axis is not None:
             axis = self._get_axis_number(axis)
 
+        fill_value = bool(inplace)
+
         # align the cond to same shape as myself
         cond = common.apply_if_callable(cond, self)
         if isinstance(cond, NDFrame):
@@ -10280,7 +10296,16 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                         copy=False,
                     )
                     cond.columns = self.columns
-            cond = cond.align(self, join="right")[0]
+            if _is_np_bool_backed(cond) and self.ndim == 2:
+                # GH#51547 a bool cond that needs reindexing would otherwise be
+                #  cast to object and cast back by the fillna/infer_objects
+                #  below.  Only safe for ndim==2: _align_series applies
+                #  fill_value via fillna to *both* objects, so it would alter
+                #  self.  Only safe for bool cond: for other dtypes a bool
+                #  fill_value is an incompatible reindex fill.
+                cond = cond.align(self, join="right", fill_value=fill_value)[0]
+            else:
+                cond = cond.align(self, join="right")[0]
         else:
             if not hasattr(cond, "shape"):
                 cond = np.asanyarray(cond)
@@ -10289,39 +10314,40 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             cond = self._constructor(cond, **self._construct_axes_dict(), copy=False)
 
         # make sure we are boolean
-        fill_value = bool(inplace)
-        with warnings.catch_warnings():
-            # GH#45153 suppress Pandas4Warning from fillna with
-            # incompatible value; if cond is not boolean, the dtype
-            # check below will raise TypeError anyway.
-            warnings.filterwarnings("ignore", ".*fill value.*", Pandas4Warning)
-            cond = cond.fillna(fill_value)
-        cond = cond.infer_objects()
+        if not _is_np_bool_backed(cond):
+            with warnings.catch_warnings():
+                # GH#45153 suppress Pandas4Warning from fillna with
+                # incompatible value; if cond is not boolean, the dtype
+                # check below will raise TypeError anyway.
+                warnings.filterwarnings("ignore", ".*fill value.*", Pandas4Warning)
+                cond = cond.fillna(fill_value)
+            cond = cond.infer_objects()
 
-        msg = "Boolean array expected for the condition, not {dtype}"
+            msg = "Boolean array expected for the condition, not {dtype}"
 
-        if not cond.empty:
-            if not isinstance(cond, ABCDataFrame):
-                # This is a single-dimensional object.
-                if not is_bool_dtype(cond):
-                    raise TypeError(msg.format(dtype=cond.dtype))
+            if not cond.empty:
+                if not isinstance(cond, ABCDataFrame):
+                    # This is a single-dimensional object.
+                    if not is_bool_dtype(cond):
+                        raise TypeError(msg.format(dtype=cond.dtype))
+                else:
+                    for block in cond._mgr.blocks:
+                        if not is_bool_dtype(block.dtype):
+                            raise TypeError(msg.format(dtype=block.dtype))
+                    if cond._mgr.any_extension_types:
+                        # GH51574: avoid object ndarray conversion later on
+                        cond = cond._constructor(
+                            cond.to_numpy(dtype=bool, na_value=fill_value),
+                            **cond._construct_axes_dict(),
+                        )
             else:
-                for block in cond._mgr.blocks:
-                    if not is_bool_dtype(block.dtype):
-                        raise TypeError(msg.format(dtype=block.dtype))
-                if cond._mgr.any_extension_types:
-                    # GH51574: avoid object ndarray conversion later on
-                    cond = cond._constructor(
-                        cond.to_numpy(dtype=bool, na_value=fill_value),
-                        **cond._construct_axes_dict(),
-                    )
-        else:
-            # GH#21947 we have an empty DataFrame/Series, could be object-dtype
-            cond = cond.astype(bool)
+                # GH#21947 we have an empty DataFrame/Series, could be object-dtype
+                cond = cond.astype(bool)
 
         cond_for_ea = cond
         cond = -cond if inplace else cond
-        cond = cond.reindex(self._info_axis, axis=self._info_axis_number)
+        if not cond._info_axis.equals(self._info_axis):
+            cond = cond.reindex(self._info_axis, axis=self._info_axis_number)
 
         # try to align with other
         if isinstance(other, NDFrame):


### PR DESCRIPTION
closes #51547

`NDFrame._where` prepares `cond` for the general case — reindex it, fill it, cast it —
even when the caller handed it a plain boolean object, which is the overwhelmingly common
case (`df.where(df > 0)`, `df[cond] = x`, `clip`).

- A boolean `cond` needs neither filling nor casting, so the whole
  `fillna` / `infer_objects` / dtype-validation block is skipped for one.
- `fill_value` is passed to the align, so a boolean `cond` that needs reindexing stays
  boolean instead of making a round trip out to object dtype and back.
- The trailing `reindex(self._info_axis, ...)` is a no-op once the align has run, so it is
  guarded on the axes actually differing.

Passing `fill_value` to `align` is only safe for a numpy-bool `cond` on a 2-D object, and
the diff gates it accordingly:

- for `ndim == 1`, `_align_series` applies `fill_value` via a blanket `fillna` to *both*
  returned objects, so it would alter `self`.  (That looks like a bug in `align` in its own
  right — `_align_frame` threads `fill_value` into the reindex and so fills only the labels
  alignment invented, while any `align` whose `other` is a `Series` also overwrites NA that
  was already in the data.  I'll file it separately; fixing it would let this gate go away
  and extend the speedup to `Series`.)
- for a non-bool `cond`, a bool `fill_value` is an incompatible reindex fill — it emits a
  stray `Pandas4Warning` for numeric conds and replaces the clean
  `TypeError: Boolean array expected for the condition, not <dtype>` with a confusing one.

This is a second attempt at GH-64636, which I closed after hitting exactly those two cases;
gating on the dtype and ndim is what makes it work.

## Timings

macOS arm64, `min` of 7 runs.

| case | main | PR | |
|---|---|---|---|
| `df.where`, misaligned rows | 1084 µs | 94 µs | **11.5x** |
| `ser.where`, bool cond | 50.9 µs | 30.1 µs | 1.69x |
| `df.where`, ndarray cond | 73.8 µs | 44.0 µs | 1.68x |
| `df.where`, bool cond, aligned | 80.2 µs | 50.6 µs | 1.58x |
| `df.mask`, bool cond | 93.8 µs | 65.7 µs | 1.43x |
| `df[cond] = 0` | 184 µs | 148 µs | 1.25x |
| `df.clip(0, 1)` | 365 µs | 301 µs | 1.21x |
| `df.where`, 100k x 20 | 955 µs | 834 µs | 1.15x |

The misaligned case is where the object round trip disappears. The existing `Where` and
`MaskBool` benchmarks are all aligned and large enough to be data-bound, so none of them
can see this; `WhereMisalignedCond` is added to cover it.

## Behavior

No behavior change intended. Checked with a 510-case differential — 10 object dtypes
(numpy, masked, Arrow, string, categorical, datetime-tz, empty) crossed with cond
dtype/alignment (aligned, short, extra label, missing column, nullable, object, Arrow,
integer, ndarray), scalar and Series `other`, and `where` / `mask` / `where(inplace=True)`
— comparing repr, dtypes, exception text and emitted warnings against main. 0 differences.

## Notes

Two of the three ideas in the issue are here. The third — pushing `cond = -cond if inplace`
down a level — measures as 46 µs of an 11.3 ms `df[cond] = 0` on a 100k x 20 frame, i.e.
0.4%, so it does not look worth the plumbing.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which profiled the
existing path, wrote the patch and the differential harness, and produced the timings above.
