### PR TITLE
TST: add match argument to PerformanceWarning assert_produces_warning calls

### DIFF
--- a/pandas/tests/arithmetic/test_datetime64.py
+++ b/pandas/tests/arithmetic/test_datetime64.py
@@ -1007,7 +1007,8 @@ class TestDatetime64Arithmetic:
         obj = tm.box_expected(dti, box_with_array)
         expected = tm.box_expected(expected, box_with_array).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             result = obj - obj.astype(object)
         tm.assert_equal(result, expected)
 
@@ -1498,7 +1499,8 @@ class TestDatetime64DateOffsetArithmetic:
         expected = DatetimeIndex([op(dti[n], other[n]) for n in range(len(dti))])
         expected = tm.box_expected(expected, box_with_array).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res = op(dtarr, other)
         tm.assert_equal(res, expected)
 
@@ -1507,7 +1509,7 @@ class TestDatetime64DateOffsetArithmetic:
         if box_with_array is pd.array and op is roperator.radd:
             # We expect a NumpyExtensionArray, not ndarray[object] here
             expected = pd.array(expected, dtype=object)
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res = op(dtarr, other)
         tm.assert_equal(res, expected)
 
@@ -2534,7 +2536,8 @@ class TestDatetimeIndexArithmetic:
 
         xbox = get_upcast_box(dti, other)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res = op(dti, other)
 
         expected = DatetimeIndex(
@@ -2557,14 +2560,15 @@ class TestDatetimeIndexArithmetic:
         expected = DatetimeIndex(["2017-01-31", "2017-01-06"], tz=tz_naive_fixture)
         expected = tm.box_expected(expected, xbox).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             result = dtarr + other
         tm.assert_equal(result, expected)
 
         expected = DatetimeIndex(["2016-12-31", "2016-12-29"], tz=tz_naive_fixture)
         expected = tm.box_expected(expected, xbox).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             result = dtarr - other
         tm.assert_equal(result, expected)
 
@@ -2599,14 +2603,15 @@ def test_dt64arr_addsub_object_dtype_2d(performance_warning):
     other = np.array([[pd.offsets.Day(n)] for n in range(4)])
     assert other.shape == dta.shape
 
-    with tm.assert_produces_warning(performance_warning):
+    msg = "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
+    with tm.assert_produces_warning(performance_warning, match=msg):
         result = dta + other
-    with tm.assert_produces_warning(performance_warning):
+    with tm.assert_produces_warning(performance_warning, match=msg):
         expected = (dta[:, 0] + other[:, 0]).reshape(-1, 1)
 
     tm.assert_numpy_array_equal(result, expected)
 
-    with tm.assert_produces_warning(performance_warning):
+    with tm.assert_produces_warning(performance_warning, match=msg):
         # Case where we expect to get a TimedeltaArray back
         result2 = dta - dta.astype(object)
 

--- a/pandas/tests/arithmetic/test_period.py
+++ b/pandas/tests/arithmetic/test_period.py
@@ -746,11 +746,12 @@ class TestPeriodIndexArithmetic:
         )
         expected = PeriodIndex([Period("2015Q2"), Period("2015Q4")]).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        warn_msg = "Adding/subtracting object-dtype array to PeriodArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=warn_msg):
             res = pi + offs
         tm.assert_index_equal(res, expected)
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=warn_msg):
             res2 = offs + pi
         tm.assert_index_equal(res2, expected)
 
