### PR TITLE
BUG: Make RangeIndex._data read-only to prevent external mutation

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -630,6 +630,7 @@ Interval
 
 Indexing
 ^^^^^^^^
+- Bug in :class:`RangeIndex` where the cached internal data array was writeable, allowing external modification to silently corrupt the index (:issue:`67055`)
 - Bug in :class:`TimedeltaIndex` string indexing using the resolution of the parsed value rather than the string, so keys like ``"720s"`` (an exact multiple of a minute) matched a minute-sized window instead of a second-sized one (:issue:`33603`)
 - Bug in :meth:`DataFrame.loc` and :meth:`Series.loc` replacing the index name with the key's name when indexing with an :class:`Index` (:issue:`17110`)
 - Bug in :meth:`DataFrame.loc` raising ``ValueError`` when setting a row on a :class:`DataFrame` with no columns and the label is not in the index (:issue:`17895`)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -288,7 +288,9 @@ class RangeIndex(Index):
 
         The constructed array is saved in ``_cache``.
         """
-        return np.arange(self.start, self.stop, self.step, dtype=np.int64)
+        data = np.arange(self.start, self.stop, self.step, dtype=np.int64)
+        data.flags.writeable = False
+        return data
 
     def _get_data_as_items(self) -> list[tuple[str, int]]:
         """return a list of tuples of start, stop, step"""

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -948,3 +948,17 @@ def test_searchsorted(side, value):
         assert result == expected
     else:
         tm.assert_numpy_array_equal(result, expected)
+
+
+def test_rangeindex_data_is_immutable():
+    # GH#67055 - RangeIndex._data should not be modifiable from outside
+    idx = RangeIndex(3)
+    data = idx._data
+
+    with pytest.raises(ValueError, match="read-only"):
+        data[0] = 99
+
+    # Also verify that Series created from a RangeIndex cannot corrupt it
+    ser = pd.Series(idx)
+    ser.iloc[0] = 99
+    tm.assert_index_equal(idx, RangeIndex(3))


### PR DESCRIPTION
## What does this fix

When a `Series` is created from a `RangeIndex`, the underlying cached `_data` array can be modified externally, silently corrupting the index. This happens because `_data` is decorated with `@cache_readonly` but the returned numpy array is writeable.

```python
import pandas as pd

idx = pd.RangeIndex(3)
ser = pd.Series(idx)
ser.iloc[0] = 99
# idx is now corrupted: RangeIndex(start=0, stop=3, step=1) but _data shows [99, 1, 2]
```

## Fix

Mark the `_data` array as read-only (`data.flags.writeable = False`) after construction, consistent with the same pattern used in:
- `DatetimeIndex` (`pandas/core/indexes/datetimelike.py:1041`)
- `MultiIndex` (`pandas/core/indexes/multi.py:5133`)
- `Index.values` (`pandas/core/indexes/base.py:5256`)

## Test

Added `test_rangeindex_data_is_immutable` which verifies:
1. Direct modification of `_data` raises `ValueError`
2. Creating a Series from a RangeIndex and modifying it does not corrupt the original index

Fixes #49663