### PR TITLE
BUG: Fix DataFrame/Series.interpolate ValueError with SciPy methods and a single valid value

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -675,6 +675,7 @@ Indexing
 Missing
 ^^^^^^^
 - Bug in :meth:`DataFrame.fillna` with a dict value raising ``RecursionError`` when columns are a :class:`MultiIndex` with duplicate entries (:issue:`53498`)
+- Bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` with a SciPy-based ``method`` (e.g. ``"nearest"``) raising ``ValueError: x and y arrays must have at least 2 entries`` when only a single non-NaN value was available to interpolate from (:issue:`46230`)
 - Bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` with ``method`` in ``"index"``, ``"values"`` or ``"time"`` raising when the index had an :class:`ArrowDtype` timestamp or duration dtype; these now match the equivalent :class:`DatetimeIndex` or :class:`TimedeltaIndex` (:issue:`66338`)
 - Bug in :meth:`DataFrame.shift`, :meth:`DataFrame.where`, :meth:`DataFrame.mask`, :meth:`Series.shift`, :meth:`Series.where`, and :meth:`Series.mask` raising an internal ``AssertionError`` for a NumPy bytes dtype instead of upcasting to ``object`` to hold a missing value; item assignment now raises the expected ``TypeError`` for the incompatible value (:issue:`52373`)
 - Bug in :meth:`Series.combine_first` crashing when Series names are :class:`Timestamp` objects (:issue:`65333`)

--- a/pandas/core/missing.py
+++ b/pandas/core/missing.py
@@ -541,6 +541,14 @@ def _interpolate_1d(
     if valid.all():
         return
 
+    if method not in NP_METHODS and valid.sum() < 2:
+        # GH#46230 SciPy's interpolators (e.g. "nearest") raise
+        # "ValueError: x and y arrays must have at least 2 entries" when
+        # asked to interpolate from a single valid value. There is nothing
+        # sensible to interpolate from in that case, so leave everything
+        # untouched, the same as when there are no valid values at all.
+        return
+
     # These index pointers to invalid values... i.e. {0, 1, etc...
     all_nans = np.flatnonzero(invalid)
 

--- a/pandas/tests/frame/methods/test_interpolate.py
+++ b/pandas/tests/frame/methods/test_interpolate.py
@@ -228,6 +228,16 @@ class TestDataFrameInterpolate:
         expected.loc[13, "A"] = 5.76923077
         tm.assert_frame_equal(result, expected)
 
+    def test_interp_scipy_single_valid_value(self):
+        # GH#46230 scipy's interpolators raise "x and y arrays must have at
+        # least 2 entries" when there is only a single non-NaN value to
+        # interpolate from; pandas should leave the NaN in place instead of
+        # propagating that error.
+        pytest.importorskip("scipy")
+        df = DataFrame({"a": [np.nan, 1]})
+        result = df.interpolate(method="nearest")
+        tm.assert_frame_equal(result, df)
+
         result = df.interpolate(method="zero")
         expected.loc[3, "A"] = 2.0
         expected.loc[13, "A"] = 5

--- a/pandas/tests/series/methods/test_interpolate.py
+++ b/pandas/tests/series/methods/test_interpolate.py
@@ -891,3 +891,14 @@ class TestSeriesInterpolateData:
         result = ser.interpolate(method="linear")
         expected = Series([1.0, 2.0, 3.0], dtype="Float64")
         tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("method", ["nearest", "zero", "slinear", "quadratic"])
+    def test_interpolate_scipy_single_valid_value(self, method):
+        # GH#46230 scipy's interpolators raise "x and y arrays must have at
+        # least 2 entries" when asked to interpolate from a single valid
+        # point; pandas should leave the missing values as NaN instead of
+        # propagating that error.
+        pytest.importorskip("scipy")
+        ser = Series([np.nan, 1])
+        result = ser.interpolate(method=method)
+        tm.assert_series_equal(result, ser)


### PR DESCRIPTION
Fixes #46230.

## Root cause

`pandas.core.missing._interpolate_1d` dispatches any interpolation `method` that is not in `NP_METHODS` (i.e. everything backed by SciPy, such as `"nearest"`, `"zero"`, `"slinear"`, `"quadratic"`, `"cubic"`, `"polynomial"`, ...) straight to `_interpolate_scipy_wrapper`, which ultimately calls `scipy.interpolate.interp1d(x, y, ...)`. That function only checks `valid.any()` (at least one valid value) and `valid.all()` (no missing values) before doing so - it never checks that there are *at least two* valid points. `scipy.interpolate.interp1d` requires at least 2 `(x, y)` pairs and raises `ValueError: x and y arrays must have at least 2 entries` otherwise. With `pd.DataFrame(dict(a=[np.nan, 1])).interpolate(method="nearest")` there is exactly one valid value (`1`), so the call reaches SciPy with 1-length `x`/`y` arrays and raises, exactly as reported.

## Why this fix

I considered manually reimplementing a fallback (e.g. broadcasting the single valid value to the missing slots) so that SciPy-based methods behave like `"linear"`, which uses `np.interp` and tolerates a single point via constant extrapolation. I rejected that: it would need per-method logic (a 1-point "spline" of order 2/3 is not mathematically well defined, unlike `"nearest"`/`"zero"`), and more importantly it risks silently mis-marking still-missing entries as valid for masked/Arrow-backed extension array dtypes (`Float64`, Arrow-backed columns), because those paths reconstruct the missing-value `mask` from `preserve_nans`, which is only computed under the assumption that every currently-invalid slot actually gets written to.

Instead, the fix mirrors the two existing early-return guards already in `_interpolate_1d` (`if not valid.any(): return` and `if valid.all(): return`): when a SciPy-backed method is requested and fewer than 2 valid values are available, bail out immediately without touching `yvalues` or `mask` at all. This exactly reproduces the behavior described as "Expected Behavior" in the issue (the pre-existing valid value is left alone, the NaN that can't be interpolated stays NaN), it's a 6-line change scoped to the exact failure condition, and it can't corrupt the extension-array mask bookkeeping since the code that manipulates `mask`/`preserve_nans` is never reached in this case.

## Testing

- Added `TestSeriesInterpolateData.test_interpolate_scipy_single_valid_value` in `pandas/tests/series/methods/test_interpolate.py`, parametrized over `"nearest"`, `"zero"`, `"slinear"`, `"quadratic"`, reproducing the crash on a `Series([np.nan, 1])` and asserting the result is unchanged (matching the issue's expected output).
- Added `TestDataFrameInterpolate.test_interp_scipy_single_valid_value` in `pandas/tests/frame/methods/test_interpolate.py`, reproducing the exact example from the issue (`DataFrame({"a": [np.nan, 1]}).interpolate(method="nearest")`) and asserting it returns the input unchanged instead of raising.
- Both tests `pytest.importorskip("scipy")` to match the existing convention in these files for SciPy-backed interpolation tests.
- I traced the fixed code path by hand against the issue's example and against the pre-existing test suite (e.g. `test_interp_datetime64`, `test_interpolate_fill_value`, which use 2+ valid points and are therefore unaffected) to confirm no other interpolation behavior changes; this compiled/build-less bundle does not provide a way to actually execute pytest (pandas requires building its Cython/C extensions via meson, which isn't available in this environment), so verification here is via careful manual trace rather than a pytest run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)