### PR TITLE
PERF: avoid per-slice overhead in interpolate (GH#48236)

### DIFF
--- a/asv_bench/benchmarks/frame_methods.py
+++ b/asv_bench/benchmarks/frame_methods.py
@@ -612,6 +612,22 @@ class Interpolate:
         self.df2.interpolate()
 
 
+class InterpolateMethods:
+    # GH#48236: interpolate loops over 1-d slices, so the per-slice overhead
+    #  dominates for frames with many rows (axis=0) or many columns (axis=1).
+    params = [["linear", "nearest", "zero", "slinear", "cubic"], [0, 1]]
+    param_names = ["method", "axis"]
+
+    def setup(self, method, axis):
+        N = 1000
+        arr = np.random.randn(N, 100)
+        arr[np.random.rand(*arr.shape) < 0.8] = np.nan
+        self.df = DataFrame(arr)
+
+    def time_interpolate(self, method, axis):
+        self.df.interpolate(method=method, axis=axis)
+
+
 class Shift:
     # frame shift speedup issue-5609
     params = [0, 1]

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -375,6 +375,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)
 - Performance improvement in :meth:`DataFrame.insert` when the number of blocks is small (:issue:`57641`)
+- Performance improvement in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate`, largest for frames with many rows or columns and for the SciPy-backed methods such as ``"nearest"``, ``"zero"`` and ``"slinear"`` (:issue:`48236`)
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
 - Performance improvement in :meth:`DataFrame.plot` for line plots of wide DataFrames with a :class:`DatetimeIndex` or :class:`PeriodIndex` (:issue:`61398`)
 - Performance improvement in :meth:`DataFrame.query` and :meth:`DataFrame.eval` when the :class:`DataFrame` contains :class:`PeriodDtype` or :class:`IntervalDtype` columns (:issue:`35247`)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -4,7 +4,10 @@ Routines for filling missing data.
 
 from __future__ import annotations
 
-from functools import wraps
+from functools import (
+    cache,
+    wraps,
+)
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -412,12 +415,6 @@ def interpolate_2d_inplace(
 
     indices = _index_to_interp_indices(index, method)
 
-    if method in SP_METHODS:
-        # Check once here rather than once per 1-d slice below.
-        import_optional_dependency(
-            "scipy", extra=f"{method} interpolation requires SciPy."
-        )
-
     def func(yvalues: np.ndarray) -> None:
         # process 1-d slices in the axis direction
 
@@ -636,6 +633,20 @@ def _interpolate_1d(
     return
 
 
+@cache
+def _scipy_interpolate(method: str):
+    """
+    Get scipy.interpolate, raising the message we want if SciPy is missing.
+
+    Cached because _interpolate_scipy_wrapper runs once per 1-d slice, and the
+    version check in import_optional_dependency is not free (GH#48236).
+    """
+    import_optional_dependency("scipy", extra=f"{method} interpolation requires SciPy.")
+    from scipy import interpolate
+
+    return interpolate
+
+
 def _interpolate_scipy_wrapper(
     x: np.ndarray,
     y: np.ndarray,
@@ -651,7 +662,7 @@ def _interpolate_scipy_wrapper(
     Returns an array interpolated at new_x.  Add any new methods to
     the list in _clean_interp_method.
     """
-    from scipy import interpolate
+    interpolate = _scipy_interpolate(method)
 
     new_x = np.asarray(new_x)
 

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -412,6 +412,12 @@ def interpolate_2d_inplace(
 
     indices = _index_to_interp_indices(index, method)
 
+    if method in SP_METHODS:
+        # Check once here rather than once per 1-d slice below.
+        import_optional_dependency(
+            "scipy", extra=f"{method} interpolation requires SciPy."
+        )
+
     def func(yvalues: np.ndarray) -> None:
         # process 1-d slices in the axis direction
 
@@ -428,7 +434,13 @@ def interpolate_2d_inplace(
             **kwargs,
         )
 
-    np.apply_along_axis(func, axis, data)
+    if data.ndim == 1:
+        func(data)
+    else:
+        # NB: not np.apply_along_axis, which allocates and then discards a
+        #  result array; func mutates yvalues in place and returns None.
+        for yvalues in data if axis == 1 else data.T:
+            func(yvalues)
 
 
 def _is_arrow_temporal(dtype: DtypeObj | None) -> bool:
@@ -541,9 +553,6 @@ def _interpolate_1d(
     if valid.all():
         return
 
-    # These index pointers to invalid values... i.e. {0, 1, etc...
-    all_nans = np.flatnonzero(invalid)
-
     first_valid_index = find_valid_index(how="first", is_valid=valid)
     if first_valid_index is None:  # no nan found in start
         first_valid_index = 0
@@ -563,7 +572,16 @@ def _interpolate_1d(
     # are more than 'limit' away from the prior non-NaN.
 
     # set preserve_nans based on direction using _interp_limit
-    if limit_direction == "forward":
+    if limit is None:
+        # _interp_limit would return nothing, and start_nans/end_nans are
+        #  already sorted and unique, so skip it and the union1d sort.
+        if limit_direction == "forward":
+            preserve_nans = start_nans
+        elif limit_direction == "backward":
+            preserve_nans = end_nans
+        else:
+            preserve_nans = np.array([], dtype=np.intp)
+    elif limit_direction == "forward":
         preserve_nans = np.union1d(start_nans, _interp_limit(invalid, limit, 0))
     elif limit_direction == "backward":
         preserve_nans = np.union1d(end_nans, _interp_limit(invalid, 0, limit))
@@ -579,6 +597,7 @@ def _interpolate_1d(
         preserve_nans = np.union1d(preserve_nans, end_nans)
     elif limit_area == "outside":
         # preserve NaNs on the inside
+        all_nans = np.flatnonzero(invalid)
         mid_nans = np.setdiff1d(all_nans, start_nans, assume_unique=True)
         mid_nans = np.setdiff1d(mid_nans, end_nans, assume_unique=True)
         preserve_nans = np.union1d(preserve_nans, mid_nans)
@@ -632,8 +651,6 @@ def _interpolate_scipy_wrapper(
     Returns an array interpolated at new_x.  Add any new methods to
     the list in _clean_interp_method.
     """
-    extra = f"{method} interpolation requires SciPy."
-    import_optional_dependency("scipy", extra=extra)
     from scipy import interpolate
 
     new_x = np.asarray(new_x)


### PR DESCRIPTION
First of two PRs for GH-48236. This one only trims the per-slice overhead of the existing loop; the vectorized 2-D path that gives the large speedups is GH-66965, which is what closes the issue. The two are independent but touch the same hunk, so whichever lands second needs a trivial rebase.

`interpolate` applies `_interpolate_1d` to one 1-d slice at a time, so on frames with many rows or columns the per-slice bookkeeping, not the interpolation, dominates. Four pieces of that were avoidable:

- The SciPy import and version check ran **once per slice**, re-parsing the installed and minimum versions with `packaging.Version` each time (~18% of `method="nearest"`). It is now behind a `@cache`d `_scipy_interpolate(method)` helper. It deliberately stays inside `_interpolate_scipy_wrapper` rather than being hoisted into `interpolate_2d_inplace`: the wrapper sits downstream of `_interpolate_1d`'s early returns for an all-valid or all-NaN slice, so hoisting it would make `Series([1.0, 2.0, 3.0]).interpolate(method="cubic")` raise `ImportError` in a SciPy-less environment, where `main` returns the series unchanged.
- `np.apply_along_axis` allocated and then discarded an object-dtype result array, because the callback fills its argument in place and returns `None`. Replaced with a direct loop over the slices.
- `_interp_limit` returns nothing when `limit is None`, and `start_nans`/`end_nans` are already sorted and unique, so the `np.union1d` in that (default) case was a pure sort.
- The `np.flatnonzero` for `all_nans` ran unconditionally but is only used by `limit_area="outside"`.

No behavior change is intended, and none was found: across a 59,778-case matrix (18 methods x `limit` x `limit_direction` x `limit_area` x `axis` x `fill_value` x 21 frame shapes — inf values, inf/NaT/duplicate/unsorted/object indexes, all-NaN rows, single-valid-point rows, masked/Arrow/mixed blocks), comparing result arrays *and* raised exception messages, every case is **bitwise identical** to `main`. (`barycentric` is excluded — it is ill-conditioned enough to be nondeterministic run-to-run on `main` itself.) That matrix runs with SciPy installed, so the SciPy-less paths were checked separately with `import_optional_dependency` patched to raise: for every SciPy method, and for the all-valid / all-NaN / has-NaN cases, this branch raises exactly where `main` raises and returns exactly where `main` returns.

20000x200 float64, `axis=1`, min of 5:

| case | main | this PR |
|---|---|---|
| `linear`, sparse blocks | 0.265s | 0.176s (1.51x) |
| `nearest`, sparse blocks | 0.800s | 0.541s (1.48x) |
| `zero`, sparse blocks | 1.043s | 0.739s (1.41x) |
| `slinear`, sparse blocks | 1.062s | 0.761s (1.39x) |
| `linear`, 60% NaN | 0.348s | 0.257s (1.35x) |
| `nearest`, 60% NaN | 0.862s | 0.606s (1.42x) |
| 500x `Series.interpolate`, `linear` | 0.023s | 0.017s (1.38x) |

The new `InterpolateMethods` benchmark covers `method` x `axis`, which the existing `Interpolate` benchmark did not.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which profiled the existing path, wrote the change, and ran the differential matrix and benchmarks above.


