### PR TITLE
TST: un-xfail test_add_matplotlib_datetime64

### DIFF
--- a/pandas/tests/plotting/test_datetimelike.py
+++ b/pandas/tests/plotting/test_datetimelike.py
@@ -1930,19 +1930,15 @@ class TestTSPlot:
         s2.plot(ax=ax)
         s1.plot(ax=ax)
 
-    @pytest.mark.xfail(reason="GH9053 matplotlib does not use ax.xaxis.converter")
     def test_add_matplotlib_datetime64(self):
-        # GH9053 - ensure that a plot with PeriodConverter still understands
-        # datetime64 data. This still fails because matplotlib overrides the
-        # ax.xaxis.converter with a DatetimeConverter
+        # GH#9053 - ensure that a plot with PeriodConverter still understands
+        # datetime64 data
         s = Series(
             np.random.default_rng(2).standard_normal(10),
             index=date_range("1970-01-02", periods=10),
         )
         ax = s.plot()
-        with tm.assert_produces_warning(DeprecationWarning):
-            # multi-dimensional indexing
-            ax.plot(s.index, s.values, color="g")
+        ax.plot(s.index, s.values, color="g")
         l1, l2 = ax.lines
         tm.assert_numpy_array_equal(l1.get_xydata(), l2.get_xydata())
 


### PR DESCRIPTION
- [x] closes GH-9053
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

GH-9053 (2014) reports that adding a line to a timeseries plot with `DatetimeIndex` or `datetime64` x-values plots it "at a totally wrong place outside of sight". That no longer reproduces — both forms from the issue overlay the pandas-drawn line exactly, on matplotlib 3.10.8:

```python
fig, ax = plt.subplots()
ser.plot(ax=ax)
ax.plot(ser.index, ser.values, color="g")          # xydata matches
ax.plot(ser.index.values, ser.values, color="r")   # xydata matches
```

Checked for `freq="min"` (the issue's own repro) and `freq="D"`.

`test_add_matplotlib_datetime64` has been carrying `@pytest.mark.xfail(reason="GH9053 matplotlib does not use ax.xaxis.converter")`, but that reason is stale — under `--runxfail` the failure is not the converter:

```
E   AssertionError: Did not see expected warning of class 'DeprecationWarning'
```

The test wrapped its `ax.plot` call in `tm.assert_produces_warning(DeprecationWarning)` for matplotlib's old "multi-dimensional indexing" deprecation, which matplotlib removed years ago. So the test failed on the warning assertion and never reached the converter assertion it exists to make. Dropping the wrapper lets it test what it claims to, and it passes.

No whatsnew: nothing in pandas changes here, the underlying issue was fixed upstream in matplotlib.

Found while filling in `match=` arguments for GH-58290 (GH-67070, GH-67071) — a `match=` on that assertion would have surfaced the message going away when it went away.