### PR TITLE
[fix :GH #46377] Series.astype is unable to handle NaN

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -45,6 +45,7 @@ Other enhancements
 - Added :meth:`ExtensionArray.sort` for in-place sorting of :class:`ExtensionArray` (:issue:`64977`)
 - Added :meth:`Index.replace` method to support value replacement functionality similar to :meth:`Series.replace` (:issue:`19495`)
 - Added ``union_categories`` parameter to :func:`concat` to preserve categorical dtype by unioning categories when concatenating categoricals with different categories (:issue:`14177`)
+- Added ``convert_dtype`` parameter to :meth:`Series.map` to opt out of post-mapping dtype inference, so that values such as an explicit ``None`` returned by ``func`` are no longer coerced back to ``NaN`` (:issue:`46377`)
 - Added reduction methods as public API on pandas-implemented extension arrays where applicable (:issue:`63512`)
 - Building from source no longer fails on a checkout with CRLF line endings, such as under WSL (:issue:`64272`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -44,8 +44,8 @@ Other enhancements
 - Added :meth:`ExtensionArray.count` (:issue:`64450`)
 - Added :meth:`ExtensionArray.sort` for in-place sorting of :class:`ExtensionArray` (:issue:`64977`)
 - Added :meth:`Index.replace` method to support value replacement functionality similar to :meth:`Series.replace` (:issue:`19495`)
-- Added ``union_categories`` parameter to :func:`concat` to preserve categorical dtype by unioning categories when concatenating categoricals with different categories (:issue:`14177`)
 - Added ``convert_dtype`` parameter to :meth:`Series.map` to opt out of post-mapping dtype inference, so that values such as an explicit ``None`` returned by ``func`` are no longer coerced back to ``NaN`` (:issue:`46377`)
+- Added ``union_categories`` parameter to :func:`concat` to preserve categorical dtype by unioning categories when concatenating categoricals with different categories (:issue:`14177`)
 - Added reduction methods as public API on pandas-implemented extension arrays where applicable (:issue:`63512`)
 - Building from source no longer fails on a checkout with CRLF line endings, such as under WSL (:issue:`64272`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).

--- a/pandas/core/algorithms.py
+++ b/pandas/core/algorithms.py
@@ -1900,6 +1900,7 @@ def map_array(
     arr: ArrayLike,
     mapper,
     na_action: Literal["ignore"] | None = None,
+    convert: bool = True,
 ) -> np.ndarray | ExtensionArray | Index:
     """
     Map values using an input mapping or function.
@@ -1911,6 +1912,12 @@ def map_array(
     na_action : {None, 'ignore'}, default None
         If 'ignore', propagate NA values, without passing them to the
         mapping correspondence.
+    convert : bool, default True
+        Try to find better dtype for elementwise function results. If
+        False, the values returned by ``mapper`` are kept as-is in an
+        object-dtype result instead of being passed through dtype
+        inference (e.g. so that an explicit ``None`` is not coerced
+        back to ``NaN``).
 
     Returns
     -------
@@ -1974,6 +1981,8 @@ def map_array(
     # we must convert to python types
     values = arr.astype(object, copy=False)
     if na_action is None:
-        return lib.map_infer(values, mapper)
+        return lib.map_infer(values, mapper, convert=convert)
     else:
-        return lib.map_infer_mask(values, mapper, mask=isna(values).view(np.uint8))
+        return lib.map_infer_mask(
+            values, mapper, mask=isna(values).view(np.uint8), convert=convert
+        )

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -2978,7 +2978,12 @@ class ExtensionArray:
 
         return arraylike.default_array_ufunc(self, ufunc, method, *inputs, **kwargs)
 
-    def map(self, mapper, na_action: Literal["ignore"] | None = None):
+    def map(
+        self,
+        mapper,
+        na_action: Literal["ignore"] | None = None,
+        convert: bool = True,
+    ):
         """
         Map values using an input mapping or function.
 
@@ -2990,6 +2995,10 @@ class ExtensionArray:
             If 'ignore', propagate NA values, without passing them to the
             mapping correspondence. If 'ignore' is not supported, a
             ``NotImplementedError`` should be raised.
+        convert : bool, default True
+            Try to find better dtype for elementwise function results. If
+            False, the mapped values are kept as-is in an object-dtype
+            result instead of being passed through dtype inference.
 
         Returns
         -------
@@ -2998,8 +3007,10 @@ class ExtensionArray:
             If the function returns a tuple with more than one element
             a MultiIndex will be returned.
         """
-        result = map_array(self, mapper, na_action=na_action)
+        result = map_array(self, mapper, na_action=na_action, convert=convert)
         if isinstance(result, np.ndarray):
+            if not convert:
+                return result
             return self._cast_pointwise_result(result)
         return result
 

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -1552,6 +1552,7 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         self,
         mapper,
         na_action: Literal["ignore"] | None = None,
+        convert: bool = True,
     ):
         """
         Map categories using an input mapping or function.
@@ -1572,6 +1573,10 @@ class Categorical(NDArrayBackedExtensionArray, PandasObject, ObjectStringArrayMi
         na_action : {None, 'ignore'}, default None
             If 'ignore', propagate NaN values, without passing them to the
             mapping correspondence.
+        convert : bool, default True
+            Accepted for signature compatibility with
+            :meth:`ExtensionArray.map`; has no effect since categories are
+            mapped via :meth:`Index.map`, which always infers dtype.
 
         Returns
         -------

--- a/pandas/core/arrays/datetimelike.py
+++ b/pandas/core/arrays/datetimelike.py
@@ -754,10 +754,15 @@ class DatetimeLikeArrayMixin(OpsMixin, NDArrayBackedExtensionArray):
     #  pandas assumes they're there.
 
     @ravel_compat
-    def map(self, mapper, na_action: Literal["ignore"] | None = None):
+    def map(
+        self,
+        mapper,
+        na_action: Literal["ignore"] | None = None,
+        convert: bool = True,
+    ):
         from pandas import Index
 
-        result = map_array(self, mapper, na_action=na_action)
+        result = map_array(self, mapper, na_action=na_action, convert=convert)
         result = Index(result)
 
         if isinstance(result, ABCMultiIndex):

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1426,7 +1426,12 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         return self._simple_new(sp_values, self.sp_index, dtype)
 
-    def map(self, mapper, na_action: Literal["ignore"] | None = None) -> Self:
+    def map(
+        self,
+        mapper,
+        na_action: Literal["ignore"] | None = None,
+        convert: bool = True,
+    ) -> Self:
         """
         Map categories using an input mapping or function.
 
@@ -1437,6 +1442,10 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         na_action : {None, 'ignore'}, default None
             If 'ignore', propagate NA values, without passing them to the
             mapping correspondence.
+        convert : bool, default True
+            Accepted for signature compatibility with
+            :meth:`ExtensionArray.map`; has no effect since ``SparseArray``
+            always infers the dtype of its non-fill values.
 
         Returns
         -------

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1043,7 +1043,7 @@ class IndexOpsMixin(OpsMixin):
         return bool(isna(self).any())  # type: ignore[union-attr]
 
     @final
-    def _map_values(self, mapper, na_action=None):
+    def _map_values(self, mapper, na_action=None, convert: bool = True):
         """
         An internal function that maps values using the input
         correspondence (which can be a dict, Series, or function).
@@ -1055,6 +1055,9 @@ class IndexOpsMixin(OpsMixin):
         na_action : {None, 'ignore'}
             If 'ignore', propagate NA values, without passing them to the
             mapping function
+        convert : bool, default True
+            Try to find better dtype for elementwise function results. If
+            False, keep the mapped values as-is in an object-dtype result.
 
         Returns
         -------
@@ -1066,9 +1069,9 @@ class IndexOpsMixin(OpsMixin):
         arr = self._values
 
         if isinstance(arr, ExtensionArray):
-            return arr.map(mapper, na_action=na_action)
+            return arr.map(mapper, na_action=na_action, convert=convert)
 
-        return algorithms.map_array(arr, mapper, na_action=na_action)
+        return algorithms.map_array(arr, mapper, na_action=na_action, convert=convert)
 
     def value_counts(
         self,

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6845,7 +6845,7 @@ class Index(IndexOpsMixin, PandasObject):
         """
         from pandas.core.indexes.multi import MultiIndex
 
-        new_values = self._map_values(mapper, na_action=na_action)  # type: ignore[no-untyped-call]
+        new_values = self._map_values(mapper, na_action=na_action)
 
         # we can return a MultiIndex
         if new_values.size and isinstance(new_values[0], tuple):

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4966,6 +4966,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         func: Callable | Mapping | Series | None = None,
         na_action: Literal["ignore"] | None = None,
         engine: Callable | None = None,
+        convert_dtype: bool = True,
         **kwargs,
     ) -> Series:
         """
@@ -5000,6 +5001,16 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             NumPy APIs are supported. Check the engine documentation for limitations.
 
             .. versionadded:: 3.0.0
+
+        convert_dtype : bool, default True
+            Try to find better dtype for elementwise function results. If
+            False, the values returned by ``func`` are kept as-is in an
+            object-dtype result instead of being passed through dtype
+            inference. This matters when ``func`` can return ``None``, since
+            dtype inference otherwise coerces a returned ``None`` back to
+            ``NaN``.
+
+            .. versionadded:: 3.1.0
 
         **kwargs
             Additional keyword arguments to pass as keywords arguments to
@@ -5116,6 +5127,10 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
                 )
             if not hasattr(engine, "__pandas_udf__"):
                 raise ValueError(f"Not a valid engine: {engine!r}")
+            if not convert_dtype:
+                raise ValueError(
+                    "convert_dtype=False is not supported when engine is specified"
+                )
             result = engine.__pandas_udf__.map(  # type: ignore[attr-defined]
                 data=self,
                 func=func,
@@ -5130,7 +5145,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         if callable(func):
             func = functools.partial(func, **kwargs)
-        new_values = self._map_values(func, na_action=na_action)
+        new_values = self._map_values(func, na_action=na_action, convert=convert_dtype)
         return self._constructor(new_values, index=self.index, copy=False).__finalize__(
             self, method="map"
         )

--- a/pandas/tests/series/methods/test_map.py
+++ b/pandas/tests/series/methods/test_map.py
@@ -26,7 +26,10 @@ import pandas._testing as tm
 
 # The fixture it's mostly used in pandas/tests/apply, so it's defined in that
 # conftest, which is out of scope here. So we need to manually import
-from pandas.tests.apply.conftest import engine  # noqa: F401
+from pandas.tests.apply.conftest import (  # noqa: F401
+    MockEngineDecorator,
+    engine,
+)
 
 
 def test_series_map_box_timedelta():
@@ -273,6 +276,32 @@ def test_map_type_inference():
     s = Series(range(3))
     s2 = s.map(lambda x: np.where(x == 0, 0, 1))
     assert issubclass(s2.dtype.type, np.integer)
+
+
+def test_map_convert_dtype_false_keeps_none():
+    # GH#46377
+    s = Series([2.0, np.nan, 1.0])
+    result = s.map(lambda x: None if np.isnan(x) else x, convert_dtype=False)
+    expected = Series([2.0, None, 1.0], dtype=object)
+    tm.assert_series_equal(result, expected)
+    assert result.iloc[1] is None
+
+
+def test_map_convert_dtype_true_default_still_infers():
+    # GH#46377 - default behavior (convert_dtype=True) is unchanged:
+    # None is coerced back to NaN by dtype inference.
+    s = Series([2.0, np.nan, 1.0])
+    result = s.map(lambda x: None if np.isnan(x) else x)
+    expected = Series([2.0, np.nan, 1.0])
+    tm.assert_series_equal(result, expected)
+
+
+def test_map_convert_dtype_false_with_engine_raises():
+    # GH#46377
+    s = Series([1, 2, 3])
+    msg = "convert_dtype=False is not supported when engine is specified"
+    with pytest.raises(ValueError, match=msg):
+        s.map(lambda x: x, engine=MockEngineDecorator, convert_dtype=False)
 
 
 def test_map_decimal(string_series):


### PR DESCRIPTION
 ] add the convert_dtype args to avoid implicit None to NaN conversion

- [x] closes #46377 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
