### PR TITLE
BLD: avoid Cython 3.3.0 -Warray-bounds build failure

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -588,7 +588,10 @@ cdef class TextReader:
         self.warning_sink = None
         self.na_left_literal = False
 
-        if float_precision in ("round_trip", "legacy", "high", None):
+        # None by identity, not in the tuple; see tzconversion.pyx (GH#66939)
+        if float_precision is None or float_precision in (
+            "round_trip", "legacy", "high"
+        ):
             self.parser.double_converter = precise_xstrtod_wrapper
         else:
             raise ValueError(f"Unrecognized float_precision option: "

--- a/pandas/_libs/tslibs/tzconversion.pyx
+++ b/pandas/_libs/tslibs/tzconversion.pyx
@@ -341,7 +341,9 @@ timedelta-like}
     elif PyDelta_Check(nonexistent):
         from .timedeltas import delta_to_nanoseconds
         shift_delta = delta_to_nanoseconds(nonexistent, reso=creso)
-    elif nonexistent not in ("raise", None):
+    # `is not None` rather than `in (..., None)`: comparing an object against
+    # Py_None trips GCC -Warray-bounds in Cython's inline compare helper (GH#66939)
+    elif nonexistent is not None and nonexistent != "raise":
         msg = ("nonexistent must be one of {'NaT', 'raise', 'shift_forward', "
                "'shift_backward'} or a timedelta object")
         raise ValueError(msg)


### PR DESCRIPTION
closes GH-66939

Cython 3.3.0 (PyPI, 2026-08-22 05:16 UTC) broke the three CI jobs that build from
source with `--werror`: `Linux-32-bit`, `Linux-Musl` and `python-dev (ubuntu-24.04)`.
`pip` never gets past metadata generation, so no tests run.

### Cause

3.3.0 lowers `x in (..., None)` to a new inlined compare helper,
`__Pyx_PyObject_CompareBool{Ne,Eq}_object_object`, with `Py_None` as a literal
operand. `Py_None` is `&_Py_NoneStruct` — a *statically declared* object of known
size — so GCC constant-propagates it into the helper's int/float/bytearray branches
and reports out-of-bounds reads of `ob_digit[]`, `ob_fval` and `ob_size`. Those
branches are guarded by type checks GCC doesn't follow through the inline, so the
warning is a false positive rather than genuinely out-of-bounds indexing.

Cython 3.2.9 emits no such helper, which matches the timeline on `main`:
`bcd74fb154fc` (Aug 21, cython 3.2.9) green, `1026aa1ba6d0` (Aug 22, cython 3.3.0) red,
with only pure-Python commits in between.

### Fix

Test `None` by identity, which keeps it out of the compare helper entirely.

### Why not the other options in the issue

`-Wno-array-bounds` would mask real bounds bugs across all of `_libs`, and capping
`Cython<3.3` only defers the problem while needing `environment.yml` and
`asv.conf.json` kept in sync. This is two lines and neither loses warning coverage
nor pins anything.

### Note: a second site the build never reached

Ninja stopped at target 68/156, so `parsers.pyx` was never compiled — a fix touching
only `tzconversion.pyx` would have left CI red at the next file.

To be sure those were the only two, I cythonized all 41 `.pyx` files under 3.3.0
(with the build-generated `.pxi` files, and `--cplus` for `window/aggregations.pyx`)
and grepped the generated C for helper calls taking a statically declared singleton
operand — widened beyond `Py_None` to `Py_True`/`Py_False`/`Py_Ellipsis`/
`Py_NotImplemented`, since those are statically declared too and would trip the same
warning:

- before: exactly 2 — `tzconversion.pyx:344`, `parsers.pyx:591`
- after: 0

The 127 helper call sites remaining tree-wide all take runtime `PyObject *` operands,
which GCC has no size information for.

### Tests

No behaviour change; existing tests cover both branches. Locally green:
`pandas/tests/io/parser/`, `pandas/tests/tslibs/`, all `tz_localize` test files,
`pandas/tests/indexes/datetimes/methods/`, `pandas/tests/scalar/timestamp/` and
`pandas/tests/arrays/datetimes/`.

I could not compile with GCC locally, so the "GCC no longer warns" step rests on the
generated C no longer containing the construct — `-Warray-bounds` is sensitive to
inlining decisions, so the three affected jobs in CI here are the real confirmation.

No whatsnew entry: `-Werror` is CI-only, so an ordinary from-source build only saw a
noisy warning rather than a failure. Happy to add one if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
