### PR TITLE
CI: Assign and unassign issues on edit

### DIFF
--- a/.github/workflows/comment-commands.yml
+++ b/.github/workflows/comment-commands.yml
@@ -1,7 +1,7 @@
 name: Comment Commands
 on:
   issue_comment:
-    types: created
+    types: [created, edited]
 
 permissions: {}
 


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/pandas/issues/46377#issuecomment-5433221087

The contributor edited from `take` to `/take` but was not assigned because we didn't have that as a trigger. Note this impacts all our comment commands, which seems desirable.