### PR TITLE
TST: tz preserved when plotting tz-aware column on the y-axis (GH#26676)

### DIFF
--- a/pandas/tests/plotting/frame/test_frame_subplots.py
+++ b/pandas/tests/plotting/frame/test_frame_subplots.py
@@ -152,6 +152,28 @@ class TestDataFramePlotsSubplots:
         expected = testdata[col]._values
         assert (result == expected).all()
 
+    def test_plot_y_datetime_tz_aware(self):
+        # GH#26676 the tz was dropped when plotting a tz-aware column on the y-axis
+        mdates = pytest.importorskip("matplotlib.dates")
+
+        dti = pd.to_datetime(
+            ["2017-08-01 00:00:00", "2017-08-01 02:00:00", "2017-08-02 00:00:00"]
+        )
+        ser = Series(dti.tz_localize("US/Eastern"), name="dt_tz")
+
+        ax = ser.to_frame().plot(y="dt_tz")
+
+        ydata = ax.get_lines()[0].get_ydata()
+        assert all(entry.tz is not None for entry in ydata)
+
+        # the points sit at their actual instants, not at the naive wall times
+        positions = np.asarray(ax.yaxis.get_converter().convert(ydata, None, ax.yaxis))
+        tm.assert_numpy_array_equal(positions, mdates.date2num(np.asarray(ydata)))
+        assert (positions != mdates.date2num(dti._values)).all()
+
+        # ... and the ticks are labeled in the column's own tz
+        assert ax.yaxis.units == ser.dt.tz
+
     def test_subplots_timeseries_y_text_error(self):
         # GH16953
         data = {


### PR DESCRIPTION
closes #26676

The `FutureWarning` and the dropped timezone reported in the issue are both gone on main: `_iter_data` now goes through `np.asarray(values._values)` (GH-64613), which hands matplotlib an object array of tz-aware `Timestamp`s instead of silently converting to naive `datetime64[ns]`. Points land at their true instants and the ticks are labeled in the column's own tz, matching what plain `ax.plot()` does with the same values.

Adding a regression test so it stays that way. It uses a non-UTC zone deliberately — with UTC the correct and the tz-dropping behavior are indistinguishable. Confirmed it fails if the conversion is reverted to the lossy form.

The remaining complaint in the issue — no year, "weird-looking hour" — is matplotlib's default `AutoDateFormatter` output, identical without pandas in the picture.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the issue, bisected the current behavior against matplotlib's native handling, and wrote the test.