### PR TITLE
CI: update pyarrow-nightly pixi env before installing to avoid stale locked wheel

### DIFF
--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -19,5 +19,5 @@ runs:
         manifest-path: pixi.toml
         run-install: ${{ inputs.run-install }}
         environments: ${{ inputs.environment }}
-        cache: true
+        cache: ${{ inputs.run-install }}
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -4,6 +4,10 @@ inputs:
   environment:
     description: Pixi environment name in pyproject.toml to use.
     required: true
+  run-install:
+    description: Whether to install the pandas workspace or only install pixi
+    required: false
+    default: true
 runs:
   using: composite
   steps:
@@ -13,6 +17,7 @@ runs:
         pixi-version: v0.76.2
         log-level: vv
         manifest-path: pixi.toml
+        run-install: ${{ inputs.run-install }}
         environments: ${{ inputs.environment }}
         cache: true
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -30,6 +30,7 @@ runs:
 
     - name: Install PyArrow Nightly
       if: ${{ inputs.environment == 'pyarrow-nightly' }}
+      shell: bash -euox pipefail {0}
       run: |
         pixi update -e pyarrow-nightly pyarrow
         pixi install -e pyarrow-nightly

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -4,10 +4,6 @@ inputs:
   environment:
     description: Pixi environment name in pyproject.toml to use.
     required: true
-  run-install:
-    description: Whether to install the pandas workspace or only install pixi
-    required: false
-    default: true
 runs:
   using: composite
   steps:
@@ -20,7 +16,7 @@ runs:
         environments: ${{ inputs.environment }}
         cache: true
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
-      if: ${{ inputs.run-install }}
+      if: ${{ inputs.environment != 'pyarrow-nightly' }}
 
     - name: Install ${{ inputs.environment }}
       uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
@@ -30,4 +26,10 @@ runs:
         manifest-path: pixi.toml
         run-install: false
         cache: false
-      if: ${{ not inputs.run-install }}
+      if: ${{ inputs.environment == 'pyarrow-nightly' }}
+
+    - name: Install PyArrow Nightly
+      if: ${{ inputs.environment == 'pyarrow-nightly' }}
+      run: |
+        pixi update -e pyarrow-nightly pyarrow
+        pixi install -e pyarrow-nightly

--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -17,7 +17,17 @@ runs:
         pixi-version: v0.76.2
         log-level: vv
         manifest-path: pixi.toml
-        run-install: ${{ inputs.run-install }}
         environments: ${{ inputs.environment }}
-        cache: ${{ inputs.run-install }}
+        cache: true
         cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+      if: ${{ inputs.run-install }}
+
+    - name: Install ${{ inputs.environment }}
+      uses: prefix-dev/setup-pixi@f00437f565399d418b0acc85936d12c1fb668347 # v0.10.1
+      with:
+        pixi-version: v0.76.2
+        log-level: vv
+        manifest-path: pixi.toml
+        run-install: false
+        cache: false
+      if: ${{ not inputs.run-install }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -150,6 +150,13 @@ jobs:
       uses: ./.github/actions/setup-pixi
       with:
         environment: ${{ matrix.environment }}
+        run-install: ${{ matrix.environment == 'pyarrow-nightly' && 'false' || 'true' }}
+
+    - name: Install PyArrow Nightly
+      if: ${{ matrix.environment == 'pyarrow-nightly' }}
+      run: |
+        pixi update -e pyarrow-nightly pyarrow
+        pixi install -e pyarrow-nightly
 
     - name: Build pandas
       id: build

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -150,13 +150,6 @@ jobs:
       uses: ./.github/actions/setup-pixi
       with:
         environment: ${{ matrix.environment }}
-        run-install: ${{ matrix.environment == 'pyarrow-nightly' && 'false' || 'true' }}
-
-    - name: Install PyArrow Nightly
-      if: ${{ matrix.environment == 'pyarrow-nightly' }}
-      run: |
-        pixi update -e pyarrow-nightly pyarrow
-        pixi install -e pyarrow-nightly
 
     - name: Build pandas
       id: build


### PR DESCRIPTION
Based on the suggestion at https://github.com/prefix-dev/pixi/discussions/6186#discussioncomment-18108586, trying to fix https://github.com/pandas-dev/pandas/issues/65690#issuecomment-4500687495