### PR TITLE
TST: cover surviving mutants from GH#58517 in tz_localize, reset_index, and reindex

### DIFF
--- a/pandas/tests/frame/methods/test_reindex.py
+++ b/pandas/tests/frame/methods/test_reindex.py
@@ -1038,6 +1038,18 @@ class TestDataFrameSelectReindex:
 
         tm.assert_frame_equal(result, expected)
 
+    def test_reindex_multi_promotes_dtype_for_missing_columns(self):
+        # GH#58517 reindexing both axes at once takes the take_2d_multi
+        #  fastpath; a missing column must promote the result dtype so that
+        #  the fill value fits, even when every row label is present
+        df = DataFrame(np.arange(6).reshape(2, 3), index=[0, 1], columns=[0, 1, 2])
+
+        result = df.reindex(index=[1, 0], columns=[0, 1, 5])
+        expected = DataFrame(
+            {0: [3.0, 0.0], 1: [4.0, 1.0], 5: [np.nan, np.nan]}, index=[1, 0]
+        )
+        tm.assert_frame_equal(result, expected)
+
     def test_reindex_multi_categorical_time(self):
         # https://github.com/pandas-dev/pandas/issues/21390
         midx = MultiIndex.from_product(

--- a/pandas/tests/frame/methods/test_reset_index.py
+++ b/pandas/tests/frame/methods/test_reset_index.py
@@ -666,6 +666,24 @@ def test_reset_index_dtypes_on_empty_frame_with_multiindex(
     tm.assert_series_equal(result, expected)
 
 
+def test_reset_index_infers_dtype_from_object_levels():
+    # GH#58517 object-dtype MultiIndex levels are inferred to concrete dtypes
+    #  when they are moved into columns
+    mi = MultiIndex.from_arrays(
+        [
+            Index([1, 2], dtype=object),
+            Index([1.5, 2.5], dtype=object),
+            Index([True, False], dtype=object),
+        ],
+        names=["i", "f", "b"],
+    )
+    result = DataFrame({"v": [1, 2]}, index=mi).reset_index()
+    expected = DataFrame(
+        {"i": [1, 2], "f": [1.5, 2.5], "b": [True, False], "v": [1, 2]}
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_reset_index_empty_frame_with_datetime64_multiindex():
     # https://github.com/pandas-dev/pandas/issues/35606
     dti = pd.DatetimeIndex(["2020-07-20 00:00:00"], dtype="M8[ns]")

--- a/pandas/tests/series/methods/test_tz_localize.py
+++ b/pandas/tests/series/methods/test_tz_localize.py
@@ -1,4 +1,7 @@
-from datetime import UTC
+from datetime import (
+    UTC,
+    timedelta,
+)
 
 import pytest
 
@@ -8,6 +11,7 @@ from pandas import (
     DatetimeIndex,
     NaT,
     Series,
+    Timedelta,
     Timestamp,
     date_range,
 )
@@ -117,6 +121,26 @@ class TestTZLocalize:
 
             res_index = dti.tz_localize(tz, nonexistent=method)
             tm.assert_index_equal(res_index, expected.index)
+
+    @pytest.mark.parametrize("offset", [Timedelta("1h"), timedelta(hours=1)])
+    def test_tz_localize_nonexistent_timedelta(self, warsaw, unit, offset):
+        # GH#58517 nonexistent= also accepts a timedelta, but that form was
+        #  only covered for DatetimeIndex, not for Series/DataFrame
+        tz = warsaw
+        dti = date_range(start="2015-03-29 02:00:00", periods=3, freq="min", unit=unit)
+        ser = Series(1, index=dti)
+
+        # localizing shifts the nonexistent times by offset and keeps the unit
+        expected_index = (dti + offset).tz_localize(tz).as_unit(unit)
+
+        result = ser.tz_localize(tz, nonexistent=offset)
+        tm.assert_series_equal(result, Series(1, index=expected_index))
+
+        result = ser.to_frame().tz_localize(tz, nonexistent=offset)
+        tm.assert_frame_equal(result, Series(1, index=expected_index).to_frame())
+
+        res_index = dti.tz_localize(tz, nonexistent=offset)
+        tm.assert_index_equal(res_index, expected_index)
 
     @pytest.mark.parametrize("tzstr", ["US/Eastern", "dateutil/US/Eastern"])
     def test_series_tz_localize_empty(self, tzstr):


### PR DESCRIPTION
- [x] Reference #58517
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.

Follow-up to the mutation testing results in #58517, adding coverage for three code paths
where mutating the source leaves the suite green. Each test was checked to pass on `main` and
to fail under the corresponding mutation.

- `Series.tz_localize` / `DataFrame.tz_localize` with a `timedelta` for `nonexistent`. The
  validation in `generic.py` accepts a timedelta, and the error message advertises it, but
  only the `DatetimeIndex` path was covered. Dropping the `not` from the `isinstance` check
  went unnoticed.
- `DataFrame.reset_index` with object-dtype `MultiIndex` levels. Removing the
  `maybe_convert_objects` call leaves the moved-in columns as `object` instead of `int64` /
  `float64` / `bool`, and no test noticed.
- `DataFrame.reindex` on both axes at once, where all row labels are present but a column is
  missing. This takes the `take_2d_multi` fastpath, and the column half of the promotion
  check was untested: breaking it makes the result keep `int64` and return uninitialised
  values instead of promoting to `float64` and filling with `NaN`. Existing `test_reindex_multi`
  cases all either have a missing row, which promotes anyway, or no missing labels at all.

No whatsnew entry, as there is no behavior change.

---

Replaces #66592, which was closed as stale after every CI job failed due to a GitHub Actions
infrastructure outage (`Service Unavailable` while resolving action download info — not a
test/code failure). No changes were requested on the diff itself. Rebased onto current `main`
and re-pushed here since the old branch can no longer be reopened once force-pushed after close.