### PR TITLE
TST: add match argument to plotting assert_produces_warning calls

### DIFF
--- a/pandas/tests/plotting/frame/test_frame_color.py
+++ b/pandas/tests/plotting/frame/test_frame_color.py
@@ -230,7 +230,10 @@ class TestDataFrameColor:
         )
         df["species"] = ["r", "r", "g", "g", "b"]
         if cmap is not None:
-            with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+            msg = "No data for colormapping provided via 'c'"
+            with tm.assert_produces_warning(
+                UserWarning, check_stacklevel=False, match=msg
+            ):
                 ax = df.plot.scatter(x=0, y=1, cmap=cmap, c="species")
         else:
             ax = df.plot.scatter(x=0, y=1, c="species", cmap=cmap)

--- a/pandas/tests/plotting/frame/test_hist_box_by.py
+++ b/pandas/tests/plotting/frame/test_hist_box_by.py
@@ -146,7 +146,8 @@ class TestHistWithBy:
     def test_hist_plot_layout_with_by(self, by, column, layout, axes_num, hist_df):
         # GH 15079
         # _check_plot_works adds an ax so catch warning. see GH #13188
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(
                 hist_df.plot.hist, column=column, by=by, layout=layout
             )

--- a/pandas/tests/plotting/test_boxplot_method.py
+++ b/pandas/tests/plotting/test_boxplot_method.py
@@ -86,7 +86,8 @@ class TestDataFramePlots:
         df["indic2"] = ["foo", "bar", "foo"] * 2
 
         # _check_plot_works can add an ax so catch warning. see GH #13188
-        with tm.assert_produces_warning(warn, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(warn, check_stacklevel=False, match=msg):
             _check_plot_works(df.boxplot, **kwargs)
 
     def test_boxplot_legacy1_series(self):
@@ -99,7 +100,8 @@ class TestDataFramePlots:
         )
         df["X"] = Series(["A", "A", "A", "A", "A", "B", "B", "B", "B", "B"])
         df["Y"] = Series(["A"] * 10)
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             _check_plot_works(df.boxplot, by="X")
 
     def test_boxplot_legacy2_with_ax(self):
@@ -404,7 +406,8 @@ class TestDataFramePlots:
 class TestDataFrameGroupByPlots:
     def test_boxplot_legacy1(self, hist_df):
         grouped = hist_df.groupby(by="gender")
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(grouped.boxplot, return_type="axes")
         _check_axes_shape(list(axes.values), axes_num=2, layout=(1, 2))
 
@@ -423,7 +426,8 @@ class TestDataFrameGroupByPlots:
             index=MultiIndex.from_tuples(tuples),
         )
         grouped = df.groupby(level=1)
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(grouped.boxplot, return_type="axes")
         _check_axes_shape(list(axes.values), axes_num=10, layout=(4, 3))
 
@@ -549,7 +553,8 @@ class TestDataFrameGroupByPlots:
     ):
         df = hist_df
         # _check_plot_works adds an ax so catch warning. see GH #13188 GH 6769
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             _check_plot_works(
                 df.groupby(gb_key).boxplot, column="height", return_type="dict"
             )
@@ -582,7 +587,8 @@ class TestDataFrameGroupByPlots:
     @pytest.mark.parametrize("cols", [2, -1])
     def test_grouped_box_layout_works(self, hist_df, cols):
         df = hist_df
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             _check_plot_works(
                 df.groupby("category").boxplot,
                 column="height",

--- a/pandas/tests/plotting/test_hist_method.py
+++ b/pandas/tests/plotting/test_hist_method.py
@@ -49,7 +49,8 @@ class TestSeriesPlots:
     @pytest.mark.parametrize("kwargs", [{}, {"bins": 5}])
     def test_hist_legacy_kwargs_warning(self, ts, kwargs):
         # _check_plot_works adds an ax so catch warning. see GH #13188
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             _check_plot_works(ts.hist, by=ts.index.month, **kwargs)
 
     @pytest.mark.parametrize("by", [None, np.array(list("aabbaabbaa"))])
@@ -126,7 +127,8 @@ class TestSeriesPlots:
         # _check_plot_works adds an `ax` kwarg to the method call
         # so we get a warning about an axis being cleared, even
         # though we don't explicitly pass one, see GH #13188
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(df.height.hist, by=getattr(df, by), layout=layout)
         _check_axes_shape(axes, axes_num=axes_num, layout=res_layout)
 
@@ -269,7 +271,8 @@ class TestDataFramePlots:
 
     @pytest.mark.slow
     def test_hist_df_legacy(self, hist_df):
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             _check_plot_works(hist_df.hist)
 
     @pytest.mark.slow
@@ -284,7 +287,8 @@ class TestDataFramePlots:
                 dtype=np.int64,
             )
         )
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(df.hist, grid=False)
         _check_axes_shape(axes, axes_num=3, layout=(2, 2))
         assert not axes[1, 1].get_visible()
@@ -308,7 +312,8 @@ class TestDataFramePlots:
                 dtype=np.int64,
             )
         )
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(df.hist, layout=(4, 2))
         _check_axes_shape(axes, axes_num=6, layout=(4, 2))
 
@@ -329,7 +334,8 @@ class TestDataFramePlots:
         # make sure sharex, sharey is handled
         # handle figsize arg
         # check bins argument
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             _check_plot_works(df.hist, **kwargs)
 
     @pytest.mark.slow
@@ -852,7 +858,8 @@ class TestDataFrameGroupByPlots:
     @pytest.mark.slow
     def test_grouped_hist_layout_warning(self, hist_df):
         df = hist_df
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(
                 df.hist, column="height", by=df.gender, layout=(2, 1)
             )
@@ -873,7 +880,8 @@ class TestDataFrameGroupByPlots:
     def test_grouped_hist_layout_by_warning(self, hist_df, kwargs):
         df = hist_df
         # GH 6769
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(df.hist, by="classroom", **kwargs)
         _check_axes_shape(axes, axes_num=3, layout=(2, 2))
 

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -171,7 +171,8 @@ class TestDataFramePlots:
         df = DataFrame(np.random.default_rng(2).standard_normal((10, 3)))
 
         # we are plotting multiples on a sub-plot
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(
                 scatter_matrix,
                 frame=df,
@@ -197,7 +198,8 @@ class TestDataFramePlots:
         df[0] = (df[0] - 2) / 3
 
         # we are plotting multiples on a sub-plot
-        with tm.assert_produces_warning(UserWarning, check_stacklevel=False):
+        msg = "the figure containing the passed axes is being cleared"
+        with tm.assert_produces_warning(UserWarning, check_stacklevel=False, match=msg):
             axes = _check_plot_works(
                 scatter_matrix,
                 frame=df,


### PR DESCRIPTION
- [x] xref GH-58290
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Second batch of GH-58290, after GH-67070. Fills in `match` for the bare `tm.assert_produces_warning` calls under `pandas/tests/plotting` — 18 call sites across 5 files.

17 of them are the same warning, raised by `_check_plot_works` adding an axes:

> To output multiple subplots, the figure containing the passed axes is being cleared.

The full sentence does not fit in 88 columns as a `match=` argument, so these match on the distinctive tail, `"the figure containing the passed axes is being cleared"`. The 18th is the scatter `cmap` warning in `test_frame_color.py`.

After this there are no bare `assert_produces_warning` calls left anywhere under `pandas/tests/plotting`.

No `closes` line — this is one batch of GH-58290, not the whole thing.