### PR TITLE
TST: fix and test tm.shares_memory (GH#55372)

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -496,6 +496,21 @@ def get_finest_unit(left: str, right: str) -> str:
     return right
 
 
+def _pa_buffer_addresses(pa_data) -> set[int]:
+    """
+    Addresses of the non-empty buffers backing a pyarrow ChunkedArray.
+
+    Zero-length buffers are excluded because distinct empty arrays can be
+    handed out the same address, which would look like sharing.
+    """
+    return {
+        buf.address
+        for chunk in pa_data.iterchunks()
+        for buf in chunk.buffers()
+        if buf is not None and buf.size > 0
+    }
+
+
 def shares_memory(left: Any, right: Any) -> bool:
     """
     Pandas-compat for np.shares_memory.
@@ -509,7 +524,7 @@ def shares_memory(left: Any, right: Any) -> bool:
     if isinstance(left, RangeIndex):
         return False
     if isinstance(left, MultiIndex):
-        return shares_memory(left._codes, right)
+        return any(shares_memory(codes, right) for codes in left._codes)
     if isinstance(left, (Index, Series)):
         if isinstance(right, (Index, Series)):
             return shares_memory(left._values, right._values)
@@ -525,22 +540,22 @@ def shares_memory(left: Any, right: Any) -> bool:
     if isinstance(left, ArrowExtensionArray):
         if isinstance(right, ArrowExtensionArray):
             # https://github.com/pandas-dev/pandas/pull/43930#discussion_r736862669
-            left_pa_data = left._pa_array
-            right_pa_data = right._pa_array
-            left_buf1 = left_pa_data.chunk(0).buffers()[1]
-            right_buf1 = right_pa_data.chunk(0).buffers()[1]
-            return left_buf1.address == right_buf1.address
+            left_addrs = _pa_buffer_addresses(left._pa_array)
+            right_addrs = _pa_buffer_addresses(right._pa_array)
+            return not left_addrs.isdisjoint(right_addrs)
         else:
             # if we have one ArrowExtensionArray and one other array, assume
             # they can only share memory if they share the same numpy buffer
             return np.shares_memory(left, right)
 
-    if isinstance(left, BaseMaskedArray) and isinstance(right, BaseMaskedArray):
+    if isinstance(left, BaseMaskedArray):
         # By convention, we'll say these share memory if they share *either*
         #  the _data or the _mask
-        return np.shares_memory(left._data, right._data) or np.shares_memory(
-            left._mask, right._mask
-        )
+        if isinstance(right, BaseMaskedArray):
+            return shares_memory(left._data, right._data) or shares_memory(
+                left._mask, right._mask
+            )
+        return shares_memory(left._data, right) or shares_memory(left._mask, right)
 
     if isinstance(left, DataFrame) and len(left._mgr.blocks) == 1:
         arr = left._mgr.blocks[0].values

--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -496,7 +496,7 @@ def get_finest_unit(left: str, right: str) -> str:
     return right
 
 
-def _pa_buffer_addresses(pa_data) -> set[int]:
+def _pa_buffer_addresses(pa_data: pa.ChunkedArray) -> set[int]:
     """
     Addresses of the non-empty buffers backing a pyarrow ChunkedArray.
 

--- a/pandas/tests/util/test_shares_memory.py
+++ b/pandas/tests/util/test_shares_memory.py
@@ -1,9 +1,89 @@
 import numpy as np
+import pytest
 
 import pandas.util._test_decorators as td
 
 import pandas as pd
 import pandas._testing as tm
+
+
+def test_shares_memory_numpy():
+    arr = np.arange(10)
+    view = arr[:5]
+    assert tm.shares_memory(arr, view)
+    arr2 = np.arange(10)
+    assert not tm.shares_memory(arr, arr2)
+
+
+def test_shares_memory_ndarray_and_ea():
+    # GH#55372 the ndarray may be passed as either argument
+    obj = pd.Categorical(["a", "b", "a"])
+    assert tm.shares_memory(obj._ndarray, obj)
+    assert tm.shares_memory(obj, obj._ndarray)
+
+    assert not tm.shares_memory(np.arange(3, dtype=np.int8), obj)
+
+
+def test_shares_memory_rangeindex():
+    idx = pd.RangeIndex(10)
+    arr = np.arange(10)
+    assert not tm.shares_memory(idx, arr)
+    assert not tm.shares_memory(idx, idx)
+
+
+def test_shares_memory_multiindex():
+    # GH#55372
+    mi = pd.MultiIndex.from_product([[1, 2], ["a", "b"]])
+
+    assert tm.shares_memory(mi, mi)
+    for codes in mi.codes:
+        assert tm.shares_memory(mi, codes)
+
+    assert not tm.shares_memory(mi, mi.copy(deep=True))
+    # the levels are not what backs a MultiIndex's values
+    assert not tm.shares_memory(mi, mi.levels[0])
+
+
+def test_shares_memory_index_and_series():
+    ser = pd.Series(np.arange(10))
+    idx = pd.Index(ser._values, copy=False)
+
+    assert tm.shares_memory(ser, idx)
+    assert tm.shares_memory(idx, ser)
+    assert tm.shares_memory(ser, ser._values)
+
+    assert not tm.shares_memory(ser, ser.copy(deep=True))
+
+
+@pytest.mark.parametrize(
+    "obj",
+    [
+        pd.Categorical(["a", "b", "a"]),
+        pd.array(["a", "b"], dtype=pd.StringDtype("python")),
+        pd.date_range("2016-01-01", periods=3, tz="US/Pacific")._data,
+        pd.period_range("2016-01-01", periods=3, freq="D")._data,
+        pd.timedelta_range("1 Day", periods=3)._data,
+    ],
+)
+def test_shares_memory_ndarray_backed(obj):
+    # GH#55372
+    assert tm.shares_memory(obj, obj)
+    assert tm.shares_memory(obj, obj[:2])
+    assert tm.shares_memory(obj, obj._ndarray)
+
+    assert not tm.shares_memory(obj, obj.copy())
+
+
+def test_shares_memory_sparse():
+    # GH#55372
+    obj = pd.arrays.SparseArray([0, 1, 0, 2])
+
+    assert tm.shares_memory(obj, obj)
+    assert tm.shares_memory(obj, obj.sp_values)
+
+    assert not tm.shares_memory(obj, obj.copy())
+    # the sparse index is not memory we track
+    assert not tm.shares_memory(obj, obj.sp_index.indices)
 
 
 def test_shares_memory_interval():
@@ -15,6 +95,40 @@ def test_shares_memory_interval():
     assert tm.shares_memory(obj, obj[:2])
 
     assert not tm.shares_memory(obj, obj._data.copy())
+
+
+def test_shares_memory_interval_one_side():
+    # GH#55372 sharing either side counts as sharing
+    obj = pd.arrays.IntervalArray.from_breaks(np.arange(5))
+    other = pd.arrays.IntervalArray.from_arrays(obj.left.copy(), obj.right)
+
+    assert tm.shares_memory(obj, other)
+    assert tm.shares_memory(obj, obj.right)
+
+
+def test_shares_memory_masked():
+    # GH#55372
+    obj = pd.array([1, 2, None], dtype="Int64")
+
+    assert tm.shares_memory(obj, obj)
+    assert not tm.shares_memory(obj, obj.copy())
+
+    # a masked array can be compared against something other than a masked array
+    assert tm.shares_memory(obj, obj._data)
+    assert tm.shares_memory(obj, obj._mask)
+    assert tm.shares_memory(obj._data, obj)
+    assert not tm.shares_memory(obj, np.arange(3))
+
+    assert tm.shares_memory(pd.Series(obj, copy=False), obj._data)
+
+
+def test_shares_memory_masked_shared_mask_only():
+    # GH#55372 sharing either the values or the mask counts as sharing
+    obj = pd.array([1, 2, None], dtype="Int64")
+    other = pd.arrays.IntegerArray(obj._data.copy(), obj._mask)
+
+    assert not tm.shares_memory(obj._data, other._data)
+    assert tm.shares_memory(obj, other)
 
 
 @td.skip_if_no("pyarrow")
@@ -32,15 +146,93 @@ def test_shares_memory_string():
     assert tm.shares_memory(obj, obj)
 
 
-def test_shares_memory_numpy():
-    arr = np.arange(10)
-    view = arr[:5]
-    assert tm.shares_memory(arr, view)
-    arr2 = np.arange(10)
-    assert not tm.shares_memory(arr, arr2)
+@td.skip_if_no("pyarrow")
+def test_shares_memory_arrow():
+    obj = pd.array([1, 2, 3], dtype="int64[pyarrow]")
+
+    # pyarrow buffers are immutable, so a copy is not a defensive one
+    assert tm.shares_memory(obj, obj)
+    assert tm.shares_memory(obj, obj.copy())
+
+    assert not tm.shares_memory(obj, pd.array([1, 2, 3], dtype="int64[pyarrow]"))
 
 
-def test_shares_memory_rangeindex():
-    idx = pd.RangeIndex(10)
-    arr = np.arange(10)
-    assert not tm.shares_memory(idx, arr)
+@td.skip_if_no("pyarrow")
+def test_shares_memory_arrow_chunked():
+    # GH#55372 sharing in any chunk counts as sharing, not just the first
+    import pyarrow as pa
+
+    shared = pa.array([1, 2, 3])
+    obj = pd.arrays.ArrowExtensionArray(pa.chunked_array([pa.array([9, 9]), shared]))
+    other = pd.arrays.ArrowExtensionArray(pa.chunked_array([pa.array([8, 8]), shared]))
+
+    assert tm.shares_memory(obj, other)
+
+
+@td.skip_if_no("pyarrow")
+@pytest.mark.parametrize(
+    "arrow_array",
+    [
+        lambda pa: pa.chunked_array([], type=pa.int64()),  # no chunks at all
+        lambda pa: pa.chunked_array([pa.nulls(3)]),  # null type has no data buffer
+        lambda pa: pa.chunked_array([pa.array([], type=pa.int64())]),  # empty buffers
+    ],
+)
+def test_shares_memory_arrow_no_buffers(arrow_array):
+    # GH#55372 these used to raise instead of returning a bool
+    import pyarrow as pa
+
+    obj = pd.arrays.ArrowExtensionArray(arrow_array(pa))
+    other = pd.arrays.ArrowExtensionArray(arrow_array(pa))
+
+    # nothing is actually backed by memory here, so nothing can be shared
+    assert not tm.shares_memory(obj, obj)
+    assert not tm.shares_memory(obj, other)
+
+
+@td.skip_if_no("pyarrow")
+def test_shares_memory_arrow_nested():
+    # GH#55372 nested types have None entries in .buffers()
+    import pyarrow as pa
+
+    obj = pd.arrays.ArrowExtensionArray(pa.array([{"a": 1}, {"a": 2}]))
+
+    assert tm.shares_memory(obj, obj)
+    assert not tm.shares_memory(
+        obj, pd.arrays.ArrowExtensionArray(pa.array([{"a": 3}, {"a": 4}]))
+    )
+
+
+@td.skip_if_no("pyarrow")
+def test_shares_memory_arrow_and_numpy():
+    # pa.array is zero-copy for a numpy int64 array
+    import pyarrow as pa
+
+    arr = np.arange(10, dtype=np.int64)
+    obj = pd.arrays.ArrowExtensionArray(pa.array(arr))
+
+    assert tm.shares_memory(obj, arr)
+    assert not tm.shares_memory(obj, arr.copy())
+
+
+def test_shares_memory_dataframe():
+    # GH#55372
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    arr = df._mgr.blocks[0].values
+
+    assert tm.shares_memory(df, df)
+    assert tm.shares_memory(df, arr)
+    assert tm.shares_memory(arr, df)
+
+    assert not tm.shares_memory(df, df.copy(deep=True))
+
+
+def test_shares_memory_not_implemented():
+    # GH#55372 unrecognized objects raise rather than silently returning False
+    with pytest.raises(NotImplementedError, match="int"):
+        tm.shares_memory(1, 2)
+
+    # more than one block is not supported
+    df = pd.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    with pytest.raises(NotImplementedError, match="DataFrame"):
+        tm.shares_memory(df, df)


### PR DESCRIPTION
closes #55372

Adds coverage for every branch of `tm.shares_memory` (4 tests -> 25). Writing them out turned up three latent defects, fixed here — 7 of the new tests fail without the fix:

- **`MultiIndex` never worked.** `left._codes` is a `FrozenList` of arrays, not an array, so the branch fell through to the `raise`. `tm.shares_memory(mi, mi)` has raised `NotImplementedError` since the function was added in GH-44747. Now iterates the per-level codes.
- **`BaseMaskedArray` only handled masked-vs-masked.** Any other pairing raised, including ones the other branches unwrap into (`tm.shares_memory(pd.Categorical(...), some_masked)` reaches it via the `NDArrayBackedExtensionArray` branch). Added the mixed-type fallback against `_data`/`_mask`, mirroring what the `ArrowExtensionArray` branch already did.
- **The Arrow branch had four problems**, all from `chunk(0).buffers()[1]`: `IndexError` on a `pa.null()`-typed array (only one buffer) and on a zero-chunk `ChunkedArray`; `AttributeError` on nested types (`buffers()[1]` is `None`); a false positive for two independent *empty* arrays (zero-size buffers can share an address); and a false negative for arrays that share a chunk other than the first. Replaced with a set-intersection over all chunks x all non-`None`, non-empty buffers.

The Arrow change means a shared validity bitmap now counts as sharing, not just the data buffer — consistent with the convention already stated for masked arrays ("share *either* the `_data` or the `_mask`"). Distinct columns of one `pa.Table` still compare `False`; zero-copy slices still compare `True`.

No whatsnew entry: `shares_memory` is not exposed via `pandas.testing` or the API docs.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which enumerated the branch matrix that exposed the three defects, wrote the fixes and tests, and verified each new test fails against the pre-fix implementation.