### PR TITLE
BUG: PeriodIndex partial-string slicing loses anchor on same-resolution labels

### DIFF
--- a/pandas/core/indexes/period.py
+++ b/pandas/core/indexes/period.py
@@ -731,6 +731,15 @@ class PeriodIndex(DatetimeIndexOpsMixin):
         return super()._maybe_cast_slice_bound(label, side)
 
     def _parsed_string_to_bounds(self, reso: Resolution, parsed: datetime):
+        if reso == self._resolution_obj:
+            # The label is expressed at the same granularity as the index's
+            # own (possibly anchored) freq, so build the bound directly from
+            # self.freq to preserve the anchor - mirrors _cast_partial_indexing_scalar,
+            # used by get_loc for this same case. Going through a calendar-freq
+            # Period first and asfreq-ing back (the branch below) discards a
+            # non-default anchor month, shifting the bounds by one period.
+            iv = self._cast_partial_indexing_scalar(parsed)
+            return (iv, iv)
         freq = OFFSET_TO_PERIOD_FREQSTR.get(reso.attr_abbrev, reso.attr_abbrev)
         iv = Period(parsed, freq=freq)
         return (iv.asfreq(self.freq, how="start"), iv.asfreq(self.freq, how="end"))

--- a/pandas/tests/indexes/period/test_partial_slicing.py
+++ b/pandas/tests/indexes/period/test_partial_slicing.py
@@ -40,6 +40,36 @@ class TestPeriodIndex:
         # Todo: fix these accessors!
         assert ser["05Q4"] == ser.iloc[2]
 
+    @pytest.mark.parametrize(
+        "freq, label",
+        [
+            ("Q-DEC", "2001Q1"),
+            ("Q-JAN", "2001Q1"),
+            ("Q-FEB", "2001Q1"),
+            ("Q-MAR", "2001Q1"),
+            ("Q-APR", "2001Q1"),
+            ("Q-NOV", "2001Q1"),
+            ("Y-DEC", "2002"),
+            ("Y-JUN", "2002"),
+            ("Y-MAR", "2002"),
+        ],
+    )
+    def test_string_slice_matches_freq_resolves_single_anchored_period(
+        self, freq, label
+    ):
+        # GH#66571 partial-string slicing at the same resolution as an
+        # anchored freq (e.g. "2001Q1" on a Q-FEB index) used to resolve the
+        # string via a calendar-freq Period first, discarding the anchor and
+        # shifting the bounds to span two periods instead of the single one
+        # get_loc already resolved it to.
+        periods = 12 if freq.startswith("Q") else 8
+        pi = period_range("2000Q1" if freq.startswith("Q") else "2000", periods=periods, freq=freq)
+        ser = Series(range(periods), index=pi)
+        result = ser.loc[label:label]
+        expected = ser.iloc[[pi.get_loc(label)]]
+        tm.assert_series_equal(result, expected)
+        assert len(result) == 1
+
     def test_pindex_slice_index(self):
         pi = period_range(start="1/1/10", end="12/31/12", freq="M")
         s = Series(np.random.default_rng(2).random(len(pi)), index=pi)


### PR DESCRIPTION
## Summary

Fixes #66571.

Partial-string slicing on a `PeriodIndex` whose frequency is anchored to a month that doesn't line up with calendar quarters/years resolves the string bound one period too early, so the slice includes an extra label:

```python
pi = pd.period_range("2000Q1", periods=12, freq="Q-FEB")
ser = pd.Series(range(12), index=pi)

ser.loc["2001Q1":"2001Q1"]
# 2000Q4    3
# 2001Q1    4      <- should only return this row
# Freq: Q-FEB, dtype: int64

pi.get_loc("2001Q1")   # 4  (correct - get_loc isn't affected)
```

## Root cause

`PeriodIndex._parsed_string_to_bounds` always parses the string into a `Period` at the *calendar* freq derived from the label's own resolution (`"Q"` for a quarterly label, `"Y"` for a yearly one - discarding any anchor month), then uses `.asfreq()` to map that calendar period back onto the index's actual (anchored) freq:

```python
def _parsed_string_to_bounds(self, reso, parsed):
    freq = OFFSET_TO_PERIOD_FREQSTR.get(reso.attr_abbrev, reso.attr_abbrev)
    iv = Period(parsed, freq=freq)
    return (iv.asfreq(self.freq, how="start"), iv.asfreq(self.freq, how="end"))
```

When the calendar period and the anchored period don't line up, that `asfreq` round-trip spans two anchored periods instead of resolving to the single period the label actually names.

`get_loc` doesn't have this problem, because `_cast_partial_indexing_scalar` (which it uses for the equivalent case) builds `Period(parsed, freq=self.freq)` directly, preserving the anchor.

## Fix

Reuse `_cast_partial_indexing_scalar` in `_parsed_string_to_bounds`, but only for the case where the label's resolution exactly matches the index's own resolution (`reso == self._resolution_obj`) - i.e. exactly the case `get_loc` already handles correctly. The coarser-resolution case (e.g. a year label on a monthly index, which legitimately needs to span many periods) is untouched and keeps the original calendar-freq + `asfreq` logic, since there's no anchor to lose there - it's enumerating a range, not naming one specific anchored period.

## Test plan

- [x] Added a parametrized regression test (`test_string_slice_matches_freq_resolves_single_anchored_period`) covering all the anchor variants from the issue: `Q-DEC`/`Q-JAN`/`Q-FEB`/`Q-MAR`/`Q-APR`/`Q-NOV` and `Y-DEC`/`Y-JUN`/`Y-MAR` - each asserts the slice matches `get_loc` and returns exactly one row.
- [x] Ran the full existing `pandas/tests/indexes/period/` suite (476 tests) plus period-related cases in `pandas/tests/indexing/` (101 tests) and `Series`/`DataFrame` `.truncate()` tests (92 tests, since `truncate` delegates to `.loc`) - all pass, no regressions.
- [x] Explicitly checked the coarser-resolution case (a year label on a monthly index) is unaffected by the fix and still returns the full 12-month range.