### PR TITLE
DOC/WEB: remove outdated 'Hosted by OVHCloud' in footer

### DIFF
--- a/doc/_templates/pandas_footer.html
+++ b/doc/_templates/pandas_footer.html
@@ -1,3 +1,3 @@
 <p class="copyright">
-    &copy {{copyright}} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>.
+    &copy {{copyright}} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a>
 </p>

--- a/web/pandas/_templates/layout.html
+++ b/web/pandas/_templates/layout.html
@@ -91,7 +91,7 @@
                 </li>
             </ul>
             <p>
-                &copy; {{ current_year }} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a> Hosted by <a href="https://www.ovhcloud.com">OVHcloud</a>.
+                &copy; {{ current_year }} pandas via <a href="https://numfocus.org">NumFOCUS, Inc.</a>
             </p>
         </footer>
         

--- a/web/pandas/config.yml
+++ b/web/pandas/config.yml
@@ -166,9 +166,6 @@ sponsors:
       kind: regular
       description: "Bodo's parallel computing platform uses pandas API, and Bodo financially supports pandas development to help improve pandas, in particular the pandas API"
   inkind: # not included in active so they don't appear in the home page
-    - name: "OVH"
-      url: https://us.ovhcloud.com/
-      description: "Website and documentation hosting."
     - name: "Indeed"
       url: https://opensource.indeedeng.io/
       description: "<i>pandas</i> logo design"


### PR DESCRIPTION
Small cleanup, since this is no longer the case (xref https://github.com/pandas-dev/pandas/issues/64703)