### PR TITLE
DOC: fix typo 'scalaer' to 'scalar' in DataFrame.var docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -17760,7 +17760,7 @@ class DataFrame(NDFrame, OpsMixin):
 
         Returns
         -------
-        Series or scalaer
+        Series or scalar
             Unbiased variance over requested axis.
 
         See Also


### PR DESCRIPTION
Fixes a one-word typo in the `DataFrame.var()` docstring: "Series or scalaer" should read "Series or scalar", matching the wording used in every other reduction method's docstring in this file (`sum`, `mean`, `std`, `median`, `min`, `max`, etc.).

This is a documentation-only change with no functional impact.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] Tests added and passed if fixing a bug or adding a new feature — N/A, documentation-only change
- [ ] All code checks passed.
- [x] Added type annotations to new arguments/methods/functions. — N/A, no new arguments/methods
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. — N/A, typo-only fix
- [x] I have reviewed and followed all the contribution guidelines

Check exactly one of the following, per the automated contributions policy:
- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

I used Claude Sonnet 4.6 (chat) to scan the pandas codebase for docstring spelling inconsistencies, identify this typo, verify it against the rest of the codebase and existing issues/PRs to confirm it wasn't already reported, and guide me step-by-step through the git workflow (branching, committing, pushing) and opening this PR. I reviewed and understand the one-word change being made.