### PR TITLE
PERF: reduce memory reserved during numeric inference (GH#35051)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -420,6 +420,7 @@ Performance improvements
 - Performance improvement in reductions along ``axis=1`` and other operations on DataFrames produced by :meth:`DataFrame.copy` (:issue:`60469`)
 - Performance improvement in reductions with ``axis=1`` (e.g. :meth:`DataFrame.sum`, :meth:`DataFrame.mean`, :meth:`DataFrame.std`), especially on single-dtype DataFrames with many rows (:issue:`51474`)
 - Performance improvement in repr of :class:`Series` and :class:`DataFrame` containing third-party array-like objects (e.g. xarray ``DataArray``) in object dtype columns (:issue:`61809`)
+- Reduced memory usage of :func:`to_numeric`, and of the numeric type inference :func:`read_csv` performs with ``engine="python"``, which reserved roughly six times the memory of the converted column (:issue:`35051`)
 - Performance improvement in :meth:`DataFrame.loc` and :meth:`DataFrame.iloc`
   setitem with a 2D list-of-lists value by avoiding a wasteful round-trip
   through an intermediate object array (:issue:`64229`).
@@ -588,6 +589,7 @@ Conversion
 - Fixed :func:`pandas.array` to preserve mask information when converting NumPy masked arrays, converting masked values to missing values (:issue:`63879`)
 - Fixed bug in :class:`DataFrame` constructor where mutating the result could corrupt the source :class:`Series` or :class:`Index` when built with ``dtype="str"`` and ``infer_string=False`` (:issue:`63936`)
 - Fixed bug in :func:`to_numeric` where a string containing an embedded NUL byte was converted using only the bytes before the NUL, so e.g. ``"1.5\x00xyz"`` silently became ``1.5``; such values now raise, or become ``NaN`` with ``errors="coerce"`` (:issue:`66524`)
+- Fixed bug in :func:`to_numeric` where values preceding the first complex number in ``object``-dtype data were replaced with uninitialized memory, so e.g. ``to_numeric(Series(["1.5", 2j]))`` returned ``0j`` in place of ``1.5+0j`` (:issue:`35051`)
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``TypeError`` when ``to_replace`` was ``Ellipsis`` (``...``) (:issue:`50373`)
 - Fixed bug in :meth:`DataFrame.to_dict` with ``orient="index"`` did not respect the ``into`` argument in nested mappings (:issue:`65778`)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -2536,6 +2536,20 @@ cpdef bint is_interval_array(ndarray values):
     return True
 
 
+cdef tuple _empty_int_buffers(ndarray values):
+    """
+    Allocate the buffers `maybe_convert_numeric` fills in once it sees an integer.
+
+    Held off until then so that a column with no integers in it does not pay for
+    them; see the note in `maybe_convert_numeric` (GH#35051).
+    """
+    return (
+        cnp.PyArray_EMPTY(1, values.shape, cnp.NPY_INT64, 0),
+        cnp.PyArray_EMPTY(1, values.shape, cnp.NPY_UINT64, 0),
+        cnp.PyArray_EMPTY(1, values.shape, cnp.NPY_OBJECT, 0),
+    )
+
+
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def maybe_convert_numeric(
@@ -2596,6 +2610,10 @@ def maybe_convert_numeric(
             pass
 
     # Otherwise, iterate and do full inference.
+    # `floats` is filled in by every branch below, so the other result buffers
+    # are only allocated once a value of the corresponding kind shows up.  A
+    # column of floats is the common case, and allocating the rest up front
+    # costs ~5x the memory of the array actually returned (GH#35051).
     cdef:
         int maybe_int
         Py_ssize_t i, n = values.size
@@ -2603,22 +2621,17 @@ def maybe_convert_numeric(
         ndarray[float64_t, ndim=1] floats = cnp.PyArray_EMPTY(
             1, values.shape, cnp.NPY_FLOAT64, 0
         )
-        ndarray[complex128_t, ndim=1] complexes = cnp.PyArray_EMPTY(
-            1, values.shape, cnp.NPY_COMPLEX128, 0
-        )
-        ndarray[int64_t, ndim=1] ints = cnp.PyArray_EMPTY(
-            1, values.shape, cnp.NPY_INT64, 0
-        )
-        ndarray[uint64_t, ndim=1] uints = cnp.PyArray_EMPTY(
-            1, values.shape, cnp.NPY_UINT64, 0
-        )
-        ndarray[object, ndim=1] pyints = cnp.PyArray_EMPTY(
-            1, values.shape, cnp.NPY_OBJECT, 0
-        )
-        ndarray[uint8_t, ndim=1] bools = cnp.PyArray_EMPTY(
-            1, values.shape, cnp.NPY_UINT8, 0
-        )
+        ndarray[complex128_t, ndim=1] complexes = None
+        ndarray[int64_t, ndim=1] ints = None
+        ndarray[uint64_t, ndim=1] uints = None
+        ndarray[object, ndim=1] pyints = None
+        ndarray[uint8_t, ndim=1] bools = None
         ndarray[uint8_t, ndim=1] mask = np.zeros(n, dtype="u1")
+        # tracked separately: testing the buffers against None on each
+        # iteration measurably slows the loop down
+        bint have_complexes = False
+        bint have_ints = False
+        bint have_bools = False
         float64_t fval
         bint allow_null_in_int = convert_to_masked_nullable
 
@@ -2638,7 +2651,9 @@ def maybe_convert_numeric(
                 if convert_to_masked_nullable:
                     mask[i] = 1
                 seen.saw_null()
-            floats[i] = complexes[i] = NaN
+            floats[i] = NaN
+            if have_complexes:
+                complexes[i] = NaN
         elif util.is_float_object(val):
             fval = val
             if fval != fval:
@@ -2651,12 +2666,19 @@ def maybe_convert_numeric(
                     seen.float_ = True
             else:
                 seen.float_ = True
-            floats[i] = complexes[i] = fval
+            floats[i] = fval
+            if have_complexes:
+                complexes[i] = fval
         elif util.is_integer_object(val):
-            floats[i] = complexes[i] = val
+            floats[i] = val
+            if have_complexes:
+                complexes[i] = val
 
             val = int(val)
             seen.saw_int(val)
+            if not have_ints:
+                ints, uints, pyints = _empty_int_buffers(values)
+                have_ints = True
             pyints[i] = val
 
             if val >= 0:
@@ -2677,7 +2699,15 @@ def maybe_convert_numeric(
                     seen.overflow_ = True
 
         elif util.is_bool_object(val):
+            if not have_ints:
+                ints, uints, pyints = _empty_int_buffers(values)
+                have_ints = True
+            if not have_bools:
+                bools = cnp.PyArray_EMPTY(1, values.shape, cnp.NPY_UINT8, 0)
+                have_bools = True
             floats[i] = uints[i] = ints[i] = bools[i] = val
+            if have_complexes:
+                complexes[i] = val
             seen.bool_ = True
         elif val is None or val is C_NA:
             if allow_null_in_int:
@@ -2687,19 +2717,33 @@ def maybe_convert_numeric(
                 if convert_to_masked_nullable:
                     mask[i] = 1
                 seen.saw_null()
-            floats[i] = complexes[i] = NaN
+            floats[i] = NaN
+            if have_complexes:
+                complexes[i] = NaN
         elif hasattr(val, "__len__") and len(val) == 0:
             if convert_empty or seen.coerce_numeric:
                 seen.saw_null()
-                floats[i] = complexes[i] = NaN
+                floats[i] = NaN
+                if have_complexes:
+                    complexes[i] = NaN
                 mask[i] = 1
             else:
                 raise ValueError("Empty string encountered")
         elif util.is_complex_object(val):
+            if not have_complexes:
+                complexes = cnp.PyArray_EMPTY(
+                    1, values.shape, cnp.NPY_COMPLEX128, 0
+                )
+                # Every preceding branch stored its value in `floats`, so the
+                # already-seen entries carry over unchanged.
+                complexes[:i] = floats[:i]
+                have_complexes = True
             complexes[i] = val
             seen.complex_ = True
         elif is_decimal(val):
-            floats[i] = complexes[i] = val
+            floats[i] = val
+            if have_complexes:
+                complexes[i] = val
             seen.float_ = True
         else:
             try:
@@ -2707,7 +2751,9 @@ def maybe_convert_numeric(
 
                 if fval in na_values:
                     seen.saw_null()
-                    floats[i] = complexes[i] = NaN
+                    floats[i] = NaN
+                    if have_complexes:
+                        complexes[i] = NaN
                     mask[i] = 1
                 else:
                     if fval != fval:
@@ -2715,9 +2761,14 @@ def maybe_convert_numeric(
                         mask[i] = 1
 
                     floats[i] = fval
+                    if have_complexes:
+                        complexes[i] = fval
 
                 if maybe_int:
                     as_int = int(val)
+                    if not have_ints:
+                        ints, uints, pyints = _empty_int_buffers(values)
+                        have_ints = True
                     pyints[i] = as_int
 
                     if as_int in na_values:
@@ -2790,6 +2841,8 @@ def maybe_convert_numeric(
         return (bools.view(np.bool_), None)
     elif seen.uint_:
         return (uints, None)
+    if not have_ints:
+        ints = cnp.PyArray_EMPTY(1, values.shape, cnp.NPY_INT64, 0)
     return (ints, None)
 
 

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -709,6 +709,23 @@ class TestInference:
         tm.assert_numpy_array_equal(lib.maybe_convert_numeric(arr, set())[0], exp)
 
     @pytest.mark.parametrize(
+        "arr, expected",
+        [
+            (["1.5", 2j], [1.5 + 0j, 2j]),
+            (["1", 2j], [1 + 0j, 2j]),
+            ([1.5, 2j], [1.5 + 0j, 2j]),
+            ([1, 2j], [1 + 0j, 2j]),
+            ([True, 2j], [1 + 0j, 2j]),
+            ([Decimal("1.5"), 2j], [1.5 + 0j, 2j]),
+            ([np.nan, 2j], [complex(np.nan, 0), 2j]),
+        ],
+    )
+    def test_convert_numeric_complex_keeps_preceding_values(self, arr, expected):
+        # GH#35051 entries seen before the first complex were left uninitialized
+        result, _ = lib.maybe_convert_numeric(np.array(arr, dtype=object), set())
+        tm.assert_numpy_array_equal(result, np.array(expected, dtype=np.complex128))
+
+    @pytest.mark.parametrize(
         "arr",
         [
             np.array([2**63, np.nan], dtype=object),

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -970,3 +970,16 @@ def test_embedded_nul_is_not_a_float(value):
 
     result = to_numeric(ser, errors="coerce")
     tm.assert_series_equal(result, Series([np.nan]))
+
+
+@pytest.mark.parametrize(
+    "data, expected",
+    [
+        (["1.5", 2j], [1.5 + 0j, 2j]),
+        ([True, 2j], [1 + 0j, 2j]),
+    ],
+)
+def test_complex_keeps_preceding_values(data, expected):
+    # GH#35051 entries seen before the first complex were left uninitialized
+    result = to_numeric(Series(data, dtype=object))
+    tm.assert_series_equal(result, Series(expected, dtype=np.complex128))


### PR DESCRIPTION
Investigated GH-35051 (`read_csv` segfaulting on large files). It is not memory
unsafety: with `engine="python"` the parser materializes the whole file as Python
`str` objects before converting anything, so peak RSS runs ~700-830 bytes per
113-byte row, ~90% of it in `_get_lines`. The reporter's 947 MB gzip is ~34M rows,
so ~24 GB peak on a SLURM node — an OOM that presents as SIGSEGV/SIGBUS under a
cgroup limit. `engine="c"` reads the same input in 132-257 bytes/row, ~23x faster,
producing a bit-identical frame.

**This PR does not close that issue** — end-to-end `read_csv` peak RSS is unchanged
(5.7 GB for 8M rows either way), because the peak is `_get_lines` and the buffers
below were mostly untouched virtual pages. What it does fix is the amplifier sitting
at the exact frame the reporter crashed in.

### Memory

`maybe_convert_numeric` allocated six full-length buffers (`complexes`, `ints`,
`uints`, `pyints`, `bools`, `mask`) up front regardless of what the column turned
out to hold — ~48 bytes of address space per element to return an 8 byte/element
`float64` array. Each is now allocated on first use.

On a 20M-element object column of float strings:

| | before | after |
|---|---|---|
| reserved | 48 B/elt | 9 B/elt |
| resident | 30 B/elt | 22 B/elt |

The resident part was `pyints` — NumPy zero-fills object arrays on allocation, so
that one was really being touched. The reservation is what `ulimit -v` and
`vm.overcommit_memory=2` count, which is the HPC setting in the issue.

Timings are at parity (2M-element columns, best of 5, before → after): float strings
236 → 233 ms, int strings 408 → 413 ms, float objects 65 → 60 ms, mixed with NA
338 → 324 ms.

### Correctness

Allocating `complexes` lazily means backfilling it from `floats` when the first
complex shows up, and that turns out to fix uninitialized slots. The string branch
and the bool branch never wrote `complexes[i]`, so a complex appearing later in the
column returned whatever was in those slots for every value before it:

```python
>>> pd.to_numeric(pd.Series(["1.5", 2j], dtype=object))   # before
0     0.000000+0.000000j                                  # <- 1.5+0j
1     0.000000+2.000000j
```

`floats` is authoritative at every index a non-complex branch touched, so
`complexes[:i] = floats[:i]` is the correct fill. The two changes are inseparable —
the backfill is what lazy allocation requires — so they are in one PR rather than
two.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which measured the
memory and timing profiles, wrote the patch, and found the `complexes` bug while
restructuring the allocation.
