### PR TITLE
ENH: add Rolling.prod

### DIFF
--- a/doc/source/reference/window.rst
+++ b/doc/source/reference/window.rst
@@ -27,6 +27,7 @@ Rolling window functions
 
    Rolling.count
    Rolling.sum
+   Rolling.prod
    Rolling.mean
    Rolling.median
    Rolling.var

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -54,6 +54,7 @@ Other enhancements
 - MSVC is no longer required to build on Windows, and build errors when using the MinGW compiler have been fixed (:issue:`63160`)
 - Time strings with a space before ``AM``/``PM`` (e.g. ``"3:25:00 PM"``) are now recognized; :meth:`Series.between_time` and :meth:`DataFrame.between_time` previously raised on them, and :meth:`Series.at_time` and :meth:`DataFrame.at_time` warned that they would raise in a future version. Casting such strings to a pyarrow time dtype (``time32``/``time64``) no longer silently gives a missing value (:issue:`18793`)
 - Building from source no longer fails when compiling the windowing extensions against C++ standard libraries that provide only ``std::signbit`` (:issue:`50979`, :issue:`51047`)
+- Added :meth:`.Rolling.prod` to calculate the product over rolling windows (:issue:`48030`)
 - Setting values with :meth:`DataFrame.at` or :meth:`Series.at` using a non-scalar indexer (e.g. a boolean mask, list, or array) now raises a clearer ``InvalidIndexError`` directing users to ``.loc`` (:issue:`51866`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/window/aggregations.pyi
+++ b/pandas/_libs/window/aggregations.pyi
@@ -17,6 +17,12 @@ def roll_sum(
     end: np.ndarray,  # np.ndarray[np.int64]
     minp: int,  # int64_t
 ) -> np.ndarray: ...  # np.ndarray[float]
+def roll_prod(
+    values: np.ndarray,  # const float64_t[:]
+    start: np.ndarray,  # np.ndarray[np.int64]
+    end: np.ndarray,  # np.ndarray[np.int64]
+    minp: int,  # int64_t
+) -> np.ndarray: ...  # np.ndarray[float]
 def roll_mean(
     values: np.ndarray,  # const float64_t[:]
     start: np.ndarray,  # np.ndarray[np.int64]

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -1,6 +1,9 @@
 # cython: boundscheck=False, wraparound=False, cdivision=True
 
-from libc.math cimport fabs
+from libc.math cimport (
+    fabs,
+    isinf,
+)
 from libcpp.cmath cimport signbit
 from libcpp.deque cimport deque
 from libcpp.stack cimport stack
@@ -197,6 +200,149 @@ def roll_sum(const float64_t[:] values, ndarray[int64_t] start,
 
     return output
 
+
+# ----------------------------------------------------------------------
+# Rolling product
+
+
+cdef float64_t calc_prod(int64_t minp, int64_t nobs, int64_t zero_count,
+                         int64_t neg_count, float64_t prod_x) noexcept nogil:
+    cdef:
+        float64_t result
+
+    if nobs == 0 == minp:
+        result = 1.0
+    elif nobs >= minp:
+        if zero_count > 0:
+            if neg_count % 2:
+                result = -0.0
+            else:
+                result = 0.0
+        else:
+            result = prod_x
+    else:
+        result = NaN
+
+    return result
+
+
+cdef void add_prod(
+    float64_t val,
+    int64_t *nobs,
+    int64_t *zero_count,
+    int64_t *neg_count,
+    float64_t *prod_x,
+    bint *numerically_unstable,
+) noexcept nogil:
+    # Not NaN
+    if val == val:
+        nobs[0] += 1
+
+        if signbit(val):
+            neg_count[0] += 1
+
+        if val == 0:
+            zero_count[0] += 1
+        else:
+            prod_x[0] *= val
+            if prod_x[0] == 0 or isinf(prod_x[0]):
+                numerically_unstable[0] = True
+
+
+cdef void remove_prod(
+    float64_t val,
+    int64_t *nobs,
+    int64_t *zero_count,
+    int64_t *neg_count,
+    float64_t *prod_x,
+    bint *numerically_unstable,
+) noexcept nogil:
+    # Not NaN
+    if val == val:
+        nobs[0] -= 1
+
+        if signbit(val):
+            neg_count[0] -= 1
+
+        if val == 0:
+            zero_count[0] -= 1
+        else:
+            if prod_x[0] == 0 or isinf(prod_x[0]):
+                numerically_unstable[0] = True
+            prod_x[0] /= val
+            if prod_x[0] == 0 or isinf(prod_x[0]):
+                numerically_unstable[0] = True
+
+
+def roll_prod(const float64_t[:] values, ndarray[int64_t] start,
+              ndarray[int64_t] end, int64_t minp) -> np.ndarray:
+    cdef:
+        Py_ssize_t i, j
+        float64_t prod_x
+        int64_t s, e, zero_count, neg_count
+        int64_t nobs = 0, N = len(start)
+        ndarray[float64_t] output
+        bint is_monotonic_increasing_bounds
+        bint requires_recompute, numerically_unstable = False
+
+    is_monotonic_increasing_bounds = is_monotonic_increasing_start_end_bounds(
+        start, end
+    )
+    output = np.empty(N, dtype=np.float64)
+
+    with nogil:
+        for i in range(0, N):
+            s = start[i]
+            e = end[i]
+
+            requires_recompute = (
+                i == 0
+                or not is_monotonic_increasing_bounds
+                or s >= end[i - 1]
+            )
+
+            if not requires_recompute:
+                for j in range(start[i - 1], s):
+                    remove_prod(
+                        values[j],
+                        &nobs,
+                        &zero_count,
+                        &neg_count,
+                        &prod_x,
+                        &numerically_unstable,
+                    )
+
+                for j in range(end[i - 1], e):
+                    add_prod(
+                        values[j],
+                        &nobs,
+                        &zero_count,
+                        &neg_count,
+                        &prod_x,
+                        &numerically_unstable,
+                    )
+
+            if requires_recompute or numerically_unstable:
+                prod_x = 1.0
+                zero_count = 0
+                neg_count = 0
+                nobs = 0
+
+                for j in range(s, e):
+                    add_prod(
+                        values[j],
+                        &nobs,
+                        &zero_count,
+                        &neg_count,
+                        &prod_x,
+                        &numerically_unstable,
+                    )
+
+                numerically_unstable = False
+
+            output[i] = calc_prod(minp, nobs, zero_count, neg_count, prod_x)
+
+    return output
 
 # ----------------------------------------------------------------------
 # Rolling mean

--- a/pandas/core/window/rolling.py
+++ b/pandas/core/window/rolling.py
@@ -2482,6 +2482,81 @@ class Rolling(RollingAndExpandingMixin):
             engine_kwargs=engine_kwargs,
         )
 
+    def prod(
+        self,
+        numeric_only: bool = False,
+        engine: Literal["cython", "numba"] | None = None,
+        engine_kwargs: dict[str, bool] | None = None,
+    ):
+        """
+        Calculate the rolling product.
+
+        This is equivalent to applying ``numpy.prod`` over each rolling window.
+        Missing values (NaN) are excluded from the calculation.
+
+        Parameters
+        ----------
+        numeric_only : bool, default False
+            Include only float, int, boolean columns.
+
+        engine : str, default None
+            * ``'cython'`` : Runs the operation through C-extensions from cython.
+            * ``'numba'`` : Runs the operation through JIT compiled code from numba.
+            * ``None`` : Defaults to ``'cython'`` or
+              globally setting ``compute.use_numba``
+
+        engine_kwargs : dict, default None
+            * For ``'cython'`` engine, there are no accepted ``engine_kwargs``
+            * For ``'numba'`` engine, the engine can accept ``nogil``
+              and ``parallel`` dictionary keys. The values must either be ``True`` or
+              ``False``. The default ``engine_kwargs`` for the ``'numba'`` engine is
+              ``{'nogil': False, 'parallel': False}``.
+
+        Returns
+        -------
+        Series or DataFrame
+            Return type is the same as the original object with ``np.float64`` dtype.
+
+        See Also
+        --------
+        Series.rolling : Calling rolling with Series data.
+        DataFrame.rolling : Calling rolling with DataFrames.
+        Series.prod : Aggregating product for Series.
+        DataFrame.prod : Aggregating product for DataFrame.
+
+        Notes
+        -----
+        See :ref:`window.numba_engine` and :ref:`enhancingperf.numba`
+        for extended documentation and performance considerations
+        for the Numba engine.
+
+        Examples
+        --------
+        >>> s = pd.Series([1, 2, 3, 4, 5])
+        >>> s.rolling(3).prod()
+        0     NaN
+        1     NaN
+        2     6.0
+        3    24.0
+        4    60.0
+        dtype: float64
+        """
+        if maybe_use_numba(engine):
+            if self.method == "table":
+                func = generate_manual_numpy_nan_agg_with_axis(np.nanprod)
+            else:
+                func = np.nanprod
+
+            return self.apply(
+                func,
+                raw=True,
+                engine=engine,
+                engine_kwargs=engine_kwargs,
+            )
+
+        window_func = window_aggregations.roll_prod
+        return self._apply(window_func, name="prod", numeric_only=numeric_only)
+
     def max(
         self,
         numeric_only: bool = False,

--- a/pandas/tests/window/test_groupby.py
+++ b/pandas/tests/window/test_groupby.py
@@ -90,6 +90,7 @@ class TestRolling:
         "f",
         [
             "sum",
+            "prod",
             "mean",
             "min",
             "max",

--- a/pandas/tests/window/test_numba.py
+++ b/pandas/tests/window/test_numba.py
@@ -583,6 +583,17 @@ def test_npfunc_no_warnings():
         df.col1.rolling(2).apply(np.prod, raw=True, engine="numba")
 
 
+@td.skip_if_no("numba")
+def test_rolling_prod_numba():
+    # GH 48030
+    values = Series([2.0, 3.0, 4.0, 5.0])
+
+    result = values.rolling(2).prod(engine="numba")
+    expected = values.rolling(2).prod(engine="cython")
+
+    tm.assert_series_equal(result, expected)
+
+
 class PrescribedWindowIndexer(BaseIndexer):
     def __init__(self, start, end):
         self._start = start

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -576,6 +576,70 @@ def test_missing_minp_zero_variable():
     tm.assert_series_equal(result, expected)
 
 
+def test_rolling_prod():
+    # GH 48030
+    values = Series([2.0, -3.0, 0.0, np.nan, 4.0, -5.0, 2.0])
+    expected = Series([2.0, -6.0, 0.0, 0.0, 0.0, -20.0, -40.0])
+
+    result = values.rolling(3, min_periods=1).prod()
+
+    tm.assert_series_equal(result, expected)
+
+
+def test_rolling_prod_min_periods_zero():
+    # GH 48030
+    values = Series([np.nan])
+
+    result = values.rolling(1, min_periods=0).prod()
+    expected = Series([1.0])
+
+    tm.assert_series_equal(result, expected)
+
+
+def test_rolling_prod_variable_window():
+    # GH 48030
+    values = Series(
+        [2.0, 3.0, 4.0, 5.0],
+        index=DatetimeIndex(["2026-01-01", "2026-01-02", "2026-01-04", "2026-01-05"]),
+    )
+    expected = Series([2.0, 6.0, 12.0, 20.0], index=values.index)
+
+    result = values.rolling("3D", min_periods=1).prod()
+
+    tm.assert_series_equal(result, expected)
+
+
+def test_rolling_prod_recovers_from_overflow():
+    # GH 48030
+    values = Series([1e308, 1e308, 1e-308])
+    expected = Series([np.nan, np.inf, 1.0])
+
+    result = values.rolling(2).prod()
+
+    tm.assert_series_equal(result, expected)
+
+
+def test_rolling_prod_recovers_from_underflow():
+    # GH 48030
+    values = Series([1e-308, 1e-308, 1e308])
+    expected = Series([np.nan, 0.0, 1.0])
+
+    result = values.rolling(2).prod()
+
+    tm.assert_series_equal(result, expected)
+
+
+def test_rolling_prod_preserves_signed_zero():
+    # GH 48030
+    values = Series([-2.0, 0.0, 3.0])
+    result = values.rolling(2).prod()
+    expected = Series([np.nan, -0.0, 0.0])
+
+    tm.assert_series_equal(result, expected)
+    assert np.signbit(result.iloc[1])
+    assert not np.signbit(result.iloc[2])
+
+
 def test_multi_index_names():
     # GH 16789, 16825
     cols = MultiIndex.from_product([["A", "B"], ["C", "D", "E"]], names=["1", "2"])
@@ -1953,6 +2017,19 @@ def test_numeric_only_frame(arithmetic_win_operators, numeric_only):
     columns = ["a", "b"] if numeric_only else ["a", "b", "c"]
     expected = df[columns].agg([kernel]).reset_index(drop=True).astype(float)
     assert list(expected.columns) == columns
+
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("numeric_only", [True, False])
+def test_rolling_prod_numeric_only_frame(numeric_only):
+    df = DataFrame({"a": [2], "b": [3], "c": [4]})
+    df["c"] = df["c"].astype(object)
+
+    result = df.rolling(1).prod(numeric_only=numeric_only)
+
+    columns = ["a", "b"] if numeric_only else ["a", "b", "c"]
+    expected = df[columns].astype(float)
 
     tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
This PR adds `Rolling.prod()`, addressing issue #48030. This version uses a dedicated Cython rolling product approach, rather than using `Rolling.apply`. It handles zeros/NaNs and recovers from floating-point overflow and underflow. It supports the Numba engine as well.

- [x] closes #48030
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

I used ChatGPT-5.6 Sol (high). It helped me reason through the implementation, proposed code and tests, and identified edge cases (such as overflow and signed zero). It also helped me walk through the contribution process. I personally reviewed the changes and reran the tests and pre-commit checks. I did not use codex. I had it read AGENTS.md and follow the instructions.

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
