### PR TITLE
BUG: Categorical.map returns category dtype instead of bool when mapping non-bool categories to boolean values

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -462,6 +462,7 @@ Categorical
 ^^^^^^^^^^^
 - Bug in :meth:`Categorical.__repr__` where the values and categories lines could exceed ``display.width`` (:issue:`12066`)
 - Bug in :meth:`Categorical.map` and :meth:`Series.map` raising ``NotImplementedError`` when the mapper returned tuples for the categories, instead of returning an :class:`Index` of tuples (:issue:`51488`)
+- Bug in :meth:`Categorical.map` returning ``CategoricalDtype`` instead of ``bool`` when mapping non-boolean categories to boolean values with a single unique category (:issue:`61719`)
 - Bug in :meth:`Categorical.map` where mapping with a ``defaultdict`` and ``na_action=None`` would bypass the default factory by using ``dict.get``, causing ``NA`` values to be replaced with ``NaN`` instead of the mapper's default value (:issue:`62710`)
 - Bug in :meth:`CategoricalIndex.union` and :meth:`CategoricalIndex.intersection` giving incorrect results when the two indexes have the same unordered categories in different orders (:issue:`55335`)
 - Bug in :meth:`Index.fillna` raising ``TypeError`` when filling with a tuple value (e.g. on object-dtype or :class:`CategoricalIndex` with tuple categories) (:issue:`37681`)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1664,6 +1664,11 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
             and new_categories.is_unique
             and not new_categories.hasnans
             and na_val is np.nan
+            and not (
+                len(new_categories) == 1
+                and new_categories.dtype == np.dtype("bool")
+                and self.categories.dtype != np.dtype("bool")
+            )
         ):
             new_dtype = CategoricalDtype(new_categories, ordered=self.ordered)
             return self.from_codes(self._codes.copy(), dtype=new_dtype, validate=False)

