### PR TITLE
DOC: state which matplotlib function receives the plot kwargs

### DIFF
--- a/pandas/plotting/_core.py
+++ b/pandas/plotting/_core.py
@@ -1127,7 +1127,11 @@ class PlotAccessor(PandasObject):
         *args
             Positional arguments to pass to the plotting backend.
         **kwargs
-            Keyword arguments to pass to the plotting backend.
+            Keyword arguments to pass to the plotting backend. For
+            the matplotlib backend, they are forwarded to the
+            matplotlib function that draws the plot for the chosen
+            ``kind``; see the individual methods for the exact
+            function.
 
         Attributes
         ----------
@@ -1469,6 +1473,8 @@ class PlotAccessor(PandasObject):
             matplotlib tick locators and formatters. See
             :ref:`Suppressing tick resolution adjustment
             <plotting.x_compat>` for more.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.plot`.
 
         Returns
         -------
@@ -1580,6 +1586,8 @@ class PlotAccessor(PandasObject):
         **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.bar`.
 
         Returns
         -------
@@ -1725,6 +1733,8 @@ class PlotAccessor(PandasObject):
         **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.barh`.
 
         Returns
         -------
@@ -1849,6 +1859,8 @@ class PlotAccessor(PandasObject):
         **kwargs
             Additional keywords are documented in
             :meth:`DataFrame.plot`.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.boxplot`.
 
         Returns
         -------
@@ -1905,6 +1917,8 @@ class PlotAccessor(PandasObject):
         **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.hist`.
 
         Returns
         -------
@@ -1978,6 +1992,9 @@ class PlotAccessor(PandasObject):
         **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
+            For the default matplotlib backend, the density is estimated
+            with :class:`scipy.stats.gaussian_kde` and they are passed to
+            :meth:`matplotlib.axes.Axes.plot`.
 
         Returns
         -------
@@ -2089,6 +2106,8 @@ class PlotAccessor(PandasObject):
         **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.plot`.
 
         Returns
         -------
@@ -2166,6 +2185,8 @@ class PlotAccessor(PandasObject):
             If not provided, ``subplots=True`` argument must be passed.
         **kwargs
             Keyword arguments to pass on to :meth:`DataFrame.plot`.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.pie`.
 
         Returns
         -------
@@ -2260,6 +2281,8 @@ class PlotAccessor(PandasObject):
 
         **kwargs
             Keyword arguments to pass on to :meth:`DataFrame.plot`.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.scatter`.
 
         Returns
         -------
@@ -2350,6 +2373,8 @@ class PlotAccessor(PandasObject):
         **kwargs
             Additional keyword arguments are documented in
             :meth:`DataFrame.plot`.
+            For the default matplotlib backend, they are passed to
+            :meth:`matplotlib.axes.Axes.hexbin`.
 
         Returns
         -------


### PR DESCRIPTION
- [x] closes #61020
- [ ] Tests added and passed (not applicable: docs-only change)
- [x] All code checks passed (ruff clean on the touched file; docstring build validated by CI)
- [ ] Added type annotations (not applicable: no new arguments)
- [ ] whatsnew entry (not applicable: docs-only change)
- [x] I have reviewed and followed all the contribution guidelines
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting.

**How AI was used:** Claude was used for identifying the issue, drafting this PR body, and preparing the docstring edits. I reviewed every change and verified each mapping against the matplotlib call sites in `pandas/plotting/_matplotlib/` before staging it.

## What does this PR do?

As discussed in #61020 (rhshadrach's comment of Apr 10), for the default matplotlib backend this adds to each `DataFrame.plot` method docstring the matplotlib function the keyword arguments are passed to, and extends the `DataFrame.plot` `**kwargs` entry accordingly:

- `plot.line`, `plot.area` → `matplotlib.axes.Axes.plot`
- `plot.kde` → density estimated with `scipy.stats.gaussian_kde`, curve drawn with `matplotlib.axes.Axes.plot`
- `plot.bar` / `plot.barh` → `matplotlib.axes.Axes.bar` / `matplotlib.axes.Axes.barh`
- `plot.box` → `matplotlib.axes.Axes.boxplot`
- `plot.hist` → `matplotlib.axes.Axes.hist`
- `plot.pie` → `matplotlib.axes.Axes.pie`
- `plot.scatter` → `matplotlib.axes.Axes.scatter`
- `plot.hexbin` → `matplotlib.axes.Axes.hexbin`

Every mapping was verified against the call sites in `pandas/plotting/_matplotlib/` (`ax.plot`, `ax.bar`, `ax.barh`, `ax.boxplot`, `ax.hist`, `ax.pie`, `ax.scatter`, `ax.hexbin`).

As jbrockmendel noted in the issue, arguments specific to third-party backends are deliberately not documented here.
