### PR TITLE
CLN: to_pyarrow_type handles extension dtype instances

### DIFF
--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -66,7 +66,9 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.dtypes.dtypes import (
     ArrowDtype,
+    BaseMaskedDtype,
     DatetimeTZDtype,
+    ExtensionDtype,
 )
 from pandas.core.dtypes.generic import (
     ABCDataFrame,
@@ -289,8 +291,6 @@ if TYPE_CHECKING:
         npt,
     )
 
-    from pandas.core.dtypes.dtypes import ExtensionDtype
-
     from pandas import Series
     from pandas.core.arrays.datetimes import DatetimeArray
     from pandas.core.arrays.timedeltas import TimedeltaArray
@@ -300,7 +300,8 @@ def to_pyarrow_type(
     dtype: ArrowDtype | pa.DataType | Dtype | None,
 ) -> pa.DataType | None:
     """
-    Convert dtype to a pyarrow type instance.
+    Convert dtype to a pyarrow type instance, or None if there is no
+    pyarrow equivalent.
     """
     if isinstance(dtype, ArrowDtype):
         return dtype.pyarrow_dtype
@@ -308,6 +309,15 @@ def to_pyarrow_type(
         return dtype
     elif isinstance(dtype, DatetimeTZDtype):
         return pa.timestamp(dtype.unit, dtype.tz)
+    elif isinstance(dtype, StringDtype):
+        # the pandas string dtypes are backed by pyarrow's large_string
+        return pa.large_string()
+    elif isinstance(dtype, BaseMaskedDtype):
+        return to_pyarrow_type(dtype.numpy_dtype)
+    elif isinstance(dtype, ExtensionDtype):
+        # no direct pyarrow equivalent (e.g. CategoricalDtype);
+        # pa.from_numpy_dtype would raise TypeError for these
+        return None
     elif dtype:
         try:
             # Accepts python types too

--- a/pandas/io/parsers/arrow_parser_wrapper.py
+++ b/pandas/io/parsers/arrow_parser_wrapper.py
@@ -76,10 +76,7 @@ def _pyarrow_parse_type(dtype) -> pa.DataType | None:
     if dtype == object:
         # match the other engines: object dtype holds the raw strings
         return pa.large_string()
-    # pass the scalar type: to_pyarrow_type accepts numpy dtypes and
-    # scalar types but not extension dtype instances like StringDtype
-    # (pa.from_numpy_dtype raises TypeError for those)
-    target_dtype = to_pyarrow_type(dtype.type)
+    target_dtype = to_pyarrow_type(dtype)
     if target_dtype is not None and (
         pa.types.is_string(target_dtype) or pa.types.is_large_string(target_dtype)
     ):

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -5288,7 +5288,7 @@ def test_reduction_axis_out_of_bounds(method, axis):
         (pd.Int64Dtype(), pa.int64()),
         (pd.Float64Dtype(), pa.float64()),
         (pd.BooleanDtype(), pa.bool_()),
-        (pd.ArrowDtype(pa.large_string()), pa.large_string()),
+        (ArrowDtype(pa.large_string()), pa.large_string()),
         (pd.CategoricalDtype(), None),
         (pd.PeriodDtype("D"), None),
         (np.dtype("int64"), pa.int64()),

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -73,7 +73,10 @@ from pandas.tests.extension import base
 
 pa = pytest.importorskip("pyarrow")
 
-from pandas.core.arrays.arrow.array import ArrowExtensionArray
+from pandas.core.arrays.arrow.array import (
+    ArrowExtensionArray,
+    to_pyarrow_type,
+)
 from pandas.core.arrays.arrow.extension_types import ArrowPeriodType
 
 
@@ -5275,3 +5278,25 @@ def test_reduction_axis_out_of_bounds(method, axis):
     msg = "`axis` must be fewer than the number of dimensions"
     with pytest.raises(ValueError, match=msg):
         getattr(arr, method)(axis=axis)
+
+
+@pytest.mark.parametrize(
+    "dtype, expected",
+    [
+        (pd.StringDtype("python"), pa.large_string()),
+        (pd.StringDtype("pyarrow"), pa.large_string()),
+        (pd.Int64Dtype(), pa.int64()),
+        (pd.Float64Dtype(), pa.float64()),
+        (pd.BooleanDtype(), pa.bool_()),
+        (pd.ArrowDtype(pa.large_string()), pa.large_string()),
+        (pd.CategoricalDtype(), None),
+        (pd.PeriodDtype("D"), None),
+        (np.dtype("int64"), pa.int64()),
+        (str, pa.string()),
+    ],
+)
+def test_to_pyarrow_type_extension_dtypes(dtype, expected):
+    # GH#62242 to_pyarrow_type raised TypeError for extension dtype
+    # instances without a direct pyarrow equivalent
+    result = to_pyarrow_type(dtype)
+    assert result == expected


### PR DESCRIPTION
Follow-up to the discussion in #62242 - the dtype.type review thread.

to_pyarrow_type raised TypeError for extension dtype instances without a direct pyarrow equivalent, because pa.from_numpy_dtype raises TypeError for those and only ArrowNotImplementedError was caught. That is why the read_csv pyarrow dtype helper had to pass dtype.type instead of the dtype itself.

Changes:
- StringDtype maps to pa.large_string() (what the pandas string dtypes are backed by)
- BaseMaskedDtype maps through its numpy_dtype (so e.g. Int64Dtype() -> int64 instead of raising)
- remaining extension dtypes (e.g. CategoricalDtype) hit an explicit isinstance(dtype, ExtensionDtype) branch and return None instead of raising - deliberately not a broadened except TypeError, so error behavior for non-dtype inputs is untouched
the read_csv helper now passes the dtype instance directly and the .type workaround comment is gone

Behavior is unchanged for every input that worked before - all the new branches handle inputs that previously raised. One latent crash this fixes along the way: ArrowExtensionArray._reduce with keepdims passes infer_dtype_from_scalar(...)[0] to this function, which can be a StringDtype under pandas 3 string inference and would have raised.

No whatsnew since the function is internal and nothing user-facing changes; happy to add an entry if preferred.

Direct tests added in pandas/tests/extension/test_arrow.py. 

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [X] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [X] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [X] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [X] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [ ] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