@@ -759,10 +760,10 @@ class TestPeriodIndexArithmetic:
         # a PerformanceWarning and _then_ raise a TypeError.
         msg = r"Input cannot be converted to Period\(freq=Q-DEC\)"
         with pytest.raises(IncompatibleFrequency, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 pi + unanchored
         with pytest.raises(IncompatibleFrequency, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 unanchored + pi
 
     @pytest.mark.parametrize("box", [np.array, pd.Index])
@@ -779,7 +780,8 @@ class TestPeriodIndexArithmetic:
         expected = PeriodIndex([pi[n] - other[n] for n in range(len(pi))])
         expected = expected.astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        warn_msg = "Adding/subtracting object-dtype array to PeriodArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=warn_msg):
             res = pi - other
         tm.assert_index_equal(res, expected)
 
@@ -789,10 +791,10 @@ class TestPeriodIndexArithmetic:
         # a PerformanceWarning and _then_ raise a TypeError.
         msg = r"Input has different freq=-1M from Period\(freq=Q-DEC\)"
         with pytest.raises(IncompatibleFrequency, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 pi - anchored
         with pytest.raises(IncompatibleFrequency, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 anchored - pi
 
     def test_pi_add_iadd_int(self, one):
@@ -1202,7 +1204,8 @@ class TestPeriodIndexArithmetic:
 
         other = np.array([Timedelta(days=1), pd.offsets.Day(2), 3])
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to PeriodArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             result = parr + other
 
         expected = PeriodIndex(
@@ -1210,7 +1213,7 @@ class TestPeriodIndexArithmetic:
         )._data.astype(object)
         tm.assert_equal(result, expected)
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             result = parr - other
 
         expected = PeriodIndex(["2000-12-30"] * 3, freq="D")._data.astype(object)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -618,7 +618,8 @@ class TestTimedelta64ArithmeticUnsorted:
         obj = tm.box_expected(tdi, box)
         other = tm.box_expected(dti, box)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to TimedeltaArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             result = obj + other.astype(object)
         tm.assert_equal(result, other.astype(object))
 
@@ -1422,15 +1423,16 @@ class TestTimedeltaArraylikeAddSubOps:
         expected = tm.box_expected(expected, box).astype(object)
         expected_sub = tm.box_expected(expected_sub, box).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to TimedeltaArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res = tdi + other
         tm.assert_equal(res, expected)
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res2 = other + tdi
         tm.assert_equal(res2, expected)
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res_sub = tdi - other
         tm.assert_equal(res_sub, expected_sub)
 
@@ -1450,16 +1452,17 @@ class TestTimedeltaArraylikeAddSubOps:
         tdi = tm.box_expected(tdi, box)
         expected = tm.box_expected(expected, box).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to TimedeltaArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res = tdi + other
         tm.assert_equal(res, expected)
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res2 = other + tdi
         tm.assert_equal(res2, expected)
 
         expected_sub = tm.box_expected(expected_sub, box_with_array).astype(object)
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res_sub = tdi - other
         tm.assert_equal(res_sub, expected_sub)
 
@@ -1480,11 +1483,12 @@ class TestTimedeltaArraylikeAddSubOps:
         obj = tm.box_expected(tdi, box)
         expected_add = tm.box_expected(expected_add, box2).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Adding/subtracting object-dtype array to TimedeltaArray not vectorized"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res = obj + other
         tm.assert_equal(res, expected_add)
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res2 = other + obj
         tm.assert_equal(res2, expected_add)
 
@@ -1493,7 +1497,7 @@ class TestTimedeltaArraylikeAddSubOps:
         )
         expected_sub = tm.box_expected(expected_sub, box2).astype(object)
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=msg):
             res3 = obj - other
         tm.assert_equal(res3, expected_sub)
 
@@ -1511,16 +1515,19 @@ class TestTimedeltaArraylikeAddSubOps:
         # a PerformanceWarning and _then_ raise a TypeError.
         msg = "|".join(["has incorrect type", "cannot add the type MonthEnd"])
         with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            warn_msg = (
+                "Adding/subtracting object-dtype array to TimedeltaArray not vectorized"
+            )
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 tdi + anchored
         with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 anchored + tdi
         with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 tdi - anchored
         with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 anchored - tdi
 
     # ------------------------------------------------------------------
@@ -1535,7 +1542,10 @@ class TestTimedeltaArraylikeAddSubOps:
 
         other = np.array([Timedelta(days=1), offsets.Day(2), Timestamp("2000-01-04")])
 
-        with tm.assert_produces_warning(performance_warning):
+        warn_msg = (
+            "Adding/subtracting object-dtype array to TimedeltaArray not vectorized"
+        )
+        with tm.assert_produces_warning(performance_warning, match=warn_msg):
             result = tdarr + other
 
         expected = Index(
@@ -1546,10 +1556,10 @@ class TestTimedeltaArraylikeAddSubOps:
 
         msg = "|".join(["unsupported operand type", "cannot subtract a datelike"])
         with pytest.raises(TypeError, match=msg):
-            with tm.assert_produces_warning(performance_warning):
+            with tm.assert_produces_warning(performance_warning, match=warn_msg):
                 tdarr - other
 
-        with tm.assert_produces_warning(performance_warning):
+        with tm.assert_produces_warning(performance_warning, match=warn_msg):
             result = other - tdarr
 
         expected = Index([Timedelta(0), Timedelta(0), Timestamp("2000-01-01")])
@@ -2214,7 +2224,10 @@ class TestTimedeltaArraylikeMulDivOps:
         else:
             performance_warning = False
 
-        with tm.assert_produces_warning(performance_warning):
+        warn_msg = (
+            "Adding/subtracting object-dtype array to TimedeltaArray not vectorized"
+        )
+        with tm.assert_produces_warning(performance_warning, match=warn_msg):
             result = divmod(tdarr, three_days)
 
         tm.assert_equal(result[1], expected)

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -307,7 +307,10 @@ class TestSparseArray(base.ExtensionTests):
         tm.assert_series_equal(result, expected)
 
     def test_searchsorted(self, performance_warning, data_for_sorting, as_series):
-        with tm.assert_produces_warning(performance_warning, check_stacklevel=False):
+        msg = "searchsorted requires high memory usage"
+        with tm.assert_produces_warning(
+            performance_warning, check_stacklevel=False, match=msg
+        ):
             super().test_searchsorted(data_for_sorting, as_series)
 
     def test_sort_inplace(self, data_for_sorting):

--- a/pandas/tests/frame/methods/test_drop.py
+++ b/pandas/tests/frame/methods/test_drop.py
@@ -191,7 +191,8 @@ class TestDataFrameDrop:
         assert not not_lexsorted_df.columns._is_lexsorted()
 
         expected = lexsorted_df.drop("a", axis=1).astype(float)
-        with tm.assert_produces_warning(performance_warning):
+        msg = "dropping on a non-lexsorted multi-index without a level parameter"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             result = not_lexsorted_df.drop("a", axis=1)
 
         tm.assert_frame_equal(result, expected)

--- a/pandas/tests/frame/test_block_internals.py
+++ b/pandas/tests/frame/test_block_internals.py
@@ -333,8 +333,9 @@ class TestDataFrameBlockInternals:
         df[0] = np.nan
         wasCol = {}
 
+        msg = "DataFrame is highly fragmented"
         with tm.assert_produces_warning(
-            performance_warning, raise_on_extra_warnings=False
+            performance_warning, raise_on_extra_warnings=False, match=msg
         ):
             for i, dt in enumerate(df.index):
                 for col in range(100, 200):

--- a/pandas/tests/groupby/test_groupby.py
+++ b/pandas/tests/groupby/test_groupby.py
@@ -1574,7 +1574,8 @@ def test_groupby_multiindex_not_lexsorted(performance_warning):
     assert not not_lexsorted_df.columns._is_lexsorted()
 
     expected = lexsorted_df.groupby("a").mean()
-    with tm.assert_produces_warning(performance_warning):
+    msg = "dropping on a non-lexsorted multi-index without a level parameter"
+    with tm.assert_produces_warning(performance_warning, match=msg):
         result = not_lexsorted_df.groupby("a").mean()
     tm.assert_frame_equal(expected, result)
 

--- a/pandas/tests/indexes/datetimes/methods/test_shift.py
+++ b/pandas/tests/indexes/datetimes/methods/test_shift.py
@@ -170,7 +170,8 @@ class TestDatetimeIndexShift:
             freq=pd.offsets.BMonthEnd(),
             unit=unit,
         )
-        with tm.assert_produces_warning(performance_warning):
+        msg = "Non-vectorized DateOffset being applied to Series or DatetimeIndex"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             shifted = rng.shift(1, freq=pd.offsets.CDay())
             assert shifted[0] == rng[0] + pd.offsets.CDay()
 

--- a/pandas/tests/indexes/multi/test_drop.py
+++ b/pandas/tests/indexes/multi/test_drop.py
@@ -138,7 +138,8 @@ def test_drop_not_lexsorted(performance_warning):
 
     # compare the results
     tm.assert_index_equal(lexsorted_mi, not_lexsorted_mi)
-    with tm.assert_produces_warning(performance_warning):
+    msg = "dropping on a non-lexsorted multi-index without a level parameter"
+    with tm.assert_produces_warning(performance_warning, match=msg):
         tm.assert_index_equal(lexsorted_mi.drop("a"), not_lexsorted_mi.drop("a"))
 
 

--- a/pandas/tests/indexes/multi/test_indexing.py
+++ b/pandas/tests/indexes/multi/test_indexing.py
@@ -760,7 +760,8 @@ class TestGetLoc:
         )
         key = ("a", 7)
 
-        with tm.assert_produces_warning(performance_warning):
+        msg = "indexing past lexsort depth may impact performance"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             # PerformanceWarning: indexing past lexsort depth may impact performance
             result = idx.get_loc(key)
 

--- a/pandas/tests/indexing/multiindex/test_multiindex.py
+++ b/pandas/tests/indexing/multiindex/test_multiindex.py
@@ -31,7 +31,8 @@ class TestMultiIndexBasic:
 
         # Partial key still goes through lexsort path
         df = df.iloc[[2, 1, 3, 0]]
-        with tm.assert_produces_warning(performance_warning):
+        msg = "indexing past lexsort depth may impact performance"
+        with tm.assert_produces_warning(performance_warning, match=msg):
             df.loc[(0,)]
 
     @pytest.mark.parametrize("offset", [-5, 5])

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -585,7 +585,8 @@ def test_tuple_index(temp_h5_path, performance_warning):
     data = np.random.default_rng(2).standard_normal(30).reshape((3, 10))
     DF = DataFrame(data, index=idx, columns=col)
 
-    with tm.assert_produces_warning(performance_warning):
+    msg = "your performance may suffer as PyTables will pickle object types"
+    with tm.assert_produces_warning(performance_warning, match=msg):
         _check_roundtrip(DF, tm.assert_frame_equal, path=temp_h5_path)
 
 

--- a/pandas/tests/reshape/merge/test_merge.py
+++ b/pandas/tests/reshape/merge/test_merge.py
@@ -3057,7 +3057,8 @@ def test_merge_multiindex_reset_index_mixed():
         columns=MultiIndex.from_product([["new_data"], [""]]),
     )
 
