### PR TITLE
REF: single helper for the inf float spellings

### DIFF
--- a/pandas/_libs/include/pandas/parser/tokenizer.h
+++ b/pandas/_libs/include/pandas/parser/tokenizer.h
@@ -274,17 +274,17 @@ int try_parse_plain_double(const char *start, const char *end, char decimal,
                            double *out);
 int to_boolean(const char *item, int64_t length, uint8_t *val);
 // Recognize the infinity spellings pandas accepts outside the numeric
-// converters, for both read_csv and lib.maybe_convert_numeric.
+// converters -- "inf"/"infinity", optionally signed, case-insensitively -- and
+// produce their value. Shared by read_csv and lib.maybe_convert_numeric, which
+// reach it only once their numeric converter has failed on the token.
 //
 // item  : the token; exactly `length` bytes are examined, so it need not be
 //         NUL-terminated and may contain an embedded NUL
 // length: byte length of item
 //
-// Returns 1 for "inf"/"+inf"/"infinity"/"+infinity", -1 for the negative
-// spellings and 0 for anything else, all case-insensitively. Note this is the
-// opposite sense from to_boolean above, which returns 0 on a match: the return
-// value here is a sign, not a status.
-int infinity_sign(const char *item, int64_t length);
+// Like to_boolean above, returns 0 on a match and leaves *out unmodified
+// otherwise.
+int parse_special_float(const char *item, int64_t length, double *out);
 
 #ifdef __cplusplus
 }

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -169,8 +169,6 @@ cdef extern from "pandas/datetime/pd_datetime.h":
 
 
 cdef:
-    float64_t INF = <float64_t>np.inf
-    float64_t NEGINF = -INF
     int64_t DEFAULT_CHUNKSIZE = 256 * 1024
 
 DEFAULT_BUFFER_HEURISTIC = 2 ** 20
@@ -306,7 +304,8 @@ cdef extern from "pandas/parser/tokenizer.h":
     int try_parse_plain_double(const char *start, const char *end, char decimal,
                                double *out) nogil
 
-    int infinity_sign(const char *item, int64_t length) nogil
+    int parse_special_float(const char *item, int64_t length,
+                            double *out) nogil
 
 cdef extern from "pandas/parser/pd_parser.h":
     void *new_rd_source(object obj) except NULL
