### PR TITLE
TST: add match argument to eval/query assert_produces_warning calls

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from functools import reduce
 from itertools import product
-import operator
 
 import numpy as np
 import pytest
@@ -742,8 +740,9 @@ class TestEval:
     def test_true_false_logic(self):
         # GH 25823
         # This behavior is deprecated in Python 3.12
+        msg = "Bitwise inversion '~' on bool is deprecated"
         with tm.maybe_produces_warning(
-            DeprecationWarning, PY312, check_stacklevel=False
+            DeprecationWarning, PY312, check_stacklevel=False, match=msg
         ):
             assert pd.eval("not True") == -2
             assert pd.eval("not False") == -1
@@ -801,14 +800,6 @@ class TestTypeCasting:
 # Basic and complex alignment
 
 
-def should_warn(*args):
-    not_mono = not any(map(operator.attrgetter("is_monotonic_increasing"), args))
-    only_one_dt = reduce(
-        operator.xor, (issubclass(x.dtype.type, np.datetime64) for x in args)
-    )
-    return not_mono and only_one_dt
-
-
 class TestAlignment:
     index_types = ["i", "s", "dt"]
     lhs_index_types = [*index_types, "s"]  # 'p'
@@ -835,12 +826,7 @@ class TestAlignment:
             index=idx_func_dict[rr_idx_type](20),
             columns=idx_func_dict[c_idx_type](10),
         )
-        # only warns if not monotonic and not sortable
-        if should_warn(df.index, df2.index):
-            with tm.assert_produces_warning(RuntimeWarning):
-                res = pd.eval("df + df2", engine=engine, parser=parser)
-        else:
-            res = pd.eval("df + df2", engine=engine, parser=parser)
+        res = pd.eval("df + df2", engine=engine, parser=parser)
         tm.assert_frame_equal(res, df + df2)
 
     @pytest.mark.parametrize("r_idx_type", lhs_index_types)
@@ -887,11 +873,7 @@ class TestAlignment:
             index=idx_func_dict[r2](5),
             columns=idx_func_dict[c2](2),
         )
-        if should_warn(df.index, df2.index, df3.index):
-            with tm.assert_produces_warning(RuntimeWarning):
-                res = pd.eval("df + df2 + df3", engine=engine, parser=parser)
-        else:
-            res = pd.eval("df + df2 + df3", engine=engine, parser=parser)
+        res = pd.eval("df + df2 + df3", engine=engine, parser=parser)
         tm.assert_frame_equal(res, df + df2 + df3)
 
     @pytest.mark.parametrize("index_name", ["index", "columns"])
@@ -908,11 +890,7 @@ class TestAlignment:
         index = getattr(df, index_name)
         s = Series(np.random.default_rng(2).standard_normal(5), index[:5])
 
-        if should_warn(df.index, s.index):
-            with tm.assert_produces_warning(RuntimeWarning):
-                res = pd.eval("df + s", engine=engine, parser=parser)
-        else:
-            res = pd.eval("df + s", engine=engine, parser=parser)
+        res = pd.eval("df + s", engine=engine, parser=parser)
 
         if r_idx_type == "dt" or c_idx_type == "dt":
             expected = df.add(s) if engine == "numexpr" else df + s
@@ -935,11 +913,7 @@ class TestAlignment:
         )
         index = getattr(df, index_name)
         s = Series(np.random.default_rng(2).standard_normal(5), index[:5])
-        if should_warn(s.index, df.index):
-            with tm.assert_produces_warning(RuntimeWarning):
-                res = pd.eval("s + df", engine=engine, parser=parser)
-        else:
-            res = pd.eval("s + df", engine=engine, parser=parser)
+        res = pd.eval("s + df", engine=engine, parser=parser)
 
         if r_idx_type == "dt" or c_idx_type == "dt":
             expected = df.add(s) if engine == "numexpr" else s + df
@@ -961,18 +935,14 @@ class TestAlignment:
             columns=idx_func_dict[c_idx_type](10),
         )
         index = getattr(df, index_name)
-        s = Series(np.random.default_rng(2).standard_normal(5), index[:5])
+        s = Series(  # noqa: F841  # referenced by name inside the eval expression
+            np.random.default_rng(2).standard_normal(5), index[:5]
+        )
 
         lhs = f"s {op} df"
         rhs = f"df {op} s"
-        if should_warn(df.index, s.index):
-            with tm.assert_produces_warning(RuntimeWarning):
-                a = pd.eval(lhs, engine=engine, parser=parser)
-            with tm.assert_produces_warning(RuntimeWarning):
-                b = pd.eval(rhs, engine=engine, parser=parser)
-        else:
-            a = pd.eval(lhs, engine=engine, parser=parser)
-            b = pd.eval(rhs, engine=engine, parser=parser)
+        a = pd.eval(lhs, engine=engine, parser=parser)
+        b = pd.eval(rhs, engine=engine, parser=parser)
 
         if r_idx_type != "dt" and c_idx_type != "dt":
             if engine == "numexpr":
@@ -1017,11 +987,7 @@ class TestAlignment:
         else:
             expected = expected2 + df
 
