### PR TITLE
DOC: pluralize 'value' to 'values' in dropna axis parameter docstring

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -8105,7 +8105,7 @@ class DataFrame(NDFrame, OpsMixin):
             removed.
 
             * 0, or 'index' : Drop rows which contain missing values.
-            * 1, or 'columns' : Drop columns which contain missing value.
+            * 1, or 'columns' : Drop columns which contain missing values.
 
             Only a single axis is allowed.
 


### PR DESCRIPTION
Fixes #67018

Pluralized "value" to "values" in the `axis=1` explanation for `dropna()` to match the phrasing already used for `axis=0`.
