### PR TITLE
DOC: clarify that interpolate/ffill/bfill limit only partially fills long gaps (GH#36352)

### DIFF
--- a/doc/source/user_guide/missing_data.rst
+++ b/doc/source/user_guide/missing_data.rst
@@ -629,6 +629,12 @@ filled since the last valid observation
    ser.interpolate()
    ser.interpolate(limit=1)
 
+Note that ``limit`` caps how many consecutive ``NaN`` values are filled within
+each gap; it does not skip gaps that are longer than the limit. A gap with more
+consecutive ``NaN`` values than ``limit`` is filled *partially*, as with the
+three ``NaN`` values between ``5`` and ``13`` above. To leave such gaps
+untouched entirely, mask them out afterwards.
+
 By default, ``NaN`` values are filled in a ``forward`` direction. Use
 ``limit_direction`` parameter to fill ``backward`` or from ``both`` directions.
 

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7419,15 +7419,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             other views on this object (e.g., a no-copy slice for a column in a
             DataFrame).
         limit : int, default None
-            If method is specified, this is the maximum number of consecutive
-            NaN values to forward/backward fill. In other words, if there is
-            a gap with more than this number of consecutive NaNs, it will only
-            be partially filled. If method is not specified, this is the
-            maximum number of entries along the entire axis where NaNs will be
-            filled. Must be greater than 0 if not None.
+            Maximum number of consecutive NaN values to fill. In other words, if
+            there is a gap with more than this number of consecutive NaNs, it
+            will only be partially filled. Must be greater than 0 if not None.
         limit_area : {`None`, 'inside', 'outside'}, default None
-            If limit is specified, consecutive NaNs will be filled with this
-            restriction.
+            Restrict which NaNs are filled based on their position relative to
+            the valid values.
 
             * ``None``: No fill restriction.
             * 'inside': Only fill NaNs surrounded by valid values
@@ -7525,15 +7522,12 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             other views on this object (e.g., a no-copy slice for a column in a
             DataFrame).
         limit : int, default None
-            If method is specified, this is the maximum number of consecutive
-            NaN values to forward/backward fill. In other words, if there is
-            a gap with more than this number of consecutive NaNs, it will only
-            be partially filled. If method is not specified, this is the
-            maximum number of entries along the entire axis where NaNs will be
-            filled. Must be greater than 0 if not None.
+            Maximum number of consecutive NaN values to fill. In other words, if
+            there is a gap with more than this number of consecutive NaNs, it
+            will only be partially filled. Must be greater than 0 if not None.
         limit_area : {`None`, 'inside', 'outside'}, default None
-            If limit is specified, consecutive NaNs will be filled with this
-            restriction.
+            Restrict which NaNs are filled based on their position relative to
+            the valid values.
 
             * ``None``: No fill restriction.
             * 'inside': Only fill NaNs surrounded by valid values
@@ -8176,16 +8170,18 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             Axis to interpolate along. For `Series` this parameter is unused
             and defaults to 0.
         limit : int, optional
-            Maximum number of consecutive NaNs to fill. Must be greater than
-            0.
+            Maximum number of consecutive NaNs to fill. In other words, if there
+            is a gap with more than this number of consecutive NaNs, it will only
+            be partially filled, from the direction given by ``limit_direction``.
+            Must be greater than 0.
         inplace : bool, default False
             Update the data in place if possible.
         limit_direction : {'forward', 'backward', 'both'}, optional, default 'forward'
             Consecutive NaNs will be filled in this direction.
 
         limit_area : {`None`, 'inside', 'outside'}, default None
-            If limit is specified, consecutive NaNs will be filled with this
-            restriction.
+            Restrict which NaNs are filled based on their position relative to
+            the valid values.
 
             * ``None``: No fill restriction.
             * 'inside': Only fill NaNs surrounded by valid values

--- a/pandas/core/resample.py
+++ b/pandas/core/resample.py
@@ -896,14 +896,16 @@ class Resampler(BaseGroupBy, PandasObject):
             Axis to interpolate along. For `Series` this parameter is unused
             and defaults to 0.
         limit : int, optional
-            Maximum number of consecutive NaNs to fill. Must be greater than
-            0.
+            Maximum number of consecutive NaNs to fill. In other words, if there
+            is a gap with more than this number of consecutive NaNs, it will only
+            be partially filled, from the direction given by ``limit_direction``.
+            Must be greater than 0.
         limit_direction : {'forward', 'backward', 'both'}, Optional
             Consecutive NaNs will be filled in this direction.
 
         limit_area : {`None`, 'inside', 'outside'}, default None
-            If limit is specified, consecutive NaNs will be filled with this
-            restriction.
+            Restrict which NaNs are filled based on their position relative to
+            the valid values.
 
             * ``None``: No fill restriction.
             * 'inside': Only fill NaNs surrounded by valid values


### PR DESCRIPTION
closes #36352

`limit` caps how many consecutive NaNs are filled within *each* gap; it does not skip gaps that are longer than the limit. A gap longer than `limit` is filled partially, from the `limit_direction` end. That is the documented and intended behavior, but `interpolate` only said "Maximum number of consecutive NaNs to fill", which several reporters read as "gaps longer than this are left alone" — the misreading behind this issue and GH-64588. `ffill`/`bfill` already spell it out; this copies that sentence over to `interpolate` (both `NDFrame.interpolate` and `Resampler.interpolate`) and adds a note to the missing-data user guide next to the existing `limit=1` example.

Two adjacent fixes in the same paragraphs:

- The `limit_area` lead-in claimed "If limit is specified, consecutive NaNs will be filled with this restriction." `limit_area` works with no `limit` at all (`ser.ffill(limit_area="inside")`), so this is replaced with a statement of what the parameter actually does. Applies to `ffill`, `bfill`, `NDFrame.interpolate`, and `Resampler.interpolate`.
- The `ffill`/`bfill` `limit` text branched on "If method is specified" / "If method is not specified", left over from `fillna(method=)` — neither method has a `method` parameter, and `fillna` lost it in 3.0. Dropped both branches.

Docs only, no behavior change. The `max_gap`-style enhancement people actually want in these threads is GH-64588 (earlier attempt: GH-25141), which this does not implement.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the report against main, traced the wording to its source docstrings, and wrote the doc changes under my review.