### PR TITLE
TST: add match argument to deprecation-decorator assert_produces_warning calls

### DIFF
--- a/pandas/tests/util/test_deprecate.py
+++ b/pandas/tests/util/test_deprecate.py
@@ -41,7 +41,8 @@ def test_deprecate_ok():
         FutureWarning, "depr_func", new_func, "1.0", msg="Use new_func instead."
     )
 
-    with tm.assert_produces_warning(FutureWarning):
+    msg = "Use new_func instead"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
         result = depr_func()
 
     assert result == "new_func called"
@@ -56,7 +57,8 @@ def test_deprecate_no_docstring():
         "1.0",
         msg="Use new_func instead.",
     )
-    with tm.assert_produces_warning(FutureWarning):
+    msg = "Use new_func instead"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
         result = depr_func()
     assert result == "new_func_no_docstring called"
 

--- a/pandas/tests/util/test_deprecate_kwarg.py
+++ b/pandas/tests/util/test_deprecate_kwarg.py
@@ -31,25 +31,29 @@ def _f3(new=0):
 def test_deprecate_kwarg(key, klass):
     x = 78
 
-    with tm.assert_produces_warning(klass):
+    msg = "the 'old' keyword is deprecated, use 'new' instead"
+    with tm.assert_produces_warning(klass, match=msg):
         assert _f1(**{key: x}) == x
 
 
 @pytest.mark.parametrize("key", list(_f2_mappings.keys()))
 def test_dict_deprecate_kwarg(key):
-    with tm.assert_produces_warning(FutureWarning):
+    msg = f"the old={key!r} keyword is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
         assert _f2(old=key) == _f2_mappings[key]
 
 
 @pytest.mark.parametrize("key", ["bogus", 12345, -1.23])
 def test_missing_deprecate_kwarg(key):
-    with tm.assert_produces_warning(FutureWarning):
+    msg = f"the old={key!r} keyword is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
         assert _f2(old=key) == key
 
 
 @pytest.mark.parametrize("x", [1, -1.4, 0])
 def test_callable_deprecate_kwarg(x):
-    with tm.assert_produces_warning(FutureWarning):
+    msg = f"the old={x!r} keyword is deprecated"
+    with tm.assert_produces_warning(FutureWarning, match=msg):
         assert _f3(old=x) == _f3_mapping(x)
 
 
@@ -86,5 +90,6 @@ def test_deprecate_keyword(key):
         klass = None
         expected = (True, x)
 
-    with tm.assert_produces_warning(klass):
+    msg = "the 'old' keyword is deprecated and will be removed in a future version"
+    with tm.assert_produces_warning(klass, match=msg):
         assert _f4(**{key: x}) == expected

--- a/pandas/tests/util/test_deprecate_nonkeyword_arguments.py
+++ b/pandas/tests/util/test_deprecate_nonkeyword_arguments.py
@@ -44,22 +44,21 @@ def test_two_and_two_arguments():
 
 
 def test_three_arguments():
-    with tm.assert_produces_warning(WARNING_CATEGORY):
-        assert f(6, 3, 3) == 12
-
-
-def test_four_arguments():
-    with tm.assert_produces_warning(WARNING_CATEGORY):
-        assert f(1, 2, 3, 4) == 10
-
-
-def test_three_arguments_with_name_in_warning():
     msg = (
         f"Starting with pandas version {WARNING_CATEGORY.version()} all arguments of "
         "f_add_inputs except for the arguments 'a' and 'b' will be keyword-only."
     )
     with tm.assert_produces_warning(WARNING_CATEGORY, match=msg):
         assert f(6, 3, 3) == 12
+
+
+def test_four_arguments():
+    msg = (
+        f"Starting with pandas version {WARNING_CATEGORY.version()} all arguments of "
+        "f_add_inputs except for the arguments 'a' and 'b' will be keyword-only."
+    )
+    with tm.assert_produces_warning(WARNING_CATEGORY, match=msg):
+        assert f(1, 2, 3, 4) == 10
 
 
 @deprecate_nonkeyword_arguments(WARNING_CATEGORY)
@@ -78,11 +77,6 @@ def test_one_and_three_arguments_default_allowed_args():
 
 
 def test_three_arguments_default_allowed_args():
-    with tm.assert_produces_warning(WARNING_CATEGORY):
-        assert g(6, 3, 3) == 12
-
-
-def test_three_positional_argument_with_warning_message_analysis():
     msg = (
         f"Starting with pandas version {WARNING_CATEGORY.version()} all arguments of g "
         "except for the argument 'a' will be keyword-only."
@@ -106,17 +100,12 @@ def test_all_keyword_arguments():
 
 
 def test_one_positional_argument():
-    with tm.assert_produces_warning(WARNING_CATEGORY):
-        assert h(23) == 23
-
-
-def test_one_positional_argument_with_warning_message_analysis():
     msg = (
         f"Starting with pandas version {WARNING_CATEGORY.version()} all arguments "
         "of h will be keyword-only."
     )
     with tm.assert_produces_warning(WARNING_CATEGORY, match=msg):
-        assert h(19) == 19
+        assert h(23) == 23
 
 
 @deprecate_nonkeyword_arguments(WARNING_CATEGORY)
@@ -129,7 +118,11 @@ def test_i_signature():
 
 
 def test_i_warns_klass():
-    with tm.assert_produces_warning(WARNING_CATEGORY):
+    msg = (
+        f"Starting with pandas version {WARNING_CATEGORY.version()} all arguments "
+        "of i will be keyword-only."
+    )
+    with tm.assert_produces_warning(WARNING_CATEGORY, match=msg):
         assert i(1, 2) == 3
 
 


### PR DESCRIPTION
- [x] xref GH-58290
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Next batch of GH-58290, covering the tests for `deprecate`, `deprecate_kwarg` and `deprecate_nonkeyword_arguments` — 12 bare calls.

Where the message varies per parametrization the `match` is built from the parameter, e.g. `f"the old={key!r} keyword is deprecated"`, so each case checks its own message rather than a lowest common denominator.

One structural change worth calling out. `test_deprecate_nonkeyword_arguments.py` had three tests whose only purpose was to re-run an already-covered call with the message asserted:

- `test_three_arguments_with_name_in_warning` vs `test_three_arguments` (both `f(6, 3, 3) == 12`)
- `test_three_positional_argument_with_warning_message_analysis` vs `test_three_arguments_default_allowed_args` (both `g(6, 3, 3) == 12`)
- `test_one_positional_argument_with_warning_message_analysis` vs `test_one_positional_argument` (`h(19)` vs `h(23)`)

Adding `match` to the bare half makes each pair an exact duplicate, so the message assertion is folded into the original test and the twin dropped. That is the whole reason the pairs existed. Net 34 tests instead of 37, with no assertion lost — the surviving test in each pair now does what both did. Happy to split that out if it is better reviewed separately.