### PR TITLE
ENH: support plotting with numeric nullable data on x axis

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1560,9 +1560,9 @@ class Index(IndexOpsMixin, PandasObject):
 
     def _mpl_repr(self) -> np.ndarray:
         # how to represent ourselves to matplotlib
-        if isinstance(self.dtype, np.dtype) and self.dtype.kind != "M":
-            return cast("np.ndarray", self.values)
-        return self.astype(object, copy=False)._values  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
+        if isinstance(self.dtype, np.dtype) and self.dtype.kind == "M":
+            return self.astype(object, copy=False)._values  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
+        return np.asarray(self.values)
 
     _default_na_rep = "NaN"
 

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1569,7 +1569,10 @@ class Index(IndexOpsMixin, PandasObject):
         elif isinstance(self.dtype, ExtensionDtype):
             if self.dtype.kind == "O":
                 return self._values.to_numpy(na_value=None)
-            return self._values.to_numpy(na_value=np.nan)
+            if self.hasnans:
+                return self._values.to_numpy(na_value=np.nan)
+            else:
+                return self._values.to_numpy()
         return self._values
 
     _default_na_rep = "NaN"

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1562,7 +1562,15 @@ class Index(IndexOpsMixin, PandasObject):
         # how to represent ourselves to matplotlib
         if isinstance(self.dtype, np.dtype) and self.dtype.kind == "M":
             return self.astype(object, copy=False)._values  # type: ignore[return-value]  # pyright: ignore[reportReturnType]
-        return np.asarray(self.values)
+        elif self.dtype.kind in "mM":
+            # e.g. ArrowDtype - relying on default of NaT for those dtypes
+            # (explicitly specifying NaT raises an error)
+            return self._values.to_numpy()
+        elif isinstance(self.dtype, ExtensionDtype):
+            if self.dtype.kind == "O":
+                return self._values.to_numpy(na_value=None)
+            return self._values.to_numpy(na_value=np.nan)
+        return self._values
 
     _default_na_rep = "NaN"
 

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -668,9 +668,11 @@ class MPLPlot(ABC):
             return data
 
         # GH32073: cast to float if values contain nulled integers
-        if (is_integer_dtype(data.dtype) or is_float_dtype(data.dtype)) and isinstance(
-            data.dtype, ExtensionDtype
-        ):
+        if (
+            is_integer_dtype(data.dtype)
+            or is_float_dtype(data.dtype)
+            or is_bool_dtype(data.dtype)
+        ) and isinstance(data.dtype, ExtensionDtype):
             return data.to_numpy(dtype="float", na_value=np.nan)
 
         # GH25587: cast ExtensionArray of pandas (IntegerArray, etc.) to

--- a/pandas/tests/extension/base/plotting.py
+++ b/pandas/tests/extension/base/plotting.py
@@ -52,12 +52,12 @@ def _check_plot_data(
 
     from pandas.plotting._matplotlib.converter import pandas_converters
 
-    arr = ser.to_numpy()
-    if munits._is_natively_supported(arr) or is_bool_dtype(arr):
+    if munits._is_natively_supported(ser) or is_bool_dtype(ser.dtype):
         # Convert natively or boolean just to float
-        converted_data = arr.astype(np.float64)
+        converted_data = ser.to_numpy(np.float64, na_value=np.nan)
     else:
         # Need to get registered converter for non-natively
+        arr = ser.to_numpy()
         type_ = ser.dtype.type
         with pandas_converters():
             converter = munits.registry[type_]

--- a/pandas/tests/extension/base/plotting.py
+++ b/pandas/tests/extension/base/plotting.py
@@ -52,7 +52,11 @@ def _check_plot_data(
 
     from pandas.plotting._matplotlib.converter import pandas_converters
 
-    if munits._is_natively_supported(ser) or is_bool_dtype(ser.dtype):
+    if (
+        munits._is_natively_supported(ser)
+        or is_bool_dtype(ser.dtype)
+        or (isinstance(ser.dtype, pd.ArrowDtype) and ser.dtype.kind == "m")
+    ):
         # Convert natively or boolean just to float
         converted_data = ser.to_numpy(np.float64, na_value=np.nan)
     else:

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -1139,18 +1139,7 @@ class TestArrowArray(base.ExtensionTests):
 
         # Certain dtypes fail with NA values
         if plot_data["Data"].isna().any():
-            if (
-                pa.types.is_integer(pa_dtype)
-                or pa.types.is_floating(pa_dtype)
-                or pa.types.is_time(pa_dtype)
-            ):
-                err_cls = TypeError
-                err_msg = re.escape(
-                    "float() argument must be a string or a real number, not 'NAType'"
-                )
-            elif (
-                pa.types.is_timestamp(pa_dtype) and pa_dtype.tz is not None
-            ) or pa.types.is_decimal(pa_dtype):
+            if pa.types.is_timestamp(pa_dtype) and pa_dtype.tz is not None:
                 err_cls = TypeError
                 err_msg = re.escape("Failed to convert value(s) to axis units: array(")
 
@@ -1197,14 +1186,6 @@ class TestArrowArray(base.ExtensionTests):
                 err_cls = TypeError
                 err_msg = re.escape(
                     "Failed to convert value(s) to axis units: masked_array(data="
-                )
-            elif pa.types.is_duration(pa_dtype):
-                err_cls = AssertionError
-                err_msg = "numpy array are different"
-            elif pa.types.is_boolean(pa_dtype):
-                err_cls = TypeError
-                err_msg = re.escape(
-                    "float() argument must be a string or a real number, not 'NAType'"
                 )
 
         # Call test, errors and warnings should only be raised for unsupported dtypes

--- a/pandas/tests/extension/test_masked.py
+++ b/pandas/tests/extension/test_masked.py
@@ -14,8 +14,6 @@ be added to the array-specific tests in `pandas/tests/arrays/`.
 
 """
 
-import re
-
 import numpy as np
 import pytest
 
@@ -342,32 +340,6 @@ class TestMaskedArrays(base.ExtensionTests):
 
     def test_loc_setitem_with_expansion_preserves_ea_index_dtype(self, data, request):
         super().test_loc_setitem_with_expansion_preserves_ea_index_dtype(data)
-
-    def test_plot_on_x_axis(self, plot_data):
-        # All non boolean dtypes cannot be plotted on x-axis with missing values
-        if plot_data["Data"].isna().any() and plot_data["Data"].dtype.kind != "b":
-            with pytest.raises(
-                TypeError,
-                match=re.escape(
-                    "float() argument must be a string or a real number, not 'NAType'"
-                ),
-            ):
-                super().test_plot_on_x_axis(plot_data)
-        else:
-            super().test_plot_on_x_axis(plot_data)
-
-    def test_plot_on_y_axis(self, plot_data):
-        # Only boolean dtype cannot be plotted on y-axis with missing values
-        if plot_data["Data"].isna().any() and plot_data["Data"].dtype.kind == "b":
-            with pytest.raises(
-                TypeError,
-                match=re.escape(
-                    "float() argument must be a string or a real number, not 'NAType'"
-                ),
-            ):
-                super().test_plot_on_y_axis(plot_data)
-        else:
-            super().test_plot_on_y_axis(plot_data)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As a follow-up on https://github.com/pandas-dev/pandas/pull/64535, this fixes the issue of plotting with NAs on the x-axis (and for boolean with NAs on the y-axis), removing the error testing in the test_masked.py overrides