--- a/pandas/tests/arrays/categorical/test_map.py
+++ b/pandas/tests/arrays/categorical/test_map.py
@@ -69,12 +69,12 @@ def test_map(na_action):
     (
         ([1, 1, np.nan], pd.isna, Index([False, False, True])),
         ([1, 2, np.nan], pd.isna, Index([False, False, True])),
-        ([1, 1, np.nan], {1: False}, Categorical([False, False, np.nan])),
+        ([1, 1, np.nan], {1: False}, Index([False, False, np.nan])),
         ([1, 2, np.nan], {1: False, 2: False}, Index([False, False, np.nan])),
         (
             [1, 1, np.nan],
             Series([False, False]),
-            Categorical([False, False, np.nan]),
+            Index([False, False, np.nan]),
         ),
         (
             [1, 2, np.nan],
@@ -95,14 +95,14 @@ def test_map_with_nan_none(data, f, expected):  # GH 24241
 @pytest.mark.parametrize(
     ("data", "f", "expected"),
     (
-        ([1, 1, np.nan], pd.isna, Categorical([False, False, np.nan])),
+        ([1, 1, np.nan], pd.isna, Index([False, False, np.nan])),
         ([1, 2, np.nan], pd.isna, Index([False, False, np.nan])),
-        ([1, 1, np.nan], {1: False}, Categorical([False, False, np.nan])),
+        ([1, 1, np.nan], {1: False}, Index([False, False, np.nan])),
         ([1, 2, np.nan], {1: False, 2: False}, Index([False, False, np.nan])),
         (
             [1, 1, np.nan],
             Series([False, False]),
-            Categorical([False, False, np.nan]),
+            Index([False, False, np.nan]),
         ),
         (
             [1, 2, np.nan],
@@ -114,7 +114,7 @@ def test_map_with_nan_none(data, f, expected):  # GH 24241
 def test_map_with_nan_ignore(data, f, expected):  # GH 24241
     values = Categorical(data)
     result = values.map(f, na_action="ignore")
-    if data[1] == 1:
+    if isinstance(expected, Categorical):
         tm.assert_categorical_equal(result, expected)
     else:
         tm.assert_index_equal(result, expected)
@@ -180,3 +180,42 @@ def test_map_to_multi_element_tuples(na_action):
     result = cat.map(mapper, na_action=na_action)
     expected = Index([("x", 1), ("y", 2)], tupleize_cols=False)
     tm.assert_index_equal(result, expected)
+
+
+def test_map_single_category_bool_result():
+    # GH#61719 - mapping a single-category Categorical to bool should
+    # return bool dtype, not category dtype
+    cat = Categorical(["a", "a"])
+    result = cat.map(lambda x: x == "c")
+    expected = Index([False, False])
+    tm.assert_index_equal(result, expected)
+    assert result.dtype == np.dtype("bool")
+
+
+def test_map_multiple_category_bool_result():
+    # GH#61719 - ensure multi-category case also returns bool dtype
+    cat = Categorical(["a", "b"])
+    result = cat.map(lambda x: x == "c")
+    expected = Index([False, False])
+    tm.assert_index_equal(result, expected)
+    assert result.dtype == np.dtype("bool")
+
+
+def test_map_bool_category_preserves_categorical():
+    # GH#61719 - mapping a bool-dtype Categorical should still preserve
+    # categorical when the mapping is one-to-one
+    cat = Categorical([True, False, True])
+    result = cat.map(lambda x: not x)
+    expected = Categorical(
+        [False, True, False], categories=[True, False], ordered=False
+    )
+    tm.assert_categorical_equal(result, expected)
+
+
+def test_map_ordered_categorical_to_bool_preserves_ordered():
+    # GH#61719 - mapping an ordered non-bool Categorical to bool with
+    # multiple unique categories should preserve Categorical and ordered
+    cat = Categorical(["a", "b"], ordered=True)
+    result = cat.map({"a": True, "b": False})
+    expected = Categorical([True, False], categories=[True, False], ordered=True)
+    tm.assert_categorical_equal(result, expected)

--- a/pandas/tests/indexes/categorical/test_map.py
+++ b/pandas/tests/indexes/categorical/test_map.py
@@ -80,14 +80,14 @@ def test_map_with_categorical_series():
 @pytest.mark.parametrize(
     ("data", "f", "expected"),
     (
-        ([1, 1, np.nan], pd.isna, CategoricalIndex([False, False, np.nan])),
+        ([1, 1, np.nan], pd.isna, Index([False, False, np.nan])),
         ([1, 2, np.nan], pd.isna, Index([False, False, np.nan])),
-        ([1, 1, np.nan], {1: False}, CategoricalIndex([False, False, np.nan])),
+        ([1, 1, np.nan], {1: False}, Index([False, False, np.nan])),
         ([1, 2, np.nan], {1: False, 2: False}, Index([False, False, np.nan])),
         (
             [1, 1, np.nan],
             Series([False, False]),
-            CategoricalIndex([False, False, np.nan]),
+            Index([False, False, np.nan]),
         ),
         (
             [1, 2, np.nan],
@@ -107,12 +107,12 @@ def test_map_with_nan_ignore(data, f, expected):  # GH 24241
     (
         ([1, 1, np.nan], pd.isna, Index([False, False, True])),
         ([1, 2, np.nan], pd.isna, Index([False, False, True])),
-        ([1, 1, np.nan], {1: False}, CategoricalIndex([False, False, np.nan])),
+        ([1, 1, np.nan], {1: False}, Index([False, False, np.nan])),
         ([1, 2, np.nan], {1: False, 2: False}, Index([False, False, np.nan])),
         (
             [1, 1, np.nan],
             Series([False, False]),
-            CategoricalIndex([False, False, np.nan]),
+            Index([False, False, np.nan]),
         ),
         (
             [1, 2, np.nan],


### PR DESCRIPTION
- [x] closes #61719
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#test-driven-development)
- [x] All [CI checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_environment.html#running-the-test-suite)
- [x] Added entry in `doc/source/whatsnew/v3.1.0.rst`

## Description

When mapping a `Categorical` with non-boolean categories to boolean values via `.map()`, the result incorrectly preserves `CategoricalDtype` when the mapped categories happen to be unique (e.g., single-category input). This produces inconsistent behavior depending on the number of input categories:

```python
# Single category: returns category (BUG)
pd.Series(["a", "a"]).astype("category").map(lambda x: x == "c")
# dtype: category, Categories (1, bool): [False]

# Two categories: returns bool (CORRECT)
pd.Series(["a", "b"]).astype("category").map(lambda x: x == "c")
# dtype: bool
```

## Fix

Added a condition to the categorical fast-path in `Categorical.map` that prevents preserving `CategoricalDtype` when the mapped categories have `bool` dtype but the original categories do not. This ensures boolean-valued map results consistently return `bool` dtype regardless of the number of input categories.

Boolean categoricals mapped to bool (e.g., `Categorical([True, False]).map(lambda x: not x)`) still correctly preserve categorical dtype since the original categories are already boolean.