### PR TITLE
DOC: use Series links in tz_convert See Also

### DIFF
--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -379,6 +379,7 @@ class DatetimeProperties(Properties):
         dtype: datetime64[us]
         """  # noqa: E501
         return self._delegate_method("tz_convert", tz)
+
     def to_pydatetime(self) -> Series:
         """
         Return the data as a Series of :class:`datetime.datetime` objects.

--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -317,6 +317,68 @@ class DatetimeProperties(Properties):
     Raises TypeError if the Series does not contain datetimelike values.
     """
 
+    def tz_convert(self, tz) -> Series:
+        """
+        Convert tz-aware Series from one time zone to another.
+
+        This method converts each timestamp in a Series to the target time zone
+        while preserving the underlying UTC time. The Series must already be
+        timezone-aware.
+
+        Parameters
+        ----------
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile, datetime.tzinfo or None
+            Time zone for time. Corresponding timestamps would be converted
+            to this time zone. A `tz` of None will convert to UTC and remove
+            the timezone information.
+
+        Returns
+        -------
+        Series
+            Series with target `tz`.
+
+        Raises
+        ------
+        TypeError
+            If the Series is tz-naive.
+
+        See Also
+        --------
+        Series.dt.tz : Return the timezone.
+        Series.dt.tz_localize : Localize tz-naive values to a time zone, or
+            remove the time zone from tz-aware values.
+
+        Examples
+        --------
+        >>> s = pd.Series(
+        ...     pd.date_range(
+        ...         start="2014-08-01 09:00",
+        ...         freq="h",
+        ...         periods=3,
+        ...         tz="Europe/Berlin",
+        ...     )
+        ... )
+        >>> s
+        0   2014-08-01 09:00:00+02:00
+        1   2014-08-01 10:00:00+02:00
+        2   2014-08-01 11:00:00+02:00
+        dtype: datetime64[us, Europe/Berlin]
+
+        >>> s.dt.tz_convert("US/Central")
+        0   2014-08-01 02:00:00-05:00
+        1   2014-08-01 03:00:00-05:00
+        2   2014-08-01 04:00:00-05:00
+        dtype: datetime64[us, US/Central]
+
+        With ``tz=None``, the timezone is removed after converting to UTC:
+
+        >>> s.dt.tz_convert(None)
+        0   2014-08-01 07:00:00
+        1   2014-08-01 08:00:00
+        2   2014-08-01 09:00:00
+        dtype: datetime64[us]
+        """  # noqa: E501
+        return self._delegate_method("tz_convert", tz)
     def to_pydatetime(self) -> Series:
         """
         Return the data as a Series of :class:`datetime.datetime` objects.


### PR DESCRIPTION
- [x] closes #49297
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest doc/source/whatsnew/vX.X.X.rst file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

Inlines the Series.dt.tz_convert docstring so its See Also section links to Series.dt.tz and Series.dt.tz_localize rather than the DatetimeIndex equivalents. The examples and return description are also expressed in terms of Series.

Validation: git diff --check and python3 -m py_compile pandas/core/indexes/accessors.py. The full documentation build was unavailable because the local checkout does not have compatible NumPy or built C extensions.

Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did not use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow AGENTS.md, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting.

AI use: OpenAI Codex using GPT-5 helped inspect the delegation mechanism, inline and adapt the docstring, and run the available validation. The reasoning-effort setting is not exposed to the agent.