### PR TITLE
CI: check for current-time values in tests (GH#44341)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -207,30 +207,15 @@ repos:
         files: ^pandas/tests/
         types_or: [python, cython, rst]
     -   id: current-time-in-tests
-        name: Check for current-time values in tests
+        name: Check for current-time strings in tests
         description: >
-            Tests that build data from the current time are time dependent and have
-            broken CI in the past, e.g. at a DST transition (GH#44341). Use a fixed
-            datetime instead. Files that test these constructions themselves are
-            excluded.
+            Current-time test data broke CI at a DST transition (GH#44341). Use a
+            fixed datetime, or append "# current-time-ok" if the test exercises this
+            construction itself. Attribute spellings like Timestamp.now() are banned
+            in pyproject.toml.
         language: pygrep
-        entry: |
-            (?x)
-            # datetime.now(), Timestamp.today(), Timestamp.utcnow(), ...
-            \.(now|today|utcnow)\(
-
-            # Timestamp("now"), date_range("today"), np.datetime64("now"), ...
-            |(date_range|datetime64|period_range|Period|Timestamp|to_datetime)\(
-             \s*\[?"(now|today)"
+        entry: '^(?!.*# current-time-ok).*(date_range|datetime64|period_range|Period|Timestamp|to_datetime)\(\s*\[?"(now|today)"'
         files: ^pandas/tests/
-        exclude: |
-            (?x)
-            ^pandas/tests/indexes/datetimes/test_constructors\.py$
-            |^pandas/tests/scalar/period/test_period\.py$
-            |^pandas/tests/scalar/timestamp/test_constructors\.py$
-            |^pandas/tests/scalar/timestamp/test_timestamp\.py$
-            |^pandas/tests/tools/test_to_datetime\.py$
-            |^pandas/tests/tslibs/test_strptime\.py$
         types_or: [python, cython, rst]
     -   id: unwanted-patterns-in-cython
         name: Unwanted patterns in Cython code

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -206,6 +206,32 @@ repos:
             |default_rng\(\)
         files: ^pandas/tests/
         types_or: [python, cython, rst]
+    -   id: current-time-in-tests
+        name: Check for current-time values in tests
+        description: >
+            Tests that build data from the current time are time dependent and have
+            broken CI in the past, e.g. at a DST transition (GH#44341). Use a fixed
+            datetime instead. Files that test these constructions themselves are
+            excluded.
+        language: pygrep
+        entry: |
+            (?x)
+            # datetime.now(), Timestamp.today(), Timestamp.utcnow(), ...
+            \.(now|today|utcnow)\(
+
+            # Timestamp("now"), date_range("today"), np.datetime64("now"), ...
+            |(date_range|datetime64|period_range|Period|Timestamp|to_datetime)\(
+             \s*\[?"(now|today)"
+        files: ^pandas/tests/
+        exclude: |
+            (?x)
+            ^pandas/tests/indexes/datetimes/test_constructors\.py$
+            |^pandas/tests/scalar/period/test_period\.py$
+            |^pandas/tests/scalar/timestamp/test_constructors\.py$
+            |^pandas/tests/scalar/timestamp/test_timestamp\.py$
+            |^pandas/tests/tools/test_to_datetime\.py$
+            |^pandas/tests/tslibs/test_strptime\.py$
+        types_or: [python, cython, rst]
     -   id: unwanted-patterns-in-cython
         name: Unwanted patterns in Cython code
         language: pygrep

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -464,7 +464,7 @@ master_doc = "index"
 # General information about the project.
 project = "pandas"
 # We have our custom "pandas_footer.html" template, using copyright for the current year
-copyright = f"{datetime.now().year},"
+copyright = f"{datetime.now().year},"  # noqa: TID251
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/pandas/io/stata.py
+++ b/pandas/io/stata.py
@@ -3007,7 +3007,7 @@ supported types."""
         # time stamp, 18 bytes, char, null terminated
         # format dd Mon yyyy hh:mm
         if time_stamp is None:
-            time_stamp = datetime.now()
+            time_stamp = datetime.now()  # noqa: TID251
         elif not isinstance(time_stamp, datetime):
             raise ValueError("time_stamp should be datetime type")
         # GH #13856
@@ -3551,7 +3551,7 @@ class StataWriter117(StataWriter):
         # time stamp, 18 bytes, char, null terminated
         # format dd Mon yyyy hh:mm
         if time_stamp is None:
-            time_stamp = datetime.now()
+            time_stamp = datetime.now()  # noqa: TID251
         elif not isinstance(time_stamp, datetime):
             raise ValueError("time_stamp should be datetime type")
         # Avoid locale-specific month conversion

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -113,9 +113,9 @@ class TestTimedelta64ArrayLikeComparisons:
             345600000000000,
             "a",
             Timestamp("2021-01-01"),
-            Timestamp("2021-01-01").now("UTC"),
-            Timestamp("2021-01-01").now().to_datetime64(),
-            Timestamp("2021-01-01").now().to_pydatetime(),
+            Timestamp("2021-01-01", tz="UTC"),
+            Timestamp("2021-01-01").to_datetime64(),
+            Timestamp("2021-01-01").to_pydatetime(),
             Timestamp("2021-01-01").date(),
             np.array(4),  # zero-dim mismatched dtype
         ],

--- a/pandas/tests/arrays/categorical/test_constructors.py
+++ b/pandas/tests/arrays/categorical/test_constructors.py
@@ -114,7 +114,7 @@ class TestCategoricalConstructors:
 
     def test_constructor_unsortable(self):
         # it works!
-        arr = np.array([1, 2, 3, datetime.now()], dtype="O")
+        arr = np.array([1, 2, 3, datetime(2011, 1, 1)], dtype="O")
         factor = Categorical(arr, ordered=False)
         assert not factor.ordered
 
@@ -366,7 +366,7 @@ class TestCategoricalConstructors:
 
     def test_constructor_date_objects(self):
         # we dont cast date objects to timestamps, matching Index constructor
-        v = date.today()
+        v = date(2011, 1, 1)
 
         cat = Categorical([v, v])
         assert cat.categories.dtype == object

--- a/pandas/tests/dtypes/cast/test_promote.py
+++ b/pandas/tests/dtypes/cast/test_promote.py
@@ -335,10 +335,10 @@ def test_maybe_promote_datetime64_with_any(datetime64_dtype, any_numpy_dtype):
 @pytest.mark.parametrize(
     "fill_value",
     [
-        pd.Timestamp("now"),
-        np.datetime64("now"),
-        datetime.datetime.now(),
-        datetime.date.today(),
+        pd.Timestamp("2011-01-01"),
+        np.datetime64("2011-01-01"),
+        datetime.datetime(2011, 1, 1),
+        datetime.date(2011, 1, 1),
     ],
     ids=["pd.Timestamp", "np.datetime64", "datetime.datetime", "datetime.date"],
 )

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -995,7 +995,7 @@ class TestInference:
         tm.assert_numpy_array_equal(out, expected)
 
     def test_maybe_convert_objects_mixed_datetimes(self):
-        ts = Timestamp("now")
+        ts = Timestamp("2011-01-01 09:42:00.123456")
         vals = [ts, ts.to_pydatetime(), ts.to_datetime64(), pd.NaT, np.nan, None]
 
         for data in itertools.permutations(vals):

--- a/pandas/tests/dtypes/test_missing.py
+++ b/pandas/tests/dtypes/test_missing.py
@@ -170,8 +170,8 @@ class TestIsNA:
         tm.assert_numpy_array_equal(result, expected)
 
     def test_isna_datetime(self):
-        assert not isna(datetime.now())
-        assert notna(datetime.now())
+        assert not isna(datetime(2011, 1, 1))
+        assert notna(datetime(2011, 1, 1))
 
         idx = date_range("1/1/1990", periods=20)
         exp = np.ones(len(idx), dtype=bool)

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -431,8 +431,8 @@ class TestDataFrameIndexing:
         df["A"] = "beginning"
         df["E"] = "foo"
         df["D"] = "bar"
-        df[datetime.now()] = "date"
-        df[datetime.now()] = 5.0
+        df[datetime(2011, 1, 1)] = "date"
+        df[datetime(2011, 1, 2)] = 5.0
 
         # what to do when empty frame with index
         dm = DataFrame(index=float_frame.index)

--- a/pandas/tests/frame/methods/test_rank.py
+++ b/pandas/tests/frame/methods/test_rank.py
@@ -128,7 +128,7 @@ class TestRank:
         tm.assert_frame_equal(result, expected)
 
     def test_rank_mixed_frame(self, float_string_frame):
-        float_string_frame["datetime"] = datetime.now()
+        float_string_frame["datetime"] = datetime(2011, 1, 1)
         float_string_frame["timedelta"] = timedelta(days=1, seconds=1)
 
         float_string_frame.rank(numeric_only=False)

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -138,7 +138,7 @@ class TestSelectDtypes:
                 "c": np.arange(3, 6, dtype="u1"),
                 "d": np.arange(4.0, 7.0, dtype="float64"),
                 "e": [True, False, True],
-                "f": pd.date_range("now", periods=3).values,
+                "f": pd.date_range("2011-01-01", periods=3).values,
             }
         )
         exclude = (np.datetime64,)
@@ -165,7 +165,7 @@ class TestSelectDtypes:
                 "c": np.arange(3, 6, dtype="int32"),
                 "d": np.arange(4.0, 7.0, dtype="float64"),
                 "e": [True, False, True],
-                "f": pd.date_range("now", periods=3).values,
+                "f": pd.date_range("2011-01-01", periods=3).values,
             }
         )
         exclude = (np.datetime64,)
@@ -297,7 +297,7 @@ class TestSelectDtypes:
                 "c": np.arange(3, 6).astype("u1"),
                 "d": np.arange(4.0, 7.0, dtype="float64"),
                 "e": [True, False, True],
-                "f": pd.date_range("now", periods=3).values,
+                "f": pd.date_range("2011-01-01", periods=3).values,
             }
         )
         df.columns = ["a", "a", "b", "b", "b", "c"]
@@ -317,7 +317,7 @@ class TestSelectDtypes:
                 "c": np.arange(3, 6).astype("u1"),
                 "d": np.arange(4.0, 7.0, dtype="float64"),
                 "e": [True, False, True],
-                "f": pd.date_range("now", periods=3).values,
+                "f": pd.date_range("2011-01-01", periods=3).values,
             }
         )
         df["g"] = df.f.diff()
@@ -351,7 +351,7 @@ class TestSelectDtypes:
                 "c": np.arange(3, 6).astype("u1"),
                 "d": np.arange(4.0, 7.0, dtype="float64"),
                 "e": [True, False, True],
-                "f": pd.date_range("now", periods=3).values,
+                "f": pd.date_range("2011-01-01", periods=3).values,
             }
         )
         # units that pandas cannot represent are rejected; only 's', 'ms',
@@ -439,7 +439,7 @@ class TestSelectDtypes:
                 "c": np.arange(3, 6).astype("u1"),
                 "d": np.arange(4.0, 7.0, dtype="float64"),
                 "e": [True, False, True],
-                "f": pd.date_range("now", periods=3).values,
+                "f": pd.date_range("2011-01-01", periods=3).values,
             }
         )
         msg = "string dtypes are not allowed"
@@ -457,7 +457,7 @@ class TestSelectDtypes:
                 "c": np.arange(3, 6).astype("u1"),
                 "d": np.arange(4.0, 7.0, dtype="float64"),
                 "e": [True, False, True],
-                "f": pd.date_range("now", periods=3).values,
+                "f": pd.date_range("2011-01-01", periods=3).values,
             }
         )
 

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -436,7 +436,7 @@ class TestFrameFlexComparisons:
     def test_bool_flex_frame_object_dtype(self):
         # corner, dtype=object
         df1 = DataFrame({"col": ["foo", np.nan, "bar"]}, dtype=object)
-        df2 = DataFrame({"col": ["foo", datetime.now(), "bar"]}, dtype=object)
+        df2 = DataFrame({"col": ["foo", datetime(2011, 1, 1), "bar"]}, dtype=object)
         result = df1.ne(df2)
         exp = DataFrame({"col": [False, True, False]})
         tm.assert_frame_equal(result, exp)

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -164,7 +164,7 @@ class TestDataFrameBlockInternals:
 
     def test_construction_with_mixed(self, float_string_frame, using_infer_string):
         # mixed-type frames
-        float_string_frame["datetime"] = datetime.now()
+        float_string_frame["datetime"] = datetime(2011, 1, 1)
         float_string_frame["timedelta"] = timedelta(days=1, seconds=1)
         assert float_string_frame["datetime"].dtype == "M8[us]"
         assert float_string_frame["timedelta"].dtype == "m8[us]"

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -125,7 +125,7 @@ class TestDataFrameConstructors:
             Series(arr[0], dtype="i8", name=0)
 
     def test_construct_from_list_of_datetimes(self):
-        df = DataFrame([datetime.now(), datetime.now()])
+        df = DataFrame([datetime(2011, 1, 1), datetime(2011, 1, 2)])
         assert df[0].dtype == np.dtype("M8[us]")
 
     def test_constructor_from_tzaware_datetimeindex(self):
@@ -2064,8 +2064,8 @@ class TestDataFrameConstructors:
     @pytest.mark.parametrize(
         "arr",
         [
-            np.array([None, None, None, None, datetime.now(), None]),
-            np.array([None, None, datetime.now(), None]),
+            np.array([None, None, None, None, datetime(2011, 1, 1), None]),
+            np.array([None, None, datetime(2011, 1, 1), None]),
             [[np.datetime64("NaT", "ns")], [None]],
             [[np.datetime64("NaT", "ns")], [pd.NaT]],
             [[None], [np.datetime64("NaT", "ns")]],
@@ -2550,7 +2550,7 @@ class TestDataFrameConstructors:
 
     def test_datetime_date_tuple_columns_from_dict(self):
         # GH 10863
-        v = date.today()
+        v = date(2011, 1, 1)
         tup = v, v
         result = DataFrame({tup: Series(range(3), index=range(3))}, columns=[tup])
         expected = DataFrame([0, 1, 2], columns=Index(Series([tup])))

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1698,7 +1698,7 @@ class TestDataFrameQueryBacktickQuoting:
 
     def test_all_nat_in_object(self):
         # GH#57068
-        now = pd.Timestamp.now("UTC")  # noqa: F841
+        now = pd.Timestamp("2011-01-01", tz="UTC")  # noqa: F841
         df = DataFrame({"a": pd.to_datetime([None, None], utc=True)}, dtype=object)
         result = df.query("a > @now")
         expected = DataFrame({"a": []}, dtype=object)

--- a/pandas/tests/frame/test_repr.py
+++ b/pandas/tests/frame/test_repr.py
@@ -204,9 +204,9 @@ NaT   4"""
         unsortable = DataFrame(
             {
                 "foo": [1] * 50,
-                datetime.today(): [1] * 50,
+                datetime(2011, 1, 1): [1] * 50,
                 "bar": ["bar"] * 50,
-                datetime.today() + timedelta(1): ["bar"] * 50,
+                datetime(2011, 1, 1) + timedelta(1): ["bar"] * 50,
             },
             index=np.arange(50),
         )

--- a/pandas/tests/groupby/aggregate/test_cython.py
+++ b/pandas/tests/groupby/aggregate/test_cython.py
@@ -114,7 +114,7 @@ def test_cython_agg_nothing_to_agg_with_dates():
         {
             "a": np.random.default_rng(2).integers(0, 5, 50),
             "b": ["foo", "bar"] * 25,
-            "dates": pd.date_range("now", periods=50, freq="min"),
+            "dates": pd.date_range("2011-01-01", periods=50, freq="min"),
         }
     )
     msg = "Cannot use numeric_only=True with SeriesGroupBy.mean and non-numeric dtypes"

--- a/pandas/tests/groupby/methods/test_groupby_shift_diff.py
+++ b/pandas/tests/groupby/methods/test_groupby_shift_diff.py
@@ -63,7 +63,7 @@ def test_group_shift_with_fill_value():
 
 def test_group_shift_lose_timezone():
     # GH 30134
-    now_dt = Timestamp.now("UTC").as_unit("ns")
+    now_dt = Timestamp("2011-01-01", tz="UTC").as_unit("ns")
     df = DataFrame({"a": [1, 1], "date": now_dt})
     result = df.groupby("a").shift(0).iloc[0]
     expected = Series({"date": now_dt}, name=result.name)

--- a/pandas/tests/groupby/test_apply.py
+++ b/pandas/tests/groupby/test_apply.py
@@ -1,6 +1,7 @@
 from datetime import (
     date,
     datetime,
+    time,
 )
 
 import numpy as np
@@ -734,7 +735,7 @@ def test_time_field_bug():
     # that were not returned by the apply function, an exception would be
     # raised.
 
-    df = DataFrame({"a": 1, "b": [datetime.now() for nn in range(10)]})
+    df = DataFrame({"a": 1, "b": [datetime(2011, 1, 1)] * 10})
 
     def func_with_no_date(batch):
         return Series({"c": 2})
@@ -862,7 +863,7 @@ def test_func_returns_object():
 
 @pytest.mark.parametrize(
     "group_column_dtlike",
-    [datetime.today(), datetime.today().date(), datetime.today().time()],
+    [datetime(2011, 1, 1, 9), date(2011, 1, 1), time(9, 0)],
 )
 def test_apply_datetime_issue(group_column_dtlike):
     # GH-28247

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -688,7 +688,7 @@ def test_raises_on_nuisance(df, using_infer_string):
         grouped.mean()
 
     df = df.loc[:, ["A", "C", "D"]]
-    df["E"] = datetime.now()
+    df["E"] = datetime(2011, 1, 1)
     grouped = df.groupby("A")
     msg = "datetime64 type does not support operation 'sum'"
     with pytest.raises(TypeError, match=msg):
@@ -1682,7 +1682,9 @@ def test_pivot_table_values_key_error():
     # This test is designed to replicate the error in issue #14938
     df = DataFrame(
         {
-            "eventDate": date_range(datetime.today(), periods=20, freq="ME").tolist(),
+            "eventDate": date_range(
+                datetime(2011, 1, 1), periods=20, freq="ME"
+            ).tolist(),
             "thename": range(20),
         }
     )
@@ -2104,7 +2106,7 @@ def test_group_on_empty_multiindex(transformation_func, request):
     # GH 47787
     # With one row, those are transforms so the schema should be the same
     df = DataFrame(
-        data=[[1, Timestamp("today"), 3, 4]],
+        data=[[1, Timestamp("2011-01-01"), 3, 4]],
         columns=["col_1", "col_2", "col_3", "col_4"],
     )
     df["col_3"] = df["col_3"].astype(int)

--- a/pandas/tests/groupby/test_grouping.py
+++ b/pandas/tests/groupby/test_grouping.py
@@ -202,8 +202,8 @@ class TestGrouping:
     def test_grouper_multilevel_freq(self):
         # GH 7885
         # with level and freq specified in a Grouper
-        d0 = date.today() - timedelta(days=14)
-        dates = date_range(d0, date.today())
+        d0 = date(2011, 1, 1)
+        dates = date_range(d0, d0 + timedelta(days=14))
         date_index = MultiIndex.from_product([dates, dates], names=["foo", "bar"])
         df = DataFrame(np.random.default_rng(2).integers(0, 100, 225), index=date_index)
 

--- a/pandas/tests/groupby/test_timegrouper.py
+++ b/pandas/tests/groupby/test_timegrouper.py
@@ -773,15 +773,18 @@ class TestGroupBy:
         # see gh-11682: Timezone info lost when broadcasting
         # scalar datetime to DataFrame
         utc = UTC
-        df = DataFrame({"a": [1], "b": [datetime.now(utc)]})
+        df = DataFrame({"a": [1], "b": [datetime(2011, 1, 1, tzinfo=utc)]})
         assert df["b"][0].tzinfo == utc
         df = DataFrame({"a": [1, 2, 3]})
-        df["b"] = datetime.now(utc)
+        df["b"] = datetime(2011, 1, 1, tzinfo=utc)
         assert df["b"][0].tzinfo == utc
 
     def test_datetime_count(self):
         df = DataFrame(
-            {"a": [1, 2, 3] * 2, "dates": date_range("now", periods=6, freq="min")}
+            {
+                "a": [1, 2, 3] * 2,
+                "dates": date_range("2011-01-01", periods=6, freq="min"),
+            }
         )
         result = df.groupby("a").dates.count()
         expected = Series([2, 2, 2], index=Index([1, 2, 3], name="a"), name="dates")

--- a/pandas/tests/groupby/transform/test_transform.py
+++ b/pandas/tests/groupby/transform/test_transform.py
@@ -1100,7 +1100,7 @@ def test_groupby_transform_rename():
 @pytest.mark.parametrize("func", [min, max, np.min, np.max, "first", "last"])
 def test_groupby_transform_timezone_column(func):
     # GH 24198
-    ts = pd.to_datetime("now", utc=True).tz_convert("Asia/Singapore")
+    ts = Timestamp("2011-01-01", tz="UTC").tz_convert("Asia/Singapore")
     result = DataFrame({"end_time": [ts], "id": [1]})
     result["max_end_time"] = result.groupby("id").end_time.transform(func)
     expected = DataFrame([[ts, 1, ts]], columns=["end_time", "id", "max_end_time"])

--- a/pandas/tests/indexes/categorical/test_astype.py
+++ b/pandas/tests/indexes/categorical/test_astype.py
@@ -81,7 +81,7 @@ class TestAstype:
     @pytest.mark.parametrize("box", [True, False])
     def test_categorical_date_roundtrip(self, box):
         # astype to categorical and back should preserve date objects
-        v = date.today()
+        v = date(2011, 1, 1)
 
         obj = Index([v, v])
         assert obj.dtype == object

--- a/pandas/tests/indexes/datetimes/test_constructors.py
+++ b/pandas/tests/indexes/datetimes/test_constructors.py
@@ -1034,10 +1034,10 @@ class TestDatetimeIndex:
 
     def test_dti_constructor_with_non_nano_now_today(self):
         # GH#55756, GH#57535
-        now = Timestamp.now()
-        today = Timestamp.today()
+        now = Timestamp.now()  # noqa: TID251
+        today = Timestamp.today()  # noqa: TID251
         result = DatetimeIndex(["now", "today"], dtype="M8[s]")
-        now_after = Timestamp.now()
+        now_after = Timestamp.now()  # noqa: TID251
         assert result.dtype == "M8[s]"
 
         # result should be between the before/after timestamps

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -281,7 +281,7 @@ class TestDateRanges:
         assert len(rng) == 4
 
     def test_date_range_normalize(self):
-        snap = datetime.today()
+        snap = datetime(2011, 1, 1)
         n = 50
 
         rng = date_range(snap, periods=n, normalize=False, freq="2D")

--- a/pandas/tests/indexes/multi/test_constructors.py
+++ b/pandas/tests/indexes/multi/test_constructors.py
@@ -813,9 +813,9 @@ def test_datetimeindex():
 
     # from datetime combos
     # GH 7888
-    date1 = np.datetime64("today")
-    date2 = datetime.today()
-    date3 = Timestamp.today()
+    date1 = np.datetime64("2011-01-01")
+    date2 = datetime(2011, 1, 1)
+    date3 = Timestamp("2011-01-01")
 
     for d1, d2 in itertools.product([date1, date2, date3], [date1, date2, date3]):
         index = MultiIndex.from_product([[d1], [d2]])
@@ -823,7 +823,7 @@ def test_datetimeindex():
         assert isinstance(index.levels[1], pd.DatetimeIndex)
 
     # but NOT date objects, matching Index behavior
-    date4 = date.today()
+    date4 = date(2011, 1, 1)
     index = MultiIndex.from_product([[date4], [date2]])
     assert not isinstance(index.levels[0], pd.DatetimeIndex)
     assert isinstance(index.levels[1], pd.DatetimeIndex)
@@ -853,7 +853,7 @@ def test_constructor_with_tz():
 def test_multiindex_inference_consistency():
     # check that inference behavior matches the base class
 
-    v = date.today()
+    v = date(2011, 1, 1)
 
     arr = [v, v]
 

--- a/pandas/tests/indexes/numeric/test_setops.py
+++ b/pandas/tests/indexes/numeric/test_setops.py
@@ -27,7 +27,9 @@ class TestSetOps:
         index = Index(np.arange(5, dtype=dtype), dtype=dtype)
         assert index.dtype == dtype
 
-        other = Index([datetime.now() + timedelta(i) for i in range(4)], dtype=object)
+        other = Index(
+            [datetime(2011, 1, 1) + timedelta(i) for i in range(4)], dtype=object
+        )
         result = index.union(other)
         expected = Index(np.concatenate((index, other)))
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/ranges/test_setops.py
+++ b/pandas/tests/indexes/ranges/test_setops.py
@@ -134,7 +134,9 @@ class TestRangeIndexSetOps:
     def test_union_noncomparable(self, sort):
         # corner case, Index with non-int64 dtype
         index = RangeIndex(start=0, stop=20, step=2)
-        other = Index([datetime.now() + timedelta(i) for i in range(4)], dtype=object)
+        other = Index(
+            [datetime(2011, 1, 1) + timedelta(i) for i in range(4)], dtype=object
+        )
         result = index.union(other, sort=sort)
         expected = Index(np.concatenate((index, other)))
         tm.assert_index_equal(result, expected)

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -837,7 +837,7 @@ class TestIndex:
         ],
     )
     def test_is_monotonic_incomparable(self, attr):
-        index = Index([5, datetime.now(), 7])
+        index = Index([5, datetime(2011, 1, 1), 7])
         assert not getattr(index, attr)
 
     @pytest.mark.parametrize("values", [["foo", "bar", "quux"], {"foo", "bar", "quux"}])

--- a/pandas/tests/indexes/test_index_new.py
+++ b/pandas/tests/indexes/test_index_new.py
@@ -174,7 +174,7 @@ class TestIndexConstructorInference:
 
     @pytest.mark.parametrize("swap_objs", [True, False])
     def test_constructor_datetime_and_datetime64(self, swap_objs):
-        data = [Timestamp(2021, 6, 8, 9, 42), np.datetime64("now")]
+        data = [Timestamp(2021, 6, 8, 9, 42), np.datetime64("2011-01-01T09:42:00", "s")]
         if swap_objs:
             data = data[::-1]
         expected = DatetimeIndex(data)

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -598,25 +598,25 @@ def test_index_types(temp_h5_path):
     ser = Series(values, [0, "y"])
     _check_roundtrip(ser, func, path=temp_h5_path)
 
-    ser = Series(values, [datetime.datetime.today(), 0])
+    ser = Series(values, [datetime.datetime(2011, 1, 1), 0])
     _check_roundtrip(ser, func, path=temp_h5_path)
 
     ser = Series(values, ["y", 0])
     _check_roundtrip(ser, func, path=temp_h5_path)
 
-    ser = Series(values, [datetime.date.today(), "a"])
+    ser = Series(values, [datetime.date(2011, 1, 1), "a"])
     _check_roundtrip(ser, func, path=temp_h5_path)
 
     ser = Series(values, [0, "y"])
     _check_roundtrip(ser, func, path=temp_h5_path)
 
-    ser = Series(values, [datetime.datetime.today(), 0])
+    ser = Series(values, [datetime.datetime(2011, 1, 1), 0])
     _check_roundtrip(ser, func, path=temp_h5_path)
 
     ser = Series(values, ["y", 0])
     _check_roundtrip(ser, func, path=temp_h5_path)
 
-    ser = Series(values, [datetime.date.today(), "a"])
+    ser = Series(values, [datetime.date(2011, 1, 1), "a"])
     _check_roundtrip(ser, func, path=temp_h5_path)
 
     ser = Series(values, [1.23, "b"])

--- a/pandas/tests/io/test_parquet.py
+++ b/pandas/tests/io/test_parquet.py
@@ -143,9 +143,9 @@ def df_full():
 
 @pytest.fixture(
     params=[
-        datetime.datetime.now(datetime.UTC),
-        datetime.datetime.now(datetime.timezone.min),
-        datetime.datetime.now(datetime.timezone.max),
+        datetime.datetime(2019, 1, 4, 16, 41, 24, tzinfo=datetime.UTC),
+        datetime.datetime(2019, 1, 4, 16, 41, 24, tzinfo=datetime.timezone.min),
+        datetime.datetime(2019, 1, 4, 16, 41, 24, tzinfo=datetime.timezone.max),
         datetime.datetime.strptime("2019-01-04T16:41:24+0200", "%Y-%m-%dT%H:%M:%S%z"),
         datetime.datetime.strptime("2019-01-04T16:41:24+0215", "%Y-%m-%dT%H:%M:%S%z"),
         datetime.datetime.strptime("2019-01-04T16:41:24-0200", "%Y-%m-%dT%H:%M:%S%z"),

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -356,7 +356,7 @@ class TestMerge:
         tm.assert_series_equal(merged["key_0"], Series(key, name="key_0"))
 
     def test_no_overlap_more_informative_error(self):
-        dt = datetime.now()
+        dt = datetime(2011, 1, 1)
         df1 = DataFrame({"x": ["a"]}, index=[dt])
 
         df2 = DataFrame({"y": ["b", "c"]}, index=[dt, dt])

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -100,16 +100,16 @@ class TestPeriodConstruction:
         i4 = Period("2005", freq="M")
         assert i1 != i4
 
-        i1 = Period.now(freq="Q")
-        i2 = Period(datetime.now(), freq="Q")
+        i1 = Period.now(freq="Q")  # noqa: TID251
+        i2 = Period(datetime.now(), freq="Q")  # noqa: TID251
 
         assert i1 == i2
 
         # Pass in freq as a keyword argument sometimes as a test for
         # https://github.com/pandas-dev/pandas/issues/53369
-        i1 = Period.now(freq="D")
-        i2 = Period(datetime.now(), freq="D")
-        i3 = Period.now(offsets.Day())
+        i1 = Period.now(freq="D")  # noqa: TID251
+        i2 = Period(datetime.now(), freq="D")  # noqa: TID251
+        i3 = Period.now(offsets.Day())  # noqa: TID251
 
         assert i1 == i2
         assert i1 == i3

--- a/pandas/tests/scalar/period/test_period.py
+++ b/pandas/tests/scalar/period/test_period.py
@@ -384,9 +384,9 @@ class TestPeriodConstruction:
     def test_invalid_arguments(self):
         msg = "Must supply freq for datetime value"
         with pytest.raises(ValueError, match=msg):
-            Period(datetime.now())
+            Period(datetime(2011, 1, 1))
         with pytest.raises(ValueError, match=msg):
-            Period(datetime.now().date())
+            Period(date(2011, 1, 1))
 
         msg = "Value must be Period, string, integer, or datetime"
         with pytest.raises(ValueError, match=msg):

--- a/pandas/tests/scalar/timestamp/test_arithmetic.py
+++ b/pandas/tests/scalar/timestamp/test_arithmetic.py
@@ -233,7 +233,7 @@ class TestTimestampArithmetic:
         ],
     )
     def test_timestamp_add_timedelta64_unit(self, other, expected_difference):
-        now = datetime.now(UTC)
+        now = datetime(2011, 1, 1, tzinfo=UTC)
         ts = Timestamp(now).as_unit("ns")
         result = ts + other
         valdiff = result._value - ts._value

--- a/pandas/tests/scalar/timestamp/test_comparisons.py
+++ b/pandas/tests/scalar/timestamp/test_comparisons.py
@@ -206,7 +206,7 @@ class TestTimestampComparison:
     def test_timestamp_compare_scalars(self):
         # case where ndim == 0
         lhs = np.datetime64(datetime(2013, 12, 6))
-        rhs = Timestamp("now")
+        rhs = Timestamp("2011-01-01 09:42:00.123456")
         nat = Timestamp("nat")
 
         ops = {"gt": "lt", "lt": "gt", "ge": "le", "le": "ge", "eq": "eq", "ne": "ne"}

--- a/pandas/tests/scalar/timestamp/test_constructors.py
+++ b/pandas/tests/scalar/timestamp/test_constructors.py
@@ -608,7 +608,7 @@ class TestTimestampClassMethodConstructors:
         # GH#56680
         msg = "Timestamp.utcnow is deprecated"
         with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            Timestamp.utcnow()
+            Timestamp.utcnow()  # noqa: TID251
 
     def test_utcfromtimestamp_deprecated(self):
         # GH#56680
@@ -663,7 +663,7 @@ class TestTimestampClassMethodConstructors:
 
     def test_constructor_fromisoformat_roundtrip_isoformat(self):
         # GH#56398 fromisoformat(ts.isoformat()) should round-trip
-        original = Timestamp.now("UTC")
+        original = Timestamp.now("UTC")  # noqa: TID251
         result = Timestamp.fromisoformat(original.isoformat())
         assert result == original
         assert result.tzinfo is not None
@@ -692,12 +692,12 @@ class TestTimestampClassMethodConstructors:
 
     def test_now(self):
         # GH#9000
-        ts_from_string = Timestamp("now")
-        ts_from_method = Timestamp.now()
-        ts_datetime = datetime.now()
+        ts_from_string = Timestamp("now")  # current-time-ok
+        ts_from_method = Timestamp.now()  # noqa: TID251
+        ts_datetime = datetime.now()  # noqa: TID251
 
-        ts_from_string_tz = Timestamp("now", tz="US/Eastern")
-        ts_from_method_tz = Timestamp.now(tz="US/Eastern")
+        ts_from_string_tz = Timestamp("now", tz="US/Eastern")  # current-time-ok
+        ts_from_method_tz = Timestamp.now(tz="US/Eastern")  # noqa: TID251
 
         # Check that the delta between the times is less than 1s (arbitrarily
         # small)
@@ -714,12 +714,12 @@ class TestTimestampClassMethodConstructors:
         )
 
     def test_today(self):
-        ts_from_string = Timestamp("today")
-        ts_from_method = Timestamp.today()
-        ts_datetime = datetime.today()
+        ts_from_string = Timestamp("today")  # current-time-ok
+        ts_from_method = Timestamp.today()  # noqa: TID251
+        ts_datetime = datetime.today()  # noqa: TID251
 
-        ts_from_string_tz = Timestamp("today", tz="US/Eastern")
-        ts_from_method_tz = Timestamp.today(tz="US/Eastern")
+        ts_from_string_tz = Timestamp("today", tz="US/Eastern")  # current-time-ok
+        ts_from_method_tz = Timestamp.today(tz="US/Eastern")  # noqa: TID251
 
         # Check that the delta between the times is less than 1s (arbitrarily
         # small)

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -533,7 +533,7 @@ class TestTimestampConversion:
 
     def test_to_numpy_alias(self):
         # GH 24653: alias .to_numpy() for scalars
-        ts = Timestamp(datetime.now())
+        ts = Timestamp(datetime(2011, 1, 1))
         assert ts.to_datetime64() == ts.to_numpy()
 
         # GH#44460

--- a/pandas/tests/scalar/timestamp/test_timestamp.py
+++ b/pandas/tests/scalar/timestamp/test_timestamp.py
@@ -287,8 +287,8 @@ class TestTimestamp:
     def test_default_to_stdlib_utc(self):
         msg = "Timestamp.utcnow is deprecated"
         with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            assert Timestamp.utcnow().tz is UTC
-        assert Timestamp.now("UTC").tz is UTC
+            assert Timestamp.utcnow().tz is UTC  # noqa: TID251
+        assert Timestamp.now("UTC").tz is UTC  # noqa: TID251
         assert Timestamp("2016-01-01", tz="UTC").tz is UTC
 
     def test_tz(self):
@@ -327,14 +327,14 @@ class TestTimestamp:
         def compare(x, y):
             assert int((Timestamp(x)._value - Timestamp(y)._value) / 1e9) == 0
 
-        compare(Timestamp.now(), datetime.now())
-        compare(Timestamp.now("UTC"), datetime.now(UTC))
-        compare(Timestamp.now("UTC"), datetime.now(tzutc()))
+        compare(Timestamp.now(), datetime.now())  # noqa: TID251
+        compare(Timestamp.now("UTC"), datetime.now(UTC))  # noqa: TID251
+        compare(Timestamp.now("UTC"), datetime.now(tzutc()))  # noqa: TID251
         msg = "Timestamp.utcnow is deprecated"
         with tm.assert_produces_warning(Pandas4Warning, match=msg):
-            compare(Timestamp.utcnow(), datetime.now(UTC))
-        compare(Timestamp.today(), datetime.today())
-        current_time = calendar.timegm(datetime.now().utctimetuple())
+            compare(Timestamp.utcnow(), datetime.now(UTC))  # noqa: TID251
+        compare(Timestamp.today(), datetime.today())  # noqa: TID251
+        current_time = calendar.timegm(datetime.now().utctimetuple())  # noqa: TID251
 
         msg = "Timestamp.utcfromtimestamp is deprecated"
         with tm.assert_produces_warning(Pandas4Warning, match=msg):
@@ -354,7 +354,7 @@ class TestTimestamp:
             datetime.fromtimestamp(current_time, UTC),
         )
 
-        date_component = datetime.now(UTC)
+        date_component = datetime.now(UTC)  # noqa: TID251
         time_component = (date_component + timedelta(minutes=10)).time()
         compare(
             Timestamp.combine(date_component, time_component),

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -68,11 +68,11 @@ class TestSetitemDT64Values:
 
     def test_setitem_with_string_index(self):
         # GH#23451
-        # Set object dtype to avoid upcast when setting date.today()
+        # Set object dtype to avoid upcast when setting a date object
         ser = Series([1, 2, 3], index=["Date", "b", "other"], dtype=object)
-        ser["Date"] = date.today()
-        assert ser.Date == date.today()
-        assert ser["Date"] == date.today()
+        ser["Date"] = date(2011, 1, 1)
+        assert ser.Date == date(2011, 1, 1)
+        assert ser["Date"] == date(2011, 1, 1)
 
     def test_setitem_tuple_with_datetimetz_values(self):
         # GH#20441

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -958,8 +958,8 @@ class TestSeriesConstructors:
     def test_constructor_datetimes_with_nulls(self):
         # gh-15869
         for arr in [
-            np.array([None, None, None, None, datetime.now(), None]),
-            np.array([None, None, datetime.now(), None]),
+            np.array([None, None, None, None, datetime(2011, 1, 1), None]),
+            np.array([None, None, datetime(2011, 1, 1), None]),
         ]:
             result = Series(arr)
             assert result.dtype == "M8[us]"
@@ -1471,7 +1471,7 @@ class TestSeriesConstructors:
         series = Series(data)
         tm.assert_is_sorted(series.index)
 
-        data = {"a": 0, "b": "1", "c": "2", "d": datetime.now()}
+        data = {"a": 0, "b": "1", "c": "2", "d": datetime(2011, 1, 1)}
         series = Series(data)
         assert series.dtype == np.object_
 
@@ -1492,7 +1492,7 @@ class TestSeriesConstructors:
         assert strings.dtype == np.object_ if not using_infer_string else "str"
         assert len(strings) == len(datetime_series)
 
-        d = datetime.now()
+        d = datetime(2011, 1, 1)
         dates = Series(d, index=datetime_series.index)
         assert dates.dtype == "M8[us]"
         assert len(dates) == len(datetime_series)

--- a/pandas/tests/strings/test_case_justify.py
+++ b/pandas/tests/strings/test_case_justify.py
@@ -18,7 +18,7 @@ def test_title(any_string_dtype):
 
 
 def test_title_mixed_object():
-    s = Series(["FOO", np.nan, "bar", True, datetime.today(), "blah", None, 1, 2.0])
+    s = Series(["FOO", np.nan, "bar", True, datetime(2011, 1, 1), "blah", None, 1, 2.0])
     result = s.str.title()
     expected = Series(
         ["Foo", np.nan, "Bar", np.nan, np.nan, "Blah", None, np.nan, np.nan],
@@ -39,7 +39,7 @@ def test_lower_upper(any_string_dtype):
 
 
 def test_lower_upper_mixed_object():
-    s = Series(["a", np.nan, "b", True, datetime.today(), "foo", None, 1, 2.0])
+    s = Series(["a", np.nan, "b", True, datetime(2011, 1, 1), "foo", None, 1, 2.0])
 
     result = s.str.upper()
     expected = Series(
@@ -73,7 +73,7 @@ def test_capitalize(data, expected, any_string_dtype):
 
 
 def test_capitalize_mixed_object():
-    s = Series(["FOO", np.nan, "bar", True, datetime.today(), "blah", None, 1, 2.0])
+    s = Series(["FOO", np.nan, "bar", True, datetime(2011, 1, 1), "blah", None, 1, 2.0])
     result = s.str.capitalize()
     expected = Series(
         ["Foo", np.nan, "Bar", np.nan, np.nan, "Blah", None, np.nan, np.nan],
@@ -90,7 +90,7 @@ def test_swapcase(any_string_dtype):
 
 
 def test_swapcase_mixed_object():
-    s = Series(["FOO", np.nan, "bar", True, datetime.today(), "Blah", None, 1, 2.0])
+    s = Series(["FOO", np.nan, "bar", True, datetime(2011, 1, 1), "Blah", None, 1, 2.0])
     result = s.str.swapcase()
     expected = Series(
         ["foo", np.nan, "BAR", np.nan, np.nan, "bLAH", None, np.nan, np.nan],
@@ -141,7 +141,7 @@ def test_pad(any_string_dtype):
 
 
 def test_pad_mixed_object():
-    s = Series(["a", np.nan, "b", True, datetime.today(), "ee", None, 1, 2.0])
+    s = Series(["a", np.nan, "b", True, datetime(2011, 1, 1), "ee", None, 1, 2.0])
 
     result = s.str.pad(5, side="left")
     expected = Series(
@@ -233,7 +233,7 @@ def test_center_ljust_rjust(any_string_dtype):
 
 
 def test_center_ljust_rjust_mixed_object():
-    s = Series(["a", np.nan, "b", True, datetime.today(), "c", "eee", None, 1, 2.0])
+    s = Series(["a", np.nan, "b", True, datetime(2011, 1, 1), "c", "eee", None, 1, 2.0])
 
     result = s.str.center(5)
     expected = Series(

--- a/pandas/tests/strings/test_extract.py
+++ b/pandas/tests/strings/test_extract.py
@@ -41,7 +41,17 @@ def test_extract_expand_kwarg(any_string_dtype):
 
 def test_extract_expand_False_mixed_object():
     ser = Series(
-        ["aBAD_BAD", np.nan, "BAD_b_BAD", True, datetime.today(), "foo", None, 1, 2.0]
+        [
+            "aBAD_BAD",
+            np.nan,
+            "BAD_b_BAD",
+            True,
+            datetime(2011, 1, 1),
+            "foo",
+            None,
+            1,
+            2.0,
+        ]
     )
 
     # two groups
@@ -232,7 +242,7 @@ def test_extract_expand_True_mixed_object():
             np.nan,
             "BAD_b_BAD",
             True,
-            datetime.today(),
+            datetime(2011, 1, 1),
             "foo",
             None,
             1,

--- a/pandas/tests/strings/test_find_replace.py
+++ b/pandas/tests/strings/test_find_replace.py
@@ -120,7 +120,7 @@ def test_contains(any_string_dtype):
 def test_contains_object_mixed():
     mixed = Series(
         np.array(
-            ["a", np.nan, "b", True, datetime.today(), "foo", None, 1, 2.0],
+            ["a", np.nan, "b", True, datetime(2011, 1, 1), "foo", None, 1, 2.0],
             dtype=object,
         )
     )
@@ -492,7 +492,7 @@ def test_startswith(pat, dtype, null_value, na, using_infer_string):
 
     # mixed
     mixed = np.array(
-        ["a", np.nan, "b", True, datetime.today(), "foo", None, 1, 2.0],
+        ["a", np.nan, "b", True, datetime(2011, 1, 1), "foo", None, 1, 2.0],
         dtype=np.object_,
     )
     rs = Series(mixed).str.startswith("f")
@@ -563,7 +563,7 @@ def test_endswith(pat, dtype, null_value, na, using_infer_string):
 
     # mixed
     mixed = np.array(
-        ["a", np.nan, "b", True, datetime.today(), "foo", None, 1, 2.0],
+        ["a", np.nan, "b", True, datetime(2011, 1, 1), "foo", None, 1, 2.0],
         dtype=object,
     )
     rs = Series(mixed).str.endswith("f")
@@ -642,7 +642,7 @@ def test_replace_max_replacements(any_string_dtype):
 
 def test_replace_mixed_object():
     ser = Series(
-        ["aBAD", np.nan, "bBAD", True, datetime.today(), "fooBAD", None, 1, 2.0]
+        ["aBAD", np.nan, "bBAD", True, datetime(2011, 1, 1), "fooBAD", None, 1, 2.0]
     )
     result = Series(ser).str.replace("BAD[_]*", "", regex=True)
     expected = Series(
@@ -851,7 +851,7 @@ def test_replace_compiled_regex(any_string_dtype):
 def test_replace_compiled_regex_mixed_object():
     pat = re.compile(r"BAD_*")
     ser = Series(
-        ["aBAD", np.nan, "bBAD", True, datetime.today(), "fooBAD", None, 1, 2.0]
+        ["aBAD", np.nan, "bBAD", True, datetime(2011, 1, 1), "fooBAD", None, 1, 2.0]
     )
     result = Series(ser).str.replace(pat, "", regex=True)
     expected = Series(
@@ -1145,7 +1145,7 @@ def test_match_mixed_object():
             np.nan,
             "BAD_b_BAD",
             True,
-            datetime.today(),
+            datetime(2011, 1, 1),
             "foo",
             None,
             1,
@@ -1655,7 +1655,7 @@ def test_findall_mixed_object():
             np.nan,
             "foo",
             True,
-            datetime.today(),
+            datetime(2011, 1, 1),
             "BAD",
             None,
             1,

--- a/pandas/tests/strings/test_split_partition.py
+++ b/pandas/tests/strings/test_split_partition.py
@@ -95,7 +95,7 @@ def test_split_regex_explicit(any_string_dtype):
 @pytest.mark.parametrize("expand", [None, False])
 @pytest.mark.parametrize("method", ["split", "rsplit"])
 def test_split_object_mixed(expand, method):
-    mixed = Series(["a_b_c", np.nan, "d_e_f", True, datetime.today(), None, 1, 2.0])
+    mixed = Series(["a_b_c", np.nan, "d_e_f", True, datetime(2011, 1, 1), None, 1, 2.0])
     result = getattr(mixed.str, method)("_", expand=expand)
     exp = Series(
         [
@@ -790,7 +790,7 @@ def test_get():
 
 
 def test_get_mixed_object():
-    ser = Series(["a_b_c", np.nan, "c_d_e", True, datetime.today(), None, 1, 2.0])
+    ser = Series(["a_b_c", np.nan, "c_d_e", True, datetime(2011, 1, 1), None, 1, 2.0])
     result = ser.str.split("_").str.get(1)
     expected = Series(
         ["b", np.nan, "d", np.nan, np.nan, None, np.nan, np.nan], dtype=object

--- a/pandas/tests/strings/test_strings.py
+++ b/pandas/tests/strings/test_strings.py
@@ -61,7 +61,7 @@ def test_count(any_string_dtype):
 
 def test_count_mixed_object():
     ser = Series(
-        ["a", np.nan, "b", True, datetime.today(), "foo", None, 1, 2.0],
+        ["a", np.nan, "b", True, datetime(2011, 1, 1), "foo", None, 1, 2.0],
         dtype=object,
     )
     result = ser.str.count("a")
@@ -154,7 +154,7 @@ def test_repeat(any_string_dtype):
 
 
 def test_repeat_mixed_object():
-    ser = Series(["a", np.nan, "b", True, datetime.today(), "foo", None, 1, 2.0])
+    ser = Series(["a", np.nan, "b", True, datetime(2011, 1, 1), "foo", None, 1, 2.0])
     result = ser.str.repeat(3)
     expected = Series(
         ["aaa", np.nan, "bbb", np.nan, np.nan, "foofoofoo", None, np.nan, np.nan],
@@ -392,7 +392,17 @@ def test_split_join_roundtrip(any_string_dtype):
 
 def test_split_join_roundtrip_mixed_object():
     ser = Series(
-        ["a_b", np.nan, "asdf_cas_asdf", True, datetime.today(), "foo", None, 1, 2.0]
+        [
+            "a_b",
+            np.nan,
+            "asdf_cas_asdf",
+            True,
+            datetime(2011, 1, 1),
+            "foo",
+            None,
+            1,
+            2.0,
+        ]
     )
     result = ser.str.split("_").str.join("_")
     expected = Series(
@@ -420,7 +430,17 @@ def test_len(any_string_dtype):
 
 def test_len_mixed():
     ser = Series(
-        ["a_b", np.nan, "asdf_cas_asdf", True, datetime.today(), "foo", None, 1, 2.0]
+        [
+            "a_b",
+            np.nan,
+            "asdf_cas_asdf",
+            True,
+            datetime(2011, 1, 1),
+            "foo",
+            None,
+            1,
+            2.0,
+        ]
     )
     result = ser.str.len()
     expected = Series([3, np.nan, 13, np.nan, np.nan, 3, np.nan, np.nan, np.nan])
@@ -536,7 +556,9 @@ def test_slice(start, stop, step, expected, any_string_dtype):
     ],
 )
 def test_slice_mixed_object(start, stop, step, expected):
-    ser = Series(["aafootwo", np.nan, "aabartwo", True, datetime.today(), None, 1, 2.0])
+    ser = Series(
+        ["aafootwo", np.nan, "aabartwo", True, datetime(2011, 1, 1), None, 1, 2.0]
+    )
     result = ser.str.slice(start, stop, step)
     expected = Series(expected, dtype=object)
     tm.assert_series_equal(result, expected)
@@ -590,7 +612,9 @@ def test_strip_lstrip_rstrip(any_string_dtype, method, exp):
     ],
 )
 def test_strip_lstrip_rstrip_mixed_object(method, exp):
-    ser = Series(["  aa  ", np.nan, " bb \t\n", True, datetime.today(), None, 1, 2.0])
+    ser = Series(
+        ["  aa  ", np.nan, " bb \t\n", True, datetime(2011, 1, 1), None, 1, 2.0]
+    )
 
     result = getattr(ser.str, method)()
     expected = Series([*exp, np.nan, np.nan, None, np.nan, np.nan], dtype=object)

--- a/pandas/tests/test_sorting.py
+++ b/pandas/tests/test_sorting.py
@@ -579,7 +579,7 @@ class TestSafeSort:
 
     def test_unsortable(self):
         # GH 13714
-        arr = np.array([1, 2, datetime.now(), 0, 3], dtype=object)
+        arr = np.array([1, 2, datetime(2011, 1, 1), 0, 3], dtype=object)
         msg = "'[<>]' not supported between instances of .*"
         with pytest.raises(TypeError, match=msg):
             safe_sort(arr)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1100,9 +1100,9 @@ class TestToDatetime:
         # See GH#18666
         with tm.set_timezone("US/Eastern"):
             # GH#18705
-            now = Timestamp("now")
-            pdnow = to_datetime("now")
-            pdnow2 = to_datetime(["now"])[0]
+            now = Timestamp("now")  # current-time-ok
+            pdnow = to_datetime("now")  # current-time-ok
+            pdnow2 = to_datetime(["now"])[0]  # current-time-ok
 
             # These should all be equal with infinite perf; this gives
             # a generous margin of 10 seconds
@@ -1123,12 +1123,13 @@ class TestToDatetime:
         # this both of these timezones _and_ UTC will all be in the same day,
         # so this test will not detect the regression introduced in #18666.
         with tm.set_timezone(tz):
-            nptoday = np.datetime64("today").astype("datetime64[us]").astype(np.int64)
-            pdtoday = to_datetime("today")
-            pdtoday2 = to_datetime(["today"])[0]
+            today64 = np.datetime64("today")  # current-time-ok
+            nptoday = today64.astype("datetime64[us]").astype(np.int64)
+            pdtoday = to_datetime("today")  # current-time-ok
+            pdtoday2 = to_datetime(["today"])[0]  # current-time-ok
 
-            tstoday = Timestamp("today")
-            tstoday2 = Timestamp.today()
+            tstoday = Timestamp("today")  # current-time-ok
+            tstoday2 = Timestamp.today()  # noqa: TID251
 
             # These should all be equal with infinite perf; this gives
             # a generous margin of 10 seconds
@@ -3785,7 +3786,7 @@ class TestOrigin:
         # GH47495
         msg = "Unknown datetime string format, unable to parse: yesterday"
         with pytest.raises(ValueError, match=msg):
-            to_datetime(["today", "yesterday"])
+            to_datetime(["today", "yesterday"])  # current-time-ok
 
     @pytest.mark.parametrize(
         "format, warning",

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -1421,7 +1421,7 @@ class TestToDatetime:
     def test_datetime_bool_arrays_mixed(self, cache):
         msg = f"{type(cache)} is not convertible to datetime"
         with pytest.raises(TypeError, match=msg):
-            to_datetime([False, datetime.today()], cache=cache)
+            to_datetime([False, datetime(2011, 1, 1)], cache=cache)
         with pytest.raises(
             ValueError,
             match=(

--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -194,7 +194,7 @@ def test_annual_ambiguous():
 
 @pytest.mark.parametrize("count", range(1, 5))
 def test_infer_freq_delta(base_delta_code_pair, count):
-    b = Timestamp(datetime.now())
+    b = Timestamp(datetime(2011, 1, 1))
     base_delta, code = base_delta_code_pair
 
     inc = base_delta * count
@@ -216,7 +216,7 @@ def test_infer_freq_delta(base_delta_code_pair, count):
     ],
 )
 def test_infer_freq_custom(base_delta_code_pair, constructor):
-    b = Timestamp(datetime.now())
+    b = Timestamp(datetime(2011, 1, 1))
     base_delta, _ = base_delta_code_pair
 
     index = constructor(b, base_delta)

--- a/pandas/tests/tslibs/test_strptime.py
+++ b/pandas/tests/tslibs/test_strptime.py
@@ -78,7 +78,7 @@ class TestArrayStrptimeResolutionInference:
         # specifically case where today/now is the *first* item
         vals = np.array(["today", np.datetime64("2017-01-01", "us")], dtype=object)
 
-        now = Timestamp("now").asm8
+        now = Timestamp("now").asm8  # current-time-ok
         res, _ = array_strptime(vals, fmt="%Y-%m-%d", utc=False, creso=creso_infer)
         res2, _ = array_strptime(
             vals[::-1], fmt="%Y-%m-%d", utc=False, creso=creso_infer

--- a/pandas/tests/window/test_rolling.py
+++ b/pandas/tests/window/test_rolling.py
@@ -637,7 +637,7 @@ def test_rolling_datetime(tz_naive_fixture):
 
 def test_rolling_window_as_string(center):
     # see gh-22590
-    date_today = datetime.now()
+    date_today = datetime(2011, 1, 1)
     days = date_range(date_today, date_today + timedelta(365), freq="D")
 
     data = np.ones(len(days))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -415,6 +415,14 @@ exclude = [
 # "numpy.array_equal".msg = "Do not use numpy.array_equal" # Used in pandas/core
 "unittest.mock".msg = "use pytest builtin monkeypatch fixture instead"
 "os.remove".msg = "Do not use os.remove"
+# Time-dependent test data broke CI at a DST transition (GH#44341).
+"datetime.datetime.now".msg = "Use a fixed datetime, not the current time (GH#44341)"
+"datetime.datetime.today".msg = "Use a fixed datetime, not the current time (GH#44341)"
+"datetime.datetime.utcnow".msg = "Use a fixed datetime, not the current time (GH#44341)"
+"pandas.Timestamp.now".msg = "Use a fixed datetime, not the current time (GH#44341)"
+"pandas.Timestamp.today".msg = "Use a fixed datetime, not the current time (GH#44341)"
+"pandas.Timestamp.utcnow".msg = "Use a fixed datetime, not the current time (GH#44341)"
+"pandas.Period.now".msg = "Use a fixed datetime, not the current time (GH#44341)"
 
 
 

--- a/scripts/issue_assignment/unassign_inactive.py
+++ b/scripts/issue_assignment/unassign_inactive.py
@@ -45,7 +45,7 @@ def free_linked_issues(client: GitHubClient, number: int, author: str | None) ->
 
 
 def run_sweep(client: GitHubClient) -> None:
-    now = datetime.now(UTC)
+    now = datetime.now(UTC)  # noqa: TID251
     window = timedelta(days=core.STALE_ASSIGNEE_DAYS)
     for number in client.list_open_assigned_issue_numbers():
         activity = client.issue_activity(number)
@@ -132,7 +132,7 @@ def _stale_clock_anchor(
 
 def run_pr_stale_sweep(client: GitHubClient) -> None:
     """Mark/clear ``Stale`` and auto-close open PRs based on author inactivity."""
-    now = datetime.now(UTC)
+    now = datetime.now(UTC)  # noqa: TID251
     for pr in client.iter_open_pull_requests_review_state():
         contributors = {pr["author"]} - {None}
         changes_requested_at = core.outstanding_changes_requested_at(pr["reviews"])

--- a/scripts/tests/test_issue_assignment.py
+++ b/scripts/tests/test_issue_assignment.py
@@ -702,7 +702,7 @@ def activity(
 
 def ago(days: int) -> datetime:
     # The sweeps read the wall clock, so fixtures are relative to real now.
-    return datetime.now(UTC) - timedelta(days=days)
+    return datetime.now(UTC) - timedelta(days=days)  # noqa: TID251
 
 
 def changes(days_ago: int) -> list[core.Review]:

--- a/web/pandas_web.py
+++ b/web/pandas_web.py
@@ -71,7 +71,7 @@ class Preprocessors:
         Add the current year to the context, so it can be used for the copyright
         note, or other places where it is needed.
         """
-        context["current_year"] = datetime.datetime.now().year
+        context["current_year"] = datetime.datetime.now().year  # noqa: TID251
         return context
 
     @staticmethod


### PR DESCRIPTION
closes #44341

Tests that build data from the current time are time dependent: on 2021-11-07 the US DST transition turned ~70 tests red with `pytz.AmbiguousTimeError`, and day-of-month/midnight-crossing variants have bitten CI since. GH-44448 and GH-44501 cleaned up some call sites in 2021, but no check was added, so the pattern crept back — there were 113 `.now()`/`.today()`/`utcnow()` calls across 41 test files plus ~28 `"now"`/`"today"` string literals.

The check is in two parts, because no single mechanism covers both spellings.

**Attribute spellings → ruff `banned-api` (TID251).** `datetime.datetime.{now,today,utcnow}`, `Timestamp.{now,today,utcnow}` and `Period.now` join the existing bans in `pyproject.toml`. TID251 resolves qualified names through aliases, so `pd.Timestamp.today()` and `from datetime import datetime as dt; dt.now()` are both caught. Intentional uses are marked per line with `# noqa: TID251` — 26 in the files that test these constructors, and 7 outside `pandas/tests` (`io/stata.py`, `doc/source/conf.py`, `web/pandas_web.py`, `scripts/issue_assignment/`), since TID251 is repo-wide.

**String spellings → a `current-time-in-tests` pygrep hook**, next to the existing unseeded-`default_rng()` check, matching `(date_range|datetime64|period_range|Period|Timestamp|to_datetime)\(\s*\[?"(now|today)"`. TID251 matches qualified names, not values, so it cannot see `Timestamp("now")` — and that form is not a rounding error: 17 of the sites this PR cleans up are string literals, including seven `date_range("now", periods=3)` in one file. The 13 remaining intentional ones take a `# current-time-ok` marker on the line. (It can't reuse `# noqa`: a bare one trips PGH004 and an invented code trips RUF100.)

Both halves are per-line, so no file is excluded wholesale — a new offender added to `test_timestamp.py` is still caught.

Everything else — ~104 sites in 45 files — is replaced with a fixed datetime. Most were arbitrary placeholders, but a few were genuinely time dependent:

- `dtypes/cast/test_promote.py` — one of the two sites named in the original failure log.
- `io/test_parquet.py` — `datetime.now(tz)` inside `@pytest.fixture(params=...)`, so the test IDs varied per run.
- `groupby/test_grouping.py` (`date_range(date.today() - 14d, date.today())`) and `groupby/test_groupby.py` (`date_range(datetime.today(), freq="ME")`) — day-of-month sensitive.
- `window/test_rolling.py` — a 366-day `date_range` starting at `datetime.now()`.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which surveyed the remaining call sites, classified them as replaceable vs. under-test, wrote the checks and the replacements, and ran the touched test files. The split above was made in response to @mroeschke's review; the claims about what TID251 does and does not match were verified against ruff 0.16.1 rather than assumed.
