### PR TITLE
HDFStore.select with where="cat == None" did not return the NaN rows

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -791,6 +791,7 @@ I/O
 - Fixed bug in :meth:`DataFrame.to_parquet` (``pyarrow`` engine) where a local file path was opened twice, once by pandas and again by pyarrow, wasting a syscall and silently truncating output to 0 bytes on filesystems that finalize a file's contents on close (:issue:`65810`)
 - Fixed bug in :meth:`HDFStore.get_storer` where ``.shape`` reported a phantom row for a fixed-format :class:`Series` or :class:`DataFrame` stored with no rows (:issue:`37235`)
 - Fixed bug in :meth:`HDFStore.remove` where a ``where`` clause selecting on more than 31 values (e.g. ``"index in [...]"``) deleted the wrong rows instead of only the matching rows (:issue:`17567`)
+- Fixed bug in :meth:`HDFStore.select` where explicitly using a ``where`` query with ``None`` does not return NaN/None rows(:issue:`67065`)
 - Fixed bug in :meth:`HDFStore.select` where passing ``where`` as a list of conditions referencing caller-scope variables failed on Python 3.12+ due to :pep:`709` inlining list comprehension stack frames (:issue:`64881`)
 - Fixed bug in :meth:`HDFStore.select` with ``format="table"`` where reading a frame with a string :class:`Index` could crash with a bus error on strict-alignment platforms such as 32-bit ARM (:issue:`54396`)
 - Storing a :class:`DataFrame` or :class:`Series` with a :class:`MultiIndex` level named ``'index'`` via :meth:`HDFStore.put` or :meth:`HDFStore.append` with ``format='table'`` now raises a clear ``ValueError`` instead of an opaque reshape error (:issue:`6208`)

--- a/pandas/core/computation/pytables.py
+++ b/pandas/core/computation/pytables.py
@@ -26,6 +26,7 @@ from pandas._libs.tslibs import (
 from pandas.errors import UndefinedVariableError
 
 from pandas.core.dtypes.common import is_list_like
+from pandas.core.dtypes.missing import isna
 
 import pandas.core.common as com
 from pandas.core.computation import (
@@ -266,7 +267,7 @@ class BinOp(ops.BinOp):
             if conv_val not in metadata:
                 # GH#22977 value is not a category; use -2 as a code that
                 # matches no row, unlike -1 which is the code for NaN values.
-                result = -2
+                result = -1 if isna(conv_val) else -2
             else:
                 # Find the index of the first match of conv_val in metadata
                 result = np.flatnonzero(metadata == conv_val)[0]

--- a/pandas/tests/io/pytables/test_categorical.py
+++ b/pandas/tests/io/pytables/test_categorical.py
@@ -389,6 +389,10 @@ def test_categorical_select_non_sorted_categories(temp_h5_path):
         ('col in ["z", "y"]', lambda col: col.isin(["z", "y"])),
         ('col in ["a", "z"]', lambda col: col.isin(["a", "z"])),
         ('col != "z"', lambda col: col != "z"),
+        ("col == None", lambda col: col.isna()),
+        ("col != None", lambda col: col.notna()),
+        ("col == NA", lambda col: col.isna()),
+        ("col != NA", lambda col: col.notna()),
     ],
 )
 def test_categorical_where_non_category_with_nan(temp_h5_path, where, mask):


### PR DESCRIPTION
- [x] closes #67065
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

I used an automated program repair approach for research to generate this patch. However, I manually reviewed the code and manually added the test cases. I take full responsibility of the code.