### PR TITLE
TST: make test_sql.py parallel-safe (GH#60378)

### DIFF
--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -61,7 +61,6 @@ pytestmark = [
     pytest.mark.filterwarnings(
         "ignore:Passing a BlockManager to DataFrame:DeprecationWarning"
     ),
-    pytest.mark.single_cpu,
 ]
 
 
@@ -621,16 +620,45 @@ def skip_if_no_db(name: str, connect) -> None:
         )
 
 
+def _worker_database(base_name: str) -> str:
+    """
+    Name of the database this pytest-xdist worker should use.
+
+    Every worker talks to the same mysql/postgres server, so on one shared
+    database they would also share a single table namespace.  That is not just a
+    matter of colliding table names: the connectable fixtures below tear down by
+    dropping *every* table and view in the database, which would pull tables out
+    from under a test still running on another worker.  A database per worker
+    isolates them; within a worker tests still run one at a time, so reusing
+    table names there stays fine.  Serial runs use ``base_name`` unchanged.
+
+    GH#60378
+    """
+    worker = os.environ.get("PYTEST_XDIST_WORKER")
+    return base_name if worker is None else f"{base_name}_{worker}"
+
+
 @pytest.fixture(scope="module")
 def _mysql_pymysql_engine():
     sqlalchemy = pytest.importorskip("sqlalchemy")
     pymysql = pytest.importorskip("pymysql")
+    connect_args = {"client_flag": pymysql.constants.CLIENT.MULTI_STATEMENTS}
+    server_url = "mysql+pymysql://root@localhost:3306"
+    database = _worker_database("pandas")
+
+    server = sqlalchemy.create_engine(
+        server_url, connect_args=connect_args, poolclass=sqlalchemy.pool.NullPool
+    )
+    skip_if_no_db("mysql", server.connect)
+    with server.begin() as con:
+        con.exec_driver_sql(f"CREATE DATABASE IF NOT EXISTS {database}")
+    server.dispose()
+
     engine = sqlalchemy.create_engine(
-        "mysql+pymysql://root@localhost:3306/pandas",
-        connect_args={"client_flag": pymysql.constants.CLIENT.MULTI_STATEMENTS},
+        f"{server_url}/{database}",
+        connect_args=connect_args,
         poolclass=sqlalchemy.pool.NullPool,
     )
-    skip_if_no_db("mysql", engine.connect)
     yield engine
     engine.dispose()
 
@@ -679,11 +707,28 @@ def mysql_pymysql_conn_types(mysql_pymysql_engine_types):
 def _postgresql_psycopg2_engine():
     sqlalchemy = pytest.importorskip("sqlalchemy")
     pytest.importorskip("psycopg2")
-    engine = sqlalchemy.create_engine(
-        "postgresql+psycopg2://postgres:postgres@localhost:5432/pandas",
+    server_url = "postgresql+psycopg2://postgres:postgres@localhost:5432"
+    database = _worker_database("pandas")
+
+    # CREATE DATABASE runs neither inside a transaction nor from a connection to
+    # the database being created, so go through "postgres" with autocommit.
+    server = sqlalchemy.create_engine(
+        f"{server_url}/postgres",
         poolclass=sqlalchemy.pool.NullPool,
+        isolation_level="AUTOCOMMIT",
     )
-    skip_if_no_db("postgresql", engine.connect)
+    skip_if_no_db("postgresql", server.connect)
+    with server.begin() as con:
+        exists = con.exec_driver_sql(
+            f"SELECT 1 FROM pg_database WHERE datname = '{database}'"
+        ).scalar()
+        if exists is None:
+            con.exec_driver_sql(f"CREATE DATABASE {database}")
+    server.dispose()
+
+    engine = sqlalchemy.create_engine(
+        f"{server_url}/{database}", poolclass=sqlalchemy.pool.NullPool
+    )
     yield engine
     engine.dispose()
 
@@ -722,9 +767,16 @@ def _postgresql_adbc_uri():
     pytest.importorskip("adbc_driver_postgresql")
     from adbc_driver_postgresql import dbapi
 
-    uri = "postgresql://postgres:postgres@localhost:5432/pandas"
-    skip_if_no_db("postgresql (adbc)", lambda: dbapi.connect(uri))
-    return uri
+    server_uri = "postgresql://postgres:postgres@localhost:5432"
+    database = _worker_database("pandas")
+
+    skip_if_no_db("postgresql (adbc)", lambda: dbapi.connect(f"{server_uri}/postgres"))
+    with dbapi.connect(f"{server_uri}/postgres", autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"SELECT 1 FROM pg_database WHERE datname = '{database}'")
+            if cur.fetchone() is None:
+                cur.execute(f"CREATE DATABASE {database}")
+    return f"{server_uri}/{database}"
 
 
 @pytest.fixture


### PR DESCRIPTION
closes #60378

`test_sql.py` is marked `single_cpu`, so its ~1500 tests run serially — about a third of the count in CI's serial `Test (single_cpu)` step.

Colliding table names are only part of why. The bigger obstacle is that the connectable fixtures tear down by dropping *every* table and view in the database, so on a shared server one worker's teardown pulls tables out from under a test still running on another worker. Unique table names alone do not fix that.

Since there is no threading anywhere in the file, all of the contention is cross-process. Giving each xdist worker its own database closes it completely: within a worker tests still run one at a time, so reusing table names stays fine and the drop-everything teardown becomes correct again. Serial runs keep using `pandas` unchanged.

The change is a `_worker_database()` helper threaded into the three module-scoped engine/URI fixtures, plus dropping the marker. **No test bodies are touched.** Postgres has no `CREATE DATABASE IF NOT EXISTS`, so it goes through an AUTOCOMMIT connection to the `postgres` maintenance database with a `pg_database` check; MySQL and ADBC are one statement each. Databases are created if missing and never dropped, which keeps the two Postgres fixtures free of any ordering hazard between them and leaves stale-state behaviour exactly as it is today.

Verified locally against Homebrew MySQL and PostgreSQL 18:

| run | result |
|---|---|
| baseline serial | 1382 passed, 4 failed, 41.8s |
| patched serial | 1382 passed, 4 failed |
| patched `-n 4` ×3, `-n 8`, `-n auto` | 1382 passed, 4 failed — ~9.8s |
| **unpatched `-n 4`** (control) | **57 failed + 211 errors** |
| servers stopped, serial and `-n 4` | 644 passed / 803 skipped |

The 4 failures are identical in every run — `test_datetime_with_timezone_query[...psycopg2...]`, a dtype mismatch from that machine's local timezone rather than UTC. Unrelated to this change.

One new requirement worth flagging: the database user now needs `CREATE DATABASE`. Both CI service containers run as superuser, so this is only a consideration for anyone pointing the tests at a managed server.

Prior attempts GH-60595, GH-61551 and GH-66996 all took the per-test-uuid route.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the teardown as the primary blocker, wrote the fixture changes, and ran the local database verification above.