-        if should_warn(df2.index, ser.index, df.index):
-            with tm.assert_produces_warning(RuntimeWarning):
-                res = pd.eval("df2 + ser + df", engine=engine, parser=parser)
-        else:
-            res = pd.eval("df2 + ser + df", engine=engine, parser=parser)
+        res = pd.eval("df2 + ser + df", engine=engine, parser=parser)
         assert res.shape == expected.shape
         tm.assert_frame_equal(res, expected)
 

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -1626,7 +1626,12 @@ class TestDataFrameQueryBacktickQuoting:
             [[1, 2], [3, 4]], columns=["a", "b"], dtype=any_numeric_ea_and_arrow_dtype
         )
         warning = RuntimeWarning if NUMEXPR_INSTALLED else None
-        with tm.assert_produces_warning(warning):
+        msg = (
+            "Engine has switched to 'python' because numexpr does not "
+            "support extension array dtypes. Please set your engine "
+            "to python manually."
+        )
+        with tm.assert_produces_warning(warning, match=msg):
             result = df.eval("c = b - a")
         expected = DataFrame(
             [[1, 2, 1], [3, 4, 1]],
@@ -1639,7 +1644,12 @@ class TestDataFrameQueryBacktickQuoting:
         # GH#29618
         df = DataFrame([[1, 2], [3, 4]], columns=["a", "b"], dtype="Float64")
         warning = RuntimeWarning if NUMEXPR_INSTALLED else None
-        with tm.assert_produces_warning(warning):
+        msg = (
+            "Engine has switched to 'python' because numexpr does not "
+            "support extension array dtypes. Please set your engine "
+            "to python manually."
+        )
+        with tm.assert_produces_warning(warning, match=msg):
             result = df.eval("c = b - 1")
         expected = DataFrame(
             [[1, 2, 1], [3, 4, 3]], columns=["a", "b", "c"], dtype="Float64"
@@ -1669,7 +1679,12 @@ class TestDataFrameQueryBacktickQuoting:
         df = DataFrame({"a": [1, 2]}, dtype=dtype)
         ref = {2}  # noqa: F841
         warning = RuntimeWarning if dtype == "Int64" and NUMEXPR_INSTALLED else None
-        with tm.assert_produces_warning(warning):
+        msg = (
+            "Engine has switched to 'python' because numexpr does not "
+            "support extension array dtypes. Please set your engine "
+            "to python manually."
+        )
+        with tm.assert_produces_warning(warning, match=msg):
             result = df.query("a in @ref")
         expected = DataFrame({"a": [2]}, index=range(1, 2), dtype=dtype)
         tm.assert_frame_equal(result, expected)
@@ -1686,7 +1701,12 @@ class TestDataFrameQueryBacktickQuoting:
         df = DataFrame(
             {"A": Series([1, 1, 2], dtype="Int64"), "B": Series([1, 2, 2], dtype=dtype)}
         )
-        with tm.assert_produces_warning(warning):
+        msg = (
+            "Engine has switched to 'python' because numexpr does not "
+            "support extension array dtypes. Please set your engine "
+            "to python manually."
+        )
+        with tm.assert_produces_warning(warning, match=msg):
             result = df.query("A == B", engine=engine)
         expected = DataFrame(
             {


### PR DESCRIPTION
- [x] xref GH-58290
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Next batch of GH-58290, covering `pd.eval` / `DataFrame.query`.

**`test_query_eval.py`** — four bare calls check the `RuntimeWarning` raised when numexpr is asked for extension-array dtypes. Filled in with the wording `test_in_column_refs_string_pyarrow` already uses for the same warning, rather than a fifth spelling.

**`test_eval.py::TestAlignment`** — the seven bare calls there turned out to be unreachable, so they are removed rather than given a `match` that would never be evaluated.

They sit behind `should_warn(*indexes)`, which needs *every* index to be non-monotonic **and** exactly one of them to be `datetime64`. Those are mutually exclusive under the current fixtures: since GH-56331 replaced the random `makeCustomIndex` generators with `idx_func_dict`, the only non-monotonic generator is `"s"` (`"97_a"`, `"98_b"`, … `"100_d"` — sorts wrong past n=3), which is never `datetime64`, and the only `datetime64` generator is `date_range`, which is always monotonic. Instrumenting the helper gives **1336 calls, 1336 × `False`**.

The expected warning is stale too. The only `RuntimeWarning` `pd.eval` can raise is the engine-switch one at `pandas/core/computation/eval.py:413`, which has nothing to do with index alignment — the alignment warning is a `PerformanceWarning` (`pandas/core/computation/align.py:141`).

Test counts are unchanged (`11650 passed, 52 skipped, 46 xfailed` before and after), confirming nothing was being exercised by the deleted branches.

Two incidental notes:
- Removing `if should_warn(df.index, s.index)` orphans `s` in one test — it is only referenced from inside the `pd.eval` expression string, so it needs a `# noqa: F841`.
- `tm.maybe_produces_warning` forwards `**kwargs` straight through, so it takes `match` as well; the one such call in this file is filled in here too.