### PR TITLE
BUG: nansem ignored axis with a mask and skipna=False (GH#65373)

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1245,8 +1245,11 @@ def nansem(
     if values.dtype.kind not in "fc":
         values = values.astype("f8")
 
-    if not skipna and mask is not None and mask.any():
-        return np.nan
+    if not skipna and mask is not None:
+        # For masked arrays, the values underneath `mask` are fill values
+        # rather than NaN, so NaN would not otherwise propagate. GH#65373
+        values = values.copy()
+        np.putmask(values, mask, np.nan)
 
     dtype_count = np.dtype(np.float64)
     if values.dtype.kind == "f":

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1346,12 +1346,7 @@ def test_nanops_independent_of_mask_param(nanops_univariate_methods):
     ],
 )
 @pytest.mark.parametrize("axis", [None, 0, 1])
-def test_nanops_reductions_dont_skip_nan_with_mask(
-    nanops_operation, skipna, axis, request
-):
-    if not skipna and axis in {0, 1} and nanops_operation == "nansem":
-        mark = pytest.mark.xfail(reason="nansem returns a scalar nan")
-        request.applymarker(mark)
+def test_nanops_reductions_dont_skip_nan_with_mask(nanops_operation, skipna, axis):
     if axis is None:
         expected = np.nan
     else:
@@ -1377,6 +1372,19 @@ def test_nanops_reductions_dont_skip_nan_with_mask(
     operation = getattr(nanops, nanops_operation)
     result = operation(values, mask=mask, skipna=skipna, axis=axis)
     tm.assert_equal(result, expected)
+
+
+def test_nansem_partial_mask_no_skipna_is_per_slice():
+    # GH#65373 masked entries propagate NaN only into the slices containing them
+    values = np.arange(25, dtype=np.float64).reshape(5, 5)
+    mask = np.zeros((5, 5), dtype=bool)
+    mask[0, 0] = True
+
+    result = nanops.nansem(values, mask=mask, skipna=False, axis=0)
+    expected = nanops.nanskew(values, mask=mask, skipna=False, axis=0)
+    tm.assert_numpy_array_equal(np.isnan(result), np.isnan(expected))
+    assert np.isnan(result[0])
+    assert not np.isnan(result[1:]).any()
 
 
 @pytest.mark.parametrize("min_count", [-1, 0])


### PR DESCRIPTION
closes #65373

`nansem` kept a scalar early-return, `if not skipna and mask is not None and mask.any(): return np.nan`, added alongside identical lines in `nanskew`/`nankurt`. Those two later moved to `libalgos.scalar_skew`/`axis_skew` and dropped it; `nansem` did not, so it ignored `axis` entirely and returned a scalar `np.nan`.

The early return can't just be deleted: for masked EAs the underlying `_data` holds fill values rather than NaN, so NaN does not propagate through `nanvar` and `Series([1, 2, None], dtype="Int64").sem(skipna=False)` would return a real number instead of `<NA>`. Instead, put NaN under the mask so it propagates per-slice. Results now match `nanskew`/`nankurt` exactly: NaN in slices containing an NA, a real value elsewhere, a scalar for `axis=None`.

Not user-visible, so no whatsnew entry: for float ndarrays `_maybe_get_mask` returns `None` when `skipna=False`, and masked EAs are 1D so `axis=0` correctly yields a scalar. It is only reachable by calling `nanops.nansem` directly, which is what the strict xfail added in GH-65372 was flagging; that xfail is removed here.

Note GH-65378 is an open PR for the same issue, taking a different approach.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which investigated the issue, wrote the fix and tests, and ran the reduction/extension suites.