@@ -3217,6 +3216,7 @@ cdef int _probe_double(parser_t *parser, int64_t col,
         c_int64_t token_idx = 0
         int64_t word_len
         char *p_end
+        double probe_value
 
     coliter_setup(&it, parser, col, line_start)
     for _ in range(lines):
@@ -3230,7 +3230,7 @@ cdef int _probe_double(parser_t *parser, int64_t col,
                                 parser.sci, parser.thousands,
                                 1, &error, NULL, word_end)
         if error != 0 or p_end == word or p_end != word_end:
-            if infinity_sign(word, word_len) != 0:
+            if parse_special_float(word, word_len, &probe_value) == 0:
                 return 0
             return 1
         return 0
@@ -3321,7 +3321,7 @@ cdef int _try_double_nogil(parser_t *parser,
                            float64_t NA, float64_t *data,
                            int *na_count, uint8_t *na_mask) nogil:
     cdef:
-        int error = 0, inf_sign
+        int error = 0
         Py_ssize_t idx, _, lines = line_end - line_start
         coliter_t it
         const char *word = NULL
@@ -3360,12 +3360,7 @@ cdef int _try_double_nogil(parser_t *parser,
                                                1, &error, NULL, word_end)
                     if error != 0 or p_end == word or p_end != word_end:
                         error = 0
-                        inf_sign = infinity_sign(word, word_len)
-                        if inf_sign > 0:
-                            data[0] = INF
-                        elif inf_sign < 0:
-                            data[0] = NEGINF
-                        else:
+                        if parse_special_float(word, word_len, data) != 0:
                             return 1
                 if use_na_flist:
                     k64 = kh_get_float64(na_fhashset, data[0])
@@ -3386,12 +3381,7 @@ cdef int _try_double_nogil(parser_t *parser,
                                            1, &error, NULL, word_end)
                 if error != 0 or p_end == word or p_end != word_end:
                     error = 0
-                    inf_sign = infinity_sign(word, word_end - word)
-                    if inf_sign > 0:
-                        data[0] = INF
-                    elif inf_sign < 0:
-                        data[0] = NEGINF
-                    else:
+                    if parse_special_float(word, word_end - word, data) != 0:
                         return 1
             data += 1
 

--- a/pandas/_libs/src/parser/pd_parser.c
+++ b/pandas/_libs/src/parser/pd_parser.c
@@ -51,11 +51,9 @@ static int floatify(PyObject *str, double *result, int *maybe_int) {
 
   if (!status) {
     /* handle inf/-inf infinity/-infinity */
-    const int sign = infinity_sign(data, length);
-    if (sign == 0) {
+    if (parse_special_float(data, length, result) != 0) {
       goto parsingerror;
     }
-    *result = sign > 0 ? HUGE_VAL : -HUGE_VAL;
     *maybe_int = 0;
   }
 

--- a/pandas/_libs/src/parser/tokenizer.cpp
+++ b/pandas/_libs/src/parser/tokenizer.cpp
@@ -1999,7 +1999,7 @@ int to_boolean(const char *item, int64_t length, uint8_t *val) {
   return -1;
 }
 
-int infinity_sign(const char *item, int64_t length) {
+int parse_special_float(const char *item, int64_t length, double *out) {
   int sign = 1;
 
   if (length > 0 && (*item == '+' || *item == '-')) {
@@ -2010,10 +2010,11 @@ int infinity_sign(const char *item, int64_t length) {
 
   if ((length == 3 && strncasecmp(item, "inf", 3) == 0) ||
       (length == 8 && strncasecmp(item, "infinity", 8) == 0)) {
-    return sign;
+    *out = sign > 0 ? HUGE_VAL : -HUGE_VAL;
+    return 0;
   }
 
-  return 0;
+  return -1;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Behavior-preserving refactor of the non-numeric float spelling path.

`infinity_sign` returned a *sign*, so every caller open-coded the sign-to-value step. Three of the four call sites carried their own copy of the same ladder:

```
inf_sign = infinity_sign(word, word_len)
if inf_sign > 0:
    data[0] = INF
elif inf_sign < 0:
    data[0] = NEGINF
else:
    return 1
```

Replaced with `parse_special_float(item, length, *out)`, which both recognizes the spelling and produces the value, returning 0 on a match like the neighbouring `to_boolean`. Used at all four sites: the three in `parsers.pyx` (`_probe_double`, and both branches of `_try_double_nogil`) and `floatify` in `pd_parser.c`. `INF`/`NEGINF` in `parsers.pyx` became dead and are gone.

Matching semantics are untouched: exactly `length` bytes examined, no NUL-termination assumed, case-insensitive, optional leading `+`/`-`. `"inf\x00xyz"` still raises (GH-66524). `try_parse_plain_double` is deliberately left alone — it rejects these spellings and defers to the full converter, which stays as is.

Worth noting the duplication here was narrower than it looks: `infinity_sign` was already the single recognizer, so adding a spelling only ever meant editing `tokenizer.cpp`. What this removes is the repeated sign-to-value mapping downstream of it, and the chance for the four sites to disagree about it. They did not disagree today — all three value-producing sites mapped `+1`/`-1` to `+inf`/`-inf` identically, and `_probe_double` only tested for a nonzero return.

Net -11 lines. No test changes: `pandas/tests/io/parser` and `pandas/tests/tools/test_to_numeric.py` pass untouched (5672 passed, 186 skipped, 115 xfailed), as does `pandas/tests/dtypes/test_inference.py`. Also verified with a `--werror` build, since the removed `cdef` globals would otherwise show up there.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the refactor and ran the parser/to_numeric suites and the --werror build to confirm it is behavior-preserving.