### PR TITLE
Fixed aliased pandas imports in namespace checker

### DIFF
--- a/scripts/check_for_inconsistent_pandas_namespace.py
+++ b/scripts/check_for_inconsistent_pandas_namespace.py
@@ -57,7 +57,7 @@ class Visitor(ast.NodeVisitor):
         if node.module is not None and "pandas" in node.module:
             self.imported_from_pandas.update(
                 name.name for name in node.names if name.asname is None
-                )
+            )
         self.generic_visit(node)
 
 
@@ -130,7 +130,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         print("Current path: ", path)
         with open(path, encoding="utf-8") as fd:
             content = fd.read()
-        print ("File content:")
+        print("File content:")
         print(content)
         new_content = check_for_inconsistent_pandas_namespace(
             content, path, replace=args.replace

--- a/scripts/check_for_inconsistent_pandas_namespace.py
+++ b/scripts/check_for_inconsistent_pandas_namespace.py
@@ -55,7 +55,9 @@ class Visitor(ast.NodeVisitor):
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         if node.module is not None and "pandas" in node.module:
-            self.imported_from_pandas.update(name.name for name in node.names if name.asname is None)
+            self.imported_from_pandas.update(
+                name.name for name in node.names if name.asname is None
+                )
         self.generic_visit(node)
 
 

--- a/scripts/check_for_inconsistent_pandas_namespace.py
+++ b/scripts/check_for_inconsistent_pandas_namespace.py
@@ -55,7 +55,7 @@ class Visitor(ast.NodeVisitor):
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
         if node.module is not None and "pandas" in node.module:
-            self.imported_from_pandas.update(name.name for name in node.names)
+            self.imported_from_pandas.update(name.name for name in node.names if name.asname is None)
         self.generic_visit(node)
 
 
@@ -122,13 +122,18 @@ def main(argv: Sequence[str] | None = None) -> None:
     parser.add_argument("paths", nargs="*")
     parser.add_argument("--replace", action="store_true")
     args = parser.parse_args(argv)
+    print("ARGS: ", args)
 
     for path in args.paths:
+        print("Current path: ", path)
         with open(path, encoding="utf-8") as fd:
             content = fd.read()
+        print ("File content:")
+        print(content)
         new_content = check_for_inconsistent_pandas_namespace(
             content, path, replace=args.replace
         )
+        print("New content: ", new_content)
         if not args.replace or new_content is None:
             continue
         with open(path, "w", encoding="utf-8") as fd:


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [ ] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
