### PR TITLE
TST: add match argument to Pandas4Warning assert_produces_warning calls

### DIFF
--- a/pandas/tests/copy_view/test_astype.py
+++ b/pandas/tests/copy_view/test_astype.py
@@ -201,7 +201,8 @@ def test_astype_arrow_timestamp():
 def test_convert_dtypes_infer_objects():
     ser = Series(["a", "b", "c"])
     ser_orig = ser.copy()
-    with tm.assert_produces_warning(Pandas4Warning):
+    msg = "keyword in Series.convert_dtypes is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = ser.convert_dtypes(
             convert_integer=False,
             convert_boolean=False,

--- a/pandas/tests/frame/methods/test_convert_dtypes.py
+++ b/pandas/tests/frame/methods/test_convert_dtypes.py
@@ -24,7 +24,8 @@ class TestConvertDtypes:
             }
         )
         with pd.option_context("string_storage", string_storage):
-            with tm.assert_produces_warning(Pandas4Warning):
+            msg = "keyword in DataFrame.convert_dtypes is deprecated"
+            with tm.assert_produces_warning(Pandas4Warning, match=msg):
                 result = df.convert_dtypes(True, True, convert_integer, False)
         expected = pd.DataFrame(
             {
@@ -170,7 +171,8 @@ class TestConvertDtypes:
         pytest.importorskip("pyarrow")
         df = pd.DataFrame({"a": [1, 2], "b": 1.5, "c": True, "d": "x"})
         expected = df.copy()
-        with tm.assert_produces_warning(Pandas4Warning):
+        msg = "keyword in DataFrame.convert_dtypes is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = df.convert_dtypes(
                 convert_floating=False,
                 convert_integer=False,
@@ -199,7 +201,8 @@ class TestConvertDtypes:
     def test_convert_dtypes_avoid_block_splitting(self):
         # GH#55341
         df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": "a"})
-        with tm.assert_produces_warning(Pandas4Warning):
+        msg = "The convert_integer keyword in DataFrame.convert_dtypes is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = df.convert_dtypes(convert_integer=False)
         expected = pd.DataFrame(
             {

--- a/pandas/tests/frame/methods/test_reindex_like.py
+++ b/pandas/tests/frame/methods/test_reindex_like.py
@@ -24,10 +24,11 @@ class TestDataFrameReindexLike:
     def test_reindex_like_methods(self, method, expected_values):
         df = DataFrame({"x": list(range(5))})
 
-        with tm.assert_produces_warning(Pandas4Warning):
+        msg = "the 'method' keyword is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = df.reindex_like(df, method=method, tolerance=0)
         tm.assert_frame_equal(df, result)
-        with tm.assert_produces_warning(Pandas4Warning):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = df.reindex_like(df, method=method, tolerance=[0, 0, 0, 0])
         tm.assert_frame_equal(df, result)
 

--- a/pandas/tests/groupby/aggregate/test_cython.py
+++ b/pandas/tests/groupby/aggregate/test_cython.py
@@ -323,7 +323,8 @@ def test_cython_agg_nullable_int(op_name):
         convert_integer = False
     else:
         convert_integer = True
-    with tm.assert_produces_warning(Pandas4Warning):
+    msg = "The convert_integer keyword in Series.convert_dtypes is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         expected = expected.convert_dtypes(convert_integer=convert_integer)
     tm.assert_series_equal(result, expected)
 

--- a/pandas/tests/indexes/period/test_period.py
+++ b/pandas/tests/indexes/period/test_period.py
@@ -42,7 +42,8 @@ class TestPeriodIndex:
         idx = PeriodIndex([], freq="M")
 
         exp = np.array([], dtype=object)
-        with tm.assert_produces_warning(Pandas4Warning):
+        msg = "PeriodIndex.values returning an object-dtype ndarray is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             tm.assert_numpy_array_equal(idx.values, exp)
         tm.assert_numpy_array_equal(idx.to_numpy(), exp)
 
@@ -52,7 +53,7 @@ class TestPeriodIndex:
         idx = PeriodIndex(["2011-01", NaT], freq="M")
 
         exp = np.array([Period("2011-01", freq="M"), NaT], dtype=object)
-        with tm.assert_produces_warning(Pandas4Warning):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             tm.assert_numpy_array_equal(idx.values, exp)
         tm.assert_numpy_array_equal(idx.to_numpy(), exp)
         exp = np.array([492, -9223372036854775808], dtype=np.int64)
@@ -61,7 +62,7 @@ class TestPeriodIndex:
         idx = PeriodIndex(["2011-01-01", NaT], freq="D")
 
         exp = np.array([Period("2011-01-01", freq="D"), NaT], dtype=object)
-        with tm.assert_produces_warning(Pandas4Warning):
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             tm.assert_numpy_array_equal(idx.values, exp)
         tm.assert_numpy_array_equal(idx.to_numpy(), exp)
         exp = np.array([14975, -9223372036854775808], dtype=np.int64)

--- a/pandas/tests/resample/test_datetime_index.py
+++ b/pandas/tests/resample/test_datetime_index.py
@@ -1313,7 +1313,8 @@ def test_resample_consistency(unit):
 
     s10 = s.reindex(index=i10, method="bfill")
     s10_2 = s.reindex(index=i10, method="bfill", limit=2)
-    with tm.assert_produces_warning(Pandas4Warning):
+    msg = "the 'method' keyword is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         rl = s.reindex_like(s10, method="bfill", limit=2)
     r10_2 = s.resample("10Min").bfill(limit=2)
     r10 = s.resample("10Min").bfill()

--- a/pandas/tests/series/methods/test_convert_dtypes.py
+++ b/pandas/tests/series/methods/test_convert_dtypes.py
@@ -201,7 +201,8 @@ class TestSeriesConvertDtypes:
         else:
             series = pd.Series(data)
 
-        with tm.assert_produces_warning(Pandas4Warning):
+        warn_msg = "keyword in Series.convert_dtypes is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=warn_msg):
             result = series.convert_dtypes(*params)
 
         param_names = [
@@ -285,7 +286,8 @@ class TestSeriesConvertDtypes:
     def test_convert_dtype_object_with_na(self, infer_objects, dtype):
         # GH#48791
         ser = pd.Series([1, pd.NA])
-        with tm.assert_produces_warning(Pandas4Warning):
+        msg = "The infer_objects keyword in Series.convert_dtypes is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = ser.convert_dtypes(infer_objects=infer_objects)
         expected = pd.Series([1, pd.NA], dtype=dtype)
         tm.assert_series_equal(result, expected)
@@ -296,7 +298,8 @@ class TestSeriesConvertDtypes:
     def test_convert_dtype_object_with_na_float(self, infer_objects, dtype):
         # GH#48791
         ser = pd.Series([1.5, pd.NA])
-        with tm.assert_produces_warning(Pandas4Warning):
+        msg = "The infer_objects keyword in Series.convert_dtypes is deprecated"
+        with tm.assert_produces_warning(Pandas4Warning, match=msg):
             result = ser.convert_dtypes(infer_objects=infer_objects)
         expected = pd.Series([1.5, pd.NA], dtype=dtype)
         tm.assert_series_equal(result, expected)

--- a/pandas/tests/series/methods/test_reindex_like.py
+++ b/pandas/tests/series/methods/test_reindex_like.py
@@ -22,7 +22,8 @@ def test_reindex_like(datetime_series):
     series1 = Series([5, None, None], [day1, day2, day3])
     series2 = Series([None, None], [day1, day3])
 
-    with tm.assert_produces_warning(Pandas4Warning):
+    msg = "the 'method' keyword is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = series1.reindex_like(series2, method="pad")
     expected = Series([5, np.nan], index=[day1, day3])
     tm.assert_series_equal(result, expected)
@@ -35,13 +36,14 @@ def test_reindex_like_nearest():
     other = ser.reindex(target, method="nearest")
     expected = Series(np.around(target).astype("int64"), target)
 
-    with tm.assert_produces_warning(Pandas4Warning):
+    msg = "the 'method' keyword is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = ser.reindex_like(other, method="nearest")
     tm.assert_series_equal(expected, result)
 
-    with tm.assert_produces_warning(Pandas4Warning):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = ser.reindex_like(other, method="nearest", tolerance=1)
     tm.assert_series_equal(expected, result)
-    with tm.assert_produces_warning(Pandas4Warning):
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = ser.reindex_like(other, method="nearest", tolerance=[1, 2, 3, 4])
     tm.assert_series_equal(expected, result)


### PR DESCRIPTION
- [x] xref GH-58290
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Third batch of GH-58290, after GH-67070 and GH-67071. Fills in `match` for every bare `tm.assert_produces_warning(Pandas4Warning)` call — 18 call sites across 8 files. After this there are no bare `Pandas4Warning` assertions left in the suite.

Four deprecation messages are involved:

- `the 'method' keyword is deprecated` — `reindex_like` (7 sites)
- `PeriodIndex.values returning an object-dtype ndarray is deprecated` (3 sites)
- `<kw> keyword in {Series,DataFrame}.convert_dtypes is deprecated` (7 sites)
- `The infer_objects keyword in Series.convert_dtypes is deprecated` (2 sites)

The `convert_dtypes` sites needed a judgement call. Four of them pass several deprecated keywords in one call, so a single context manager catches up to five *different* messages (`convert_boolean`, `convert_floating`, `convert_integer`, `convert_string`, `infer_objects`). Those match on the shared part of the message, `keyword in DataFrame.convert_dtypes is deprecated`, which still pins the method and the deprecation; the sites that deprecate exactly one keyword name it in full.

Messages were taken from what the tests actually emit rather than from reading the deprecation sites.

No `closes` line — this is one batch of GH-58290, not the whole thing.