### PR TITLE
Bug fix for #63221 PR PyArrow string: list indexing

### DIFF
--- a/pandas/core/arrays/arrow/accessors.py
+++ b/pandas/core/arrays/arrow/accessors.py
@@ -14,7 +14,7 @@ from typing import (
 from pandas.compat import HAS_PYARROW
 
 from pandas.core.dtypes.common import is_list_like
-
+import numpy as np
 if HAS_PYARROW:
     import pyarrow as pa
     import pyarrow.compute as pc
@@ -166,13 +166,60 @@ class ListAccessor(ArrowAccessor):
             # element index to be an array.
             # if key < 0:
             #     key = pc.add(key, pc.list_value_length(self._pa_array))
-            element = pc.list_element(self._pa_array, key)
-            return Series(
-                element,
-                dtype=ArrowDtype(element.type),
-                index=self._data.index,
-                name=self._data.name,
-            )
+            arr = self._pa_array
+            if key < 0:
+                lengths = pc.list_value_length(arr)
+                abs_key = abs(key)
+                too_short = pc.and_(
+                    pc.is_valid(lengths), pc.less(lengths, pa.scalar(abs_key, type=lengths.type))
+                )
+                if pc.any(too_short).as_py():
+                    bad_pos = pc.index(too_short, True).as_py()
+                    bad_length = lengths[bad_pos].as_py()
+                    raise IndexError(
+                        f"list index {key} out of range for list of length "
+                        f"{bad_length} at position {bad_pos}"
+                    )
+
+                chunks = arr.chunks if isinstance(arr, pa.ChunkedArray) else [arr]
+                all_results = []
+                for chunk in chunks:
+                    if len(chunk) == 0:
+                        continue
+                    chunk_lengths = pc.list_value_length(chunk)
+                    if pa.types.is_fixed_size_list(chunk.type):
+                        list_size = chunk.type.list_size
+                        starts = pa.array(
+                            (np.arange(len(chunk), dtype=np.int64) + chunk.offset)
+                            * list_size,
+                            type=pa.int64(),
+                        )
+                        flat_values = chunk.values
+                    else:
+                        starts = chunk.offsets[:-1]
+                        flat_values = chunk.values
+                    indices = pc.add(starts, pc.add(chunk_lengths, key))
+                    all_results.append(flat_values.take(indices))
+
+                result_values = (
+                    pa.concat_arrays(all_results)
+                    if all_results
+                    else pa.array([], type=arr.type.value_type)
+                )
+                return Series(
+                    result_values,
+                    dtype=ArrowDtype(result_values.type),
+                    index=self._data.index,
+                    name=self._data.name,
+                )
+            else:
+                element = pc.list_element(self._pa_array, key)
+                return Series(
+                    element,
+                    dtype=ArrowDtype(element.type),
+                    index=self._data.index,
+                    name=self._data.name,
+                )
         elif isinstance(key, slice):
             # TODO: Support negative start/stop/step, ideally this would be added
             # upstream in pyarrow.

--- a/pandas/tests/series/accessors/test_list_accessor.py
+++ b/pandas/tests/series/accessors/test_list_accessor.py
@@ -128,9 +128,15 @@ def test_list_getitem_invalid_index(list_dtype):
     ser = Series(
         [[1, 2, 3], [4, None, 5], None],
         dtype=ArrowDtype(list_dtype),
+        name="a"
     )
-    with tm.external_error_raised(pa.ArrowInvalid):
-        ser.list[-1]
+    result = ser.list[-1]
+    expected = Series(
+        [3, 5, None],
+        dtype=ArrowDtype(pa.int64()),  # item type, not list_dtype
+        name="a",
+    )
+    tm.assert_series_equal(result, expected)
     with tm.external_error_raised(pa.ArrowInvalid):
         ser.list[5]
     with pytest.raises(ValueError, match="key must be an int or slice, got str"):
@@ -144,3 +150,18 @@ def test_list_accessor_not_iterable():
     )
     with pytest.raises(TypeError, match="'ListAccessor' object is not iterable"):
         iter(ser.list)
+
+
+def test_list_get_negative_index():
+    ser = Series(
+        ["A-B", "C-D"],
+        dtype=ArrowDtype(pa.string()),
+        name="a"
+    )
+    result = ser.str.split("-").list[-1]
+    expected = Series(
+        ["B", "D"],
+        dtype=ArrowDtype(pa.string()),  # item type, not list_dtype
+        name="a",
+    )
+    tm.assert_series_equal(result, expected)


### PR DESCRIPTION
This is a PR based on option 2 from @Aokizy2 (https://github.com/pandas-dev/pandas/issues/63221#issuecomment-3640334567)

- [x] closes #63221 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [ ] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