-    with tm.assert_produces_warning(pd.errors.PerformanceWarning):
+    msg = "dropping on a non-lexsorted multi-index without a level parameter"
+    with tm.assert_produces_warning(pd.errors.PerformanceWarning, match=msg):
         result = df.reset_index().merge(df2.reset_index(), on="index")
 
     expected = DataFrame(

--- a/pandas/tests/tseries/offsets/test_offsets.py
+++ b/pandas/tests/tseries/offsets/test_offsets.py
@@ -529,25 +529,26 @@ class TestCommon:
         # stacklevel checking is slow, and we have ~800 of variants of this
         #  test, so let's only check the stacklevel in a subset of them
         check_stacklevel = tz_naive_fixture is None
+        msg = "Non-vectorized DateOffset being applied to Series or DatetimeIndex"
         with tm.assert_produces_warning(
-            performance_warning, check_stacklevel=check_stacklevel
+            performance_warning, check_stacklevel=check_stacklevel, match=msg
         ):
             result = dti + offset_s
         tm.assert_index_equal(result, dti)
         with tm.assert_produces_warning(
-            performance_warning, check_stacklevel=check_stacklevel
+            performance_warning, check_stacklevel=check_stacklevel, match=msg
         ):
             result = offset_s + dti
         tm.assert_index_equal(result, dti)
 
         dta = dti._data
         with tm.assert_produces_warning(
-            performance_warning, check_stacklevel=check_stacklevel
+            performance_warning, check_stacklevel=check_stacklevel, match=msg
         ):
             result = dta + offset_s
         tm.assert_equal(result, dta)
         with tm.assert_produces_warning(
-            performance_warning, check_stacklevel=check_stacklevel
+            performance_warning, check_stacklevel=check_stacklevel, match=msg
         ):
             result = offset_s + dta
         tm.assert_equal(result, dta)
@@ -1290,7 +1291,8 @@ def test_dateoffset_operations_on_dataframes(performance_warning):
         }
     )
     expecteddate = Timestamp("2021-06-30")
