### PR TITLE
DOC: clarify missing value handling in factorize docstring when use_na_sentinel is False

### DIFF
--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -876,7 +876,7 @@ def factorize(
         .. note::
 
            Even if there's a missing value in `values`, `uniques` will
-           *not* contain an entry for it.
+           *not* contain an entry for it when ``use_na_sentinel=True`` (default).
 
     See Also
     --------


### PR DESCRIPTION
- [x] closes #58000
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_code_base.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_code_base.html#pre-commit).
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.

## Description
Clarifies that in `pandas.factorize`, `uniques` will not contain an entry for missing values specifically when `use_na_sentinel=True` (default). When `use_na_sentinel=False`, NaN is preserved in `uniques`.