### PR TITLE
PERF: DataFrame.interpolate for neighbor-based methods (GH#48236)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -375,7 +375,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)
 - Performance improvement in :meth:`DataFrame.insert` when the number of blocks is small (:issue:`57641`)
-- Performance improvement in :meth:`DataFrame.interpolate` with ``method`` of ``"linear"``, ``"index"``, ``"values"``, ``"time"``, ``"nearest"`` or ``"zero"``; the frame is now interpolated in one pass instead of one column (or row) at a time (:issue:`48236`)
+- Performance improvement in :meth:`DataFrame.interpolate` with ``method`` of ``"linear"``, ``"index"``, ``"values"``, ``"time"``, ``"nearest"`` or ``"zero"``, especially for wide frames (:issue:`48236`)
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
 - Performance improvement in :meth:`DataFrame.plot` for line plots of wide DataFrames with a :class:`DatetimeIndex` or :class:`PeriodIndex` (:issue:`61398`)
 - Performance improvement in :meth:`DataFrame.query` and :meth:`DataFrame.eval` when the :class:`DataFrame` contains :class:`PeriodDtype` or :class:`IntervalDtype` columns (:issue:`35247`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -375,6 +375,7 @@ Performance improvements
 - Performance improvement in :meth:`DataFrame.fillna` and :meth:`Series.fillna` with scalar fill value for float, object, nullable, and datetime-like dtypes (:issue:`42147`)
 - Performance improvement in :meth:`DataFrame.from_records` when passing a 2D :class:`numpy.ndarray` (:issue:`22025`)
 - Performance improvement in :meth:`DataFrame.insert` when the number of blocks is small (:issue:`57641`)
+- Performance improvement in :meth:`DataFrame.interpolate` with ``method`` of ``"linear"``, ``"index"``, ``"values"``, ``"time"``, ``"nearest"`` or ``"zero"``; the frame is now interpolated in one pass instead of one column (or row) at a time (:issue:`48236`)
 - Performance improvement in :meth:`DataFrame.loc` with non-unique masked index (:issue:`56759`)
 - Performance improvement in :meth:`DataFrame.plot` for line plots of wide DataFrames with a :class:`DatetimeIndex` or :class:`PeriodIndex` (:issue:`61398`)
 - Performance improvement in :meth:`DataFrame.query` and :meth:`DataFrame.eval` when the :class:`DataFrame` contains :class:`PeriodDtype` or :class:`IntervalDtype` columns (:issue:`35247`)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -427,6 +427,8 @@ def interpolate_2d_inplace(
         # GH#48236 the per-slice loop below costs more than the interpolation
         #  itself, so handle the whole block at once where we can.
         data.ndim == 2
+        # Block.interpolate passes the last axis for every 2-d block
+        and axis == 1
         and mask is None
         and method in NEIGHBOR_METHODS
         and data.dtype.kind == "f"
@@ -434,25 +436,24 @@ def interpolate_2d_inplace(
         # limit and a non-default fill_value both need the slower path
         and limit is None
         and fill_value_is_na
-        # a later valid value must also be a larger x value
-        and index.is_monotonic_increasing
-        and index.is_unique
     ):
-        if method in SP_METHODS:
-            # unchanged requirement: _interpolate_2d_neighbors reproduces what
-            #  scipy.interpolate.interp1d gives for these kinds, but making
-            #  them work without SciPy would be an API change, not a perf one
-            import_optional_dependency(
-                "scipy", extra=f"{method} interpolation requires SciPy."
+        # np.interp and scipy both interpolate in double precision, so a later
+        #  valid value must still be a larger x value after the cast; i8
+        #  nanosecond timestamps are large enough to collapse onto each other
+        xvals = indices.astype(np.float64, copy=False)
+        with np.errstate(invalid="ignore", over="ignore"):
+            # an index holding infinities or values near the float64 limit
+            #  must not warn here either
+            increasing = bool((np.diff(xvals) > 0).all())
+        if increasing:
+            _interpolate_2d_neighbors(
+                data,
+                xvals,
+                method=method,
+                limit_direction=limit_direction,
+                limit_area=limit_area_validated,
             )
-        _interpolate_2d_neighbors(
-            data if axis == 1 else data.T,
-            indices,
-            method=method,
-            limit_direction=limit_direction,
-            limit_area=limit_area_validated,
-        )
-        return
+            return
 
     def func(yvalues: np.ndarray) -> None:
         # process 1-d slices in the axis direction
@@ -549,7 +550,7 @@ def _index_to_interp_indices(index: Index, method: str) -> np.ndarray:
 
 def _interpolate_2d_neighbors(
     values: np.ndarray,
-    indices: np.ndarray,
+    xvals: np.ndarray,
     method: str,
     limit_direction: str,
     limit_area: Literal["inside", "outside"] | None,
@@ -559,74 +560,107 @@ def _interpolate_2d_neighbors(
 
     Equivalent to _interpolate_1d applied to each row, for the subset of
     arguments the caller checks for: a float `values`, a strictly increasing
-    `indices`, a method in NEIGHBOR_METHODS, no `limit` and no `fill_value`.
+    float64 `xvals`, a method in NEIGHBOR_METHODS, no `limit` and no
+    `fill_value`.
+
+    The linear methods can differ from np.interp, which computes its
+    multiply-add as one fused instruction where numpy exposes no vectorized
+    equivalent. The difference stays under an ULP of the two values being
+    interpolated between, so it is only a large *relative* difference where
+    those two nearly cancel; neither form is the more accurate one.
 
     Notes
     -----
     Alters `values` in-place.
     """
     nrows, ncols = values.shape
-    # np.interp and scipy both interpolate in double precision
-    xvals = indices.astype(np.float64, copy=False)
-    # positions fit in int32 for any array we can hold in memory
-    positions = np.arange(ncols, dtype=np.int32)
+    if not ncols:
+        return
+    # intp so that the ncols sentinel below cannot wrap on a huge axis
+    positions = np.arange(ncols, dtype=np.intp)
     # everything below is O(chunk.size) in temporaries, so work in chunks
     step = max(1, _NEIGHBOR_CHUNK_SIZE // ncols)
+    # _interpolate_1d returns before reaching SciPy for a slice that is all
+    #  valid or all NaN, so a block with no other kind must not require it
+    check_scipy = method in SP_METHODS
 
-    for start in range(0, nrows, step):
-        chunk = values[start : start + step]
-        invalid = np.isnan(chunk)
+    # np.interp is C and leaves the FP error state alone; the ufuncs below
+    #  would otherwise warn on the infinities and huge values it accepts
+    with np.errstate(invalid="ignore", divide="ignore", over="ignore"):
+        for start in range(0, nrows, step):
+            chunk = values[start : start + step]
+            invalid = np.isnan(chunk)
 
-        # position of the closest valid value at or before / at or after each
-        #  position, or -1 / ncols where there is none
-        prev = np.where(invalid, -1, positions)
-        np.maximum.accumulate(prev, axis=1, out=prev)
-        nxt = np.where(invalid, ncols, positions)
-        np.minimum.accumulate(nxt[:, ::-1], axis=1, out=nxt[:, ::-1])
+            if check_scipy and (invalid.any(axis=1) & ~invalid.all(axis=1)).any():
+                # unchanged requirement: _interpolate_2d_neighbors reproduces
+                #  what scipy.interpolate.interp1d gives for these kinds, but
+                #  making them work without SciPy would be an API change
+                import_optional_dependency(
+                    "scipy", extra=f"{method} interpolation requires SciPy."
+                )
+                check_scipy = False
 
-        has_prev = prev >= 0
-        has_next = nxt < ncols
+            # position of the closest valid value at or before / at or after
+            #  each position, or -1 / ncols where there is none
+            prev = np.where(invalid, -1, positions)
+            np.maximum.accumulate(prev, axis=1, out=prev)
+            nxt = np.where(invalid, ncols, positions)
+            np.minimum.accumulate(nxt[:, ::-1], axis=1, out=nxt[:, ::-1])
 
-        if limit_area != "outside":
-            rows, cols = np.nonzero(invalid & has_prev & has_next)
-            prev_idx = prev[rows, cols]
-            next_idx = nxt[rows, cols]
-            xprev = xvals[prev_idx]
-            xnext = xvals[next_idx]
-            xhere = xvals[cols]
-            yprev = chunk[rows, prev_idx]
-            ynext = chunk[rows, next_idx]
-            if method == "zero":
-                filled = yprev
-            elif method == "nearest":
-                # ties go to the earlier value, as interp1d does
-                filled = np.where(xhere - xprev <= xnext - xhere, yprev, ynext)
-            else:
-                # associated as np.interp does it, to get the same rounding
-                slope = (ynext - yprev) / (xnext - xprev)
-                filled = slope * (xhere - xprev) + yprev
-                retry = np.isnan(filled)
-                if retry.any():
-                    # np.interp works from the other end when that gives NaN,
-                    #  which happens next to an infinite value
-                    alt = slope[retry] * (xhere[retry] - xnext[retry]) + ynext[retry]
-                    flat = np.isnan(alt) & (yprev[retry] == ynext[retry])
-                    filled[retry] = np.where(flat, yprev[retry], alt)
-            chunk[rows, cols] = filled
+            has_prev = prev >= 0
+            has_next = nxt < ncols
 
-        if method in SP_METHODS or limit_area == "inside":
-            # interp1d(bounds_error=False) fills fill_value, i.e. NaN, outside
-            #  the valid range, and limit_area="inside" keeps the NaNs there
-            continue
+            if limit_area != "outside":
+                rows, cols = np.nonzero(invalid & has_prev & has_next)
+                prev_idx = prev[rows, cols]
+                next_idx = nxt[rows, cols]
+                xprev = xvals[prev_idx]
+                xnext = xvals[next_idx]
+                xhere = xvals[cols]
+                yprev = chunk[rows, prev_idx]
+                ynext = chunk[rows, next_idx]
+                if method == "zero":
+                    filled = yprev
+                elif method == "nearest":
+                    # interp1d rounds against the halfway point in one step and
+                    #  takes the earlier value on a tie; comparing the two gaps
+                    #  instead rounds twice and disagrees either side of it. A
+                    #  NaN midpoint means xprev/xnext are -inf/inf, where
+                    #  interp1d's searchsorted also picks the earlier value.
+                    mid = xprev / 2.0 + xnext / 2.0
+                    filled = np.where(np.isnan(mid) | (xhere <= mid), yprev, ynext)
+                else:
+                    # np.interp promotes y to float64 before subtracting, so
+                    #  float32 input has to be interpolated just as precisely
+                    yprev = yprev.astype(np.float64, copy=False)
+                    ynext = ynext.astype(np.float64, copy=False)
+                    # associated as np.interp does it, to get the same rounding
+                    slope = (ynext - yprev) / (xnext - xprev)
+                    filled = slope * (xhere - xprev) + yprev
+                    retry = np.isnan(filled)
+                    if retry.any():
+                        # np.interp works from the other end when that gives
+                        #  NaN, which happens next to an infinite value
+                        alt = (
+                            slope[retry] * (xhere[retry] - xnext[retry]) + ynext[retry]
+                        )
+                        flat = np.isnan(alt) & (yprev[retry] == ynext[retry])
+                        filled[retry] = np.where(flat, yprev[retry], alt)
+                chunk[rows, cols] = filled
 
-        # np.interp instead clamps to the closest valid value; limit_direction
-        #  puts the NaNs back on the side it does not fill
-        if limit_direction != "forward":
-            rows, cols = np.nonzero(invalid & ~has_prev & has_next)
-            chunk[rows, cols] = chunk[rows, nxt[rows, cols]]
-        if limit_direction != "backward":
-            rows, cols = np.nonzero(invalid & has_prev & ~has_next)
-            chunk[rows, cols] = chunk[rows, prev[rows, cols]]
+            if method in SP_METHODS or limit_area == "inside":
+                # interp1d(bounds_error=False) fills fill_value, i.e. NaN,
+                #  outside the valid range, and "inside" keeps the NaNs there
+                continue
+
+            # np.interp instead clamps to the closest valid value;
+            #  limit_direction puts the NaNs back on the side it does not fill
+            if limit_direction != "forward":
+                rows, cols = np.nonzero(invalid & ~has_prev & has_next)
+                chunk[rows, cols] = chunk[rows, nxt[rows, cols]]
+            if limit_direction != "backward":
+                rows, cols = np.nonzero(invalid & has_prev & ~has_next)
+                chunk[rows, cols] = chunk[rows, prev[rows, cols]]
 
 
 def _interpolate_1d(

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -223,6 +223,16 @@ SP_METHODS = [
     "cubicspline",
 ]
 
+# interpolation methods whose value at a missing position depends only on the
+# closest valid value on either side, and so can be computed for a whole 2-D
+# block at once by _interpolate_2d_neighbors
+
+NEIGHBOR_METHODS = ["linear", "index", "values", "nearest", "zero"]
+
+# how many values _interpolate_2d_neighbors handles per pass; keeping this
+# bounded keeps its temporaries small no matter how big the block is
+_NEIGHBOR_CHUNK_SIZE = 2**18
+
 
 def clean_interp_method(method: str, index: Index, **kwargs) -> str:
     order = kwargs.get("order")
@@ -392,7 +402,8 @@ def interpolate_2d_inplace(
     # validate the interp method
     clean_interp_method(method, index, **kwargs)
 
-    if is_valid_na_for_dtype(fill_value, data.dtype):
+    fill_value_is_na = is_valid_na_for_dtype(fill_value, data.dtype)
+    if fill_value_is_na:
         fill_value = na_value_for_dtype(data.dtype, compat=False)
 
     if method == "time":
@@ -411,6 +422,37 @@ def interpolate_2d_inplace(
     limit = algos.validate_limit(nobs=None, limit=limit)
 
     indices = _index_to_interp_indices(index, method)
+
+    if (
+        # GH#48236 the per-slice loop below costs more than the interpolation
+        #  itself, so handle the whole block at once where we can.
+        data.ndim == 2
+        and mask is None
+        and method in NEIGHBOR_METHODS
+        and data.dtype.kind == "f"
+        and indices.dtype.kind in "iuf"
+        # limit and a non-default fill_value both need the slower path
+        and limit is None
+        and fill_value_is_na
+        # a later valid value must also be a larger x value
+        and index.is_monotonic_increasing
+        and index.is_unique
+    ):
+        if method in SP_METHODS:
+            # unchanged requirement: _interpolate_2d_neighbors reproduces what
+            #  scipy.interpolate.interp1d gives for these kinds, but making
+            #  them work without SciPy would be an API change, not a perf one
+            import_optional_dependency(
+                "scipy", extra=f"{method} interpolation requires SciPy."
+            )
+        _interpolate_2d_neighbors(
+            data if axis == 1 else data.T,
+            indices,
+            method=method,
+            limit_direction=limit_direction,
+            limit_area=limit_area_validated,
+        )
+        return
 
     def func(yvalues: np.ndarray) -> None:
         # process 1-d slices in the axis direction
@@ -503,6 +545,88 @@ def _index_to_interp_indices(index: Index, method: str) -> np.ndarray:
                 inds = lib.maybe_convert_objects(inds)
 
     return inds
+
+
+def _interpolate_2d_neighbors(
+    values: np.ndarray,
+    indices: np.ndarray,
+    method: str,
+    limit_direction: str,
+    limit_area: Literal["inside", "outside"] | None,
+) -> None:
+    """
+    Interpolate every row of a 2-d block at once.
+
+    Equivalent to _interpolate_1d applied to each row, for the subset of
+    arguments the caller checks for: a float `values`, a strictly increasing
+    `indices`, a method in NEIGHBOR_METHODS, no `limit` and no `fill_value`.
+
+    Notes
+    -----
+    Alters `values` in-place.
+    """
+    nrows, ncols = values.shape
+    # np.interp and scipy both interpolate in double precision
+    xvals = indices.astype(np.float64, copy=False)
+    # positions fit in int32 for any array we can hold in memory
+    positions = np.arange(ncols, dtype=np.int32)
+    # everything below is O(chunk.size) in temporaries, so work in chunks
+    step = max(1, _NEIGHBOR_CHUNK_SIZE // ncols)
+
+    for start in range(0, nrows, step):
+        chunk = values[start : start + step]
+        invalid = np.isnan(chunk)
+
+        # position of the closest valid value at or before / at or after each
+        #  position, or -1 / ncols where there is none
+        prev = np.where(invalid, -1, positions)
+        np.maximum.accumulate(prev, axis=1, out=prev)
+        nxt = np.where(invalid, ncols, positions)
+        np.minimum.accumulate(nxt[:, ::-1], axis=1, out=nxt[:, ::-1])
+
+        has_prev = prev >= 0
+        has_next = nxt < ncols
+
+        if limit_area != "outside":
+            rows, cols = np.nonzero(invalid & has_prev & has_next)
+            prev_idx = prev[rows, cols]
+            next_idx = nxt[rows, cols]
+            xprev = xvals[prev_idx]
+            xnext = xvals[next_idx]
+            xhere = xvals[cols]
+            yprev = chunk[rows, prev_idx]
+            ynext = chunk[rows, next_idx]
+            if method == "zero":
+                filled = yprev
+            elif method == "nearest":
+                # ties go to the earlier value, as interp1d does
+                filled = np.where(xhere - xprev <= xnext - xhere, yprev, ynext)
+            else:
+                # associated as np.interp does it, to get the same rounding
+                slope = (ynext - yprev) / (xnext - xprev)
+                filled = slope * (xhere - xprev) + yprev
+                retry = np.isnan(filled)
+                if retry.any():
+                    # np.interp works from the other end when that gives NaN,
+                    #  which happens next to an infinite value
+                    alt = slope[retry] * (xhere[retry] - xnext[retry]) + ynext[retry]
+                    flat = np.isnan(alt) & (yprev[retry] == ynext[retry])
+                    filled[retry] = np.where(flat, yprev[retry], alt)
+            chunk[rows, cols] = filled
+
+        if method in SP_METHODS or limit_area == "inside":
+            # interp1d(bounds_error=False) fills fill_value, i.e. NaN, outside
+            #  the valid range, and limit_area="inside" keeps the NaNs there
+            continue
+
+        # np.interp instead clamps to the closest valid value; limit_direction
+        #  puts the NaNs back on the side it does not fill
+        if limit_direction != "forward":
+            rows, cols = np.nonzero(invalid & ~has_prev & has_next)
+            chunk[rows, cols] = chunk[rows, nxt[rows, cols]]
+        if limit_direction != "backward":
+            rows, cols = np.nonzero(invalid & has_prev & ~has_next)
+            chunk[rows, cols] = chunk[rows, prev[rows, cols]]
 
 
 def _interpolate_1d(

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -5,11 +5,15 @@ import pandas.util._test_decorators as td
 
 from pandas import (
     DataFrame,
+    DatetimeIndex,
     NaT,
     Series,
+    Timestamp,
     date_range,
+    to_timedelta,
 )
 import pandas._testing as tm
+from pandas.core import missing
 
 
 class TestDataFrameInterpolate:
@@ -501,8 +505,9 @@ class TestDataFrameInterpolate:
 @pytest.mark.parametrize("limit_direction", ["forward", "backward", "both"])
 @pytest.mark.parametrize("limit_area", [None, "inside", "outside"])
 @pytest.mark.parametrize("index_values", [None, [0.0, 1.5, 2.0, 6.0, 6.5, 9.0, 20.0]])
+@pytest.mark.parametrize("dtype", ["float64", "float32"])
 def test_interpolate_frame_matches_series(
-    method, limit_direction, limit_area, index_values
+    method, limit_direction, limit_area, index_values, dtype
 ):
     # GH#48236 a frame interpolates every 1-d slice at once for these methods;
     #  a Series takes the slice-at-a-time path, so the two must agree
@@ -514,8 +519,11 @@ def test_interpolate_frame_matches_series(
         "one_valid": [np.nan, np.nan, 3.0, np.nan, np.nan, np.nan, np.nan],
         "edges_nan": [np.nan, 1.0, np.nan, np.nan, 5.0, np.nan, np.nan],
         "interior": [0.0, np.nan, 2.0, np.nan, np.nan, 5.0, 6.0],
+        # the arithmetic must not round in a narrower dtype than np.interp
+        "uneven": [-1.1140672, -0.011521468, -0.44358122, np.nan, 0.65, 0.1, -2.3],
+        "non_finite": [np.inf, np.nan, -np.inf, np.nan, 3e38, np.nan, -3e38],
     }
-    df = DataFrame(data, index=index_values)
+    df = DataFrame(data, index=index_values, dtype=dtype)
     kwargs = {
         "method": method,
         "limit_direction": limit_direction,
@@ -530,3 +538,142 @@ def test_interpolate_frame_matches_series(
     # and the axis=1 spelling gives the transposed result
     result = df.T.interpolate(axis=1, **kwargs)
     tm.assert_frame_equal(result, expected.T)
+
+
+@pytest.mark.parametrize("method", ["time", "index", "nearest"])
+@pytest.mark.parametrize("unit", ["ns", "us", "s"])
+def test_interpolate_frame_datetime_index_matches_series(method, unit):
+    # GH#48236 i8 nanosecond timestamps do not survive the cast to float64
+    #  that the whole-block path interpolates in
+    if method != "index":
+        pytest.importorskip("scipy")
+    index = DatetimeIndex(
+        Timestamp("2020-01-01") + to_timedelta([0, 1, 2, 3, 4, 5, 100], unit=unit)
+    )
+    data = {
+        "interior": [1.0, np.nan, np.nan, np.nan, np.nan, 2.0, 3.0],
+        "edges_nan": [np.nan, 1.0, np.nan, np.nan, 5.0, np.nan, np.nan],
+    }
+    df = DataFrame(data, index=index)
+    result = df.interpolate(method=method)
+    expected = DataFrame(
+        {name: df[name].interpolate(method=method) for name in data}, index=index
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_interpolate_frame_no_nans_without_scipy(monkeypatch):
+    # GH#48236 a frame whose slices are all valid or all NaN never reached
+    #  SciPy on the per-slice path, and must not start requiring it
+    real_import = missing.import_optional_dependency
+
+    def no_scipy(name, *args, **kwargs):
+        if name == "scipy":
+            raise ImportError("Missing optional dependency 'scipy'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(missing, "import_optional_dependency", no_scipy)
+    df = DataFrame({"a": [1.0, 2.0, 3.0], "b": [np.nan, np.nan, np.nan]})
+    tm.assert_frame_equal(df.interpolate(method="nearest"), df)
+
+
+@pytest.mark.parametrize("method", ["linear", "index", "nearest", "zero"])
+@pytest.mark.parametrize(
+    "index_values",
+    [None, [1.0, 2.0, np.inf], [-1.5e308, 0.0, 1.5e308], [-1.7e308, 1.7e308, np.inf]],
+)
+def test_interpolate_frame_no_runtime_warning(method, index_values):
+    # GH#48236 np.interp does not set the FP error state, so neither may the
+    #  whole-block path that replaced it -- for extreme values in the index
+    #  just as much as in the data
+    if method != "linear":
+        pytest.importorskip("scipy")
+    df = DataFrame(
+        {"a": [np.inf, np.nan, np.inf], "b": [-1e308, np.nan, 1e308]},
+        index=index_values,
+    )
+    with tm.assert_produces_warning(None):
+        df.interpolate(method=method)
+
+
+@pytest.mark.parametrize(
+    "index_values", [[0.1, 0.2, 0.3], [0.0, 1.0, 2.0], [1.0, 2.0, 4.0]]
+)
+def test_interpolate_frame_nearest_ties(index_values):
+    # GH#48236 interp1d rounds against the halfway point in one step; comparing
+    #  the gap either side rounds twice and disagrees around the midpoint
+    pytest.importorskip("scipy")
+    df = DataFrame({"a": [1.0, np.nan, 2.0]}, index=index_values)
+    result = df.interpolate(method="nearest")
+    expected = df["a"].interpolate(method="nearest").to_frame()
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "kwargs, index_values, used",
+    [
+        ({"method": "linear"}, None, True),
+        ({"method": "nearest"}, None, True),
+        # a limit needs the per-slice path
+        ({"method": "linear", "limit": 1}, None, False),
+        # so does an index that does not strictly increase
+        ({"method": "index"}, [0.0, 1.0, 1.0], False),
+    ],
+)
+def test_interpolate_frame_uses_whole_block_path(
+    kwargs, index_values, used, monkeypatch
+):
+    # GH#48236 pin which inputs take the whole-block path; every other test
+    #  here asserts equivalence, so a gate that stopped matching anything
+    #  would drop the optimization with the suite still green
+    if kwargs["method"] == "nearest":
+        pytest.importorskip("scipy")
+    calls = []
+    real = missing._interpolate_2d_neighbors
+
+    def spy(*args, **kwargs_):
+        calls.append(1)
+        return real(*args, **kwargs_)
+
+    monkeypatch.setattr(missing, "_interpolate_2d_neighbors", spy)
+    df = DataFrame({"a": [1.0, np.nan, 3.0]}, index=index_values)
+    df.interpolate(**kwargs)
+    assert bool(calls) is used
+
+
+@pytest.mark.parametrize("method", ["linear", "nearest", "zero"])
+def test_interpolate_frame_multiple_chunks(method, monkeypatch):
+    # GH#48236 the whole-block path works a bounded number of values at a time;
+    #  a block spanning several passes must come out the same as one pass
+    if method != "linear":
+        pytest.importorskip("scipy")
+    rng = np.random.default_rng(0)
+    values = rng.normal(size=(20, 9))
+    values[rng.random(values.shape) < 0.4] = np.nan
+    values[3] = np.nan
+    df = DataFrame(values.T)
+    expected = df.interpolate(method=method)
+    monkeypatch.setattr(missing, "_NEIGHBOR_CHUNK_SIZE", 9)
+    result = df.interpolate(method=method)
+    tm.assert_frame_equal(result, expected)
+
+
+def test_interpolate_frame_multiple_chunks_without_scipy(monkeypatch):
+    # GH#48236 the lazy SciPy import has to raise before any chunk is written
+    #  to, or a failed interpolate would leave the block half filled
+    real_import = missing.import_optional_dependency
+
+    def no_scipy(name, *args, **kwargs):
+        if name == "scipy":
+            raise ImportError("Missing optional dependency 'scipy'")
+        return real_import(name, *args, **kwargs)
+
+    # the first chunks need no SciPy, the last one does; interpolate inplace
+    #  so that a premature write would be visible in df
+    df = DataFrame({"a": [1.0, 2.0], "b": [np.nan, np.nan], "c": [np.nan, 1.0]})
+    orig = df.copy()
+    monkeypatch.setattr(missing, "_NEIGHBOR_CHUNK_SIZE", 2)
+    monkeypatch.setattr(missing, "import_optional_dependency", no_scipy)
+    with pytest.raises(ImportError, match="scipy"):
+        df.interpolate(method="nearest", limit_direction="both", inplace=True)
+    tm.assert_frame_equal(df, orig)

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -495,3 +495,38 @@ class TestDataFrameInterpolate:
         result = df.interpolate(method="time")
         expected = DataFrame({"a": [1.0, 1.5, 2.0]}, index=idx, dtype="Float64")
         tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("method", ["linear", "index", "values", "nearest", "zero"])
+@pytest.mark.parametrize("limit_direction", ["forward", "backward", "both"])
+@pytest.mark.parametrize("limit_area", [None, "inside", "outside"])
+@pytest.mark.parametrize("index_values", [None, [0.0, 1.5, 2.0, 6.0, 6.5, 9.0, 20.0]])
+def test_interpolate_frame_matches_series(
+    method, limit_direction, limit_area, index_values
+):
+    # GH#48236 a frame interpolates every 1-d slice at once for these methods;
+    #  a Series takes the slice-at-a-time path, so the two must agree
+    if method != "linear":
+        pytest.importorskip("scipy")
+    data = {
+        "all_nan": [np.nan] * 7,
+        "no_nan": [1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0],
+        "one_valid": [np.nan, np.nan, 3.0, np.nan, np.nan, np.nan, np.nan],
+        "edges_nan": [np.nan, 1.0, np.nan, np.nan, 5.0, np.nan, np.nan],
+        "interior": [0.0, np.nan, 2.0, np.nan, np.nan, 5.0, 6.0],
+    }
+    df = DataFrame(data, index=index_values)
+    kwargs = {
+        "method": method,
+        "limit_direction": limit_direction,
+        "limit_area": limit_area,
+    }
+    result = df.interpolate(**kwargs)
+    expected = DataFrame(
+        {name: df[name].interpolate(**kwargs) for name in data}, index=df.index
+    )
+    tm.assert_frame_equal(result, expected)
+
+    # and the axis=1 spelling gives the transposed result
+    result = df.T.interpolate(axis=1, **kwargs)
+    tm.assert_frame_equal(result, expected.T)


### PR DESCRIPTION
closes #48236

`interpolate_2d_inplace` looped a Python `_interpolate_1d` over every 1-d slice, so the per-slice overhead (~15us for `linear`, ~65us for `nearest`, independent of slice length) dominated the interpolation itself.

For the methods whose value at a missing position depends only on the closest valid value on either side — `linear`, `index`, `values`, `time`, `nearest`, `zero` — the whole 2-D block is now handled in one pass by `_interpolate_2d_neighbors`: ffill/bfill the valid *positions* with `np.maximum.accumulate` / reversed `np.minimum.accumulate`, then combine the two sides.

The speedup tracks how wide the frame is, since that is what sets the number of 1-d slices. Measured against the same build with the fast path disabled:

| frame | `linear` | `nearest` | `zero` |
| --- | --- | --- | --- |
| 400000 x 1 | 1.6x | 1.8x | 1.5x |
| 2000 x 200 | 1.8x | 3.0x | 3.5x |
| 200 x 2000 | 5.6x | 15.6x | 21.0x |
| 50 x 5000 | 18.8x | 61.9x | 86.9x |

The issue's reproducer goes 3.25s -> 0.26s.

Notes:

- The fast path is gated on `ndim == 2`, `axis == 1` (what `Block.interpolate` passes for every 2-D block), `mask is None`, float data, numeric `indices`, `limit is None`, an NA `fill_value`, and a strictly increasing index *after* the cast to float64. Everything else falls through to the existing loop unchanged. Checking the cast values rather than `is_monotonic_increasing`/`is_unique` matters: i8 nanosecond timestamps are above 2**53, so a sub-microsecond `DatetimeIndex` collapses onto itself in float64.
- Row chunking (`_NEIGHBOR_CHUNK_SIZE`) keeps temporaries bounded — the unchunked form peaked at +1.3 GB on a 128 MB frame; chunked it is +12.9 MB over the result copy.
- SciPy is required exactly where the per-slice path required it: for `nearest`/`zero`, and only once a slice is reached that is neither all-valid nor all-NaN. The import is done inside the chunk loop, before anything in that chunk is written, so a missing SciPy cannot leave a block half-filled.
- `slinear` is deliberately excluded: `interp1d` raises on a slice with exactly one valid point where `nearest`/`zero` return NaN, and it is a B-spline evaluation. It can be revisited separately.
- `nearest` rounds against the midpoint in one step (`xprev / 2 + xnext / 2`) rather than comparing the gap on either side, which rounds twice and disagrees with `interp1d` around the midpoint for an index as ordinary as `[0.1, 0.2, 0.3]`.

On equivalence: verified against a differential matrix over methods x limit x limit_direction x limit_area x axis x fill_value x frame shape (including infinities, all-NaN and single-valid slices, float32, non-unique/unsorted/datetime indexes, and masked/arrow blocks), comparing values *and* exception messages. `nearest` and `zero` are bit-identical, as is float32 throughout.

The linear methods can differ from `np.interp` in the last bits: numpy's `arr_interp` C loop is compiled with FMA contraction, and no numpy expression reproduces a fused multiply-add (a non-contracting build of numpy returns the unfused value too). The difference stays under an ULP of the two values being interpolated between — worst case measured is 6.9e-18 on operands of order 1 — so it is only a large *relative* difference where those two nearly cancel. Neither form is the more accurate one: against exact rational arithmetic, in the worst divergent cell this PR is 799 ULP from exact where `np.interp` is 1311, the spread being cancellation inherent to the shared formula.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which profiled the existing path, wrote the implementation and tests, ran the differential matrix, and did several rounds of adversarial review that found the float32, FP-warning, nanosecond-index and `nearest` tie-break divergences listed above.