-    with tm.assert_produces_warning(performance_warning):
+    msg = "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
+    with tm.assert_produces_warning(performance_warning, match=msg):
         frameresult2 = df2["T"] + 26 * df2["D"]
 
     assert frameresult1[0] == expecteddate


### PR DESCRIPTION
- [x] xref GH-58290
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

First batch of GH-58290. Fills in `match` for every bare `tm.assert_produces_warning` call whose expected warning is a `PerformanceWarning` — 51 call sites across 14 files, no behaviour change beyond the tests now checking the message users actually see.

The 51 sites reduce to nine distinct messages:

| sites | message |
|---|---|
| 18 | `Adding/subtracting object-dtype array to TimedeltaArray not vectorized` |
| 10 | `...to DatetimeArray not vectorized` |
| 9 | `...to PeriodArray not vectorized` |
| 5 | `Non-vectorized DateOffset being applied to Series or DatetimeIndex` |
| 4 | `dropping on a non-lexsorted multi-index without a level parameter` |
| 2 | `indexing past lexsort depth may impact performance` |
| 1 each | `searchsorted requires high memory usage`, `DataFrame is highly fragmented`, `your performance may suffer as PyTables will pickle object types` |

Messages were taken from what the tests actually emit rather than from reading the warning sites, which matters in at least one case: the PyTables warning wraps across a newline (`...it cannot\nmap directly to c-types...`), so the obvious `match` fails under `re.search` without `DOTALL`.

Most of these go through the `performance_warning` fixture, which yields `False` when `mode.performance_warnings` is off. That is unaffected — `assert_produces_warning` only consults `match` under `if expected_warning:`, so the perf-warnings-off parametrization still passes.

Draft: putting the remaining clusters up separately so each stays reviewable. No `closes` line — this is one batch of GH-58290, not the whole thing.