### PR TITLE
TST: add match argument to io assert_produces_warning calls

### DIFF
--- a/pandas/tests/io/excel/test_readers.py
+++ b/pandas/tests/io/excel/test_readers.py
@@ -1837,7 +1837,8 @@ class TestExcelFileRead:
 
         Path(tmp_excel).write_text("corrupt", encoding="utf-8")
         expected_warning = Pandas4Warning if engine in {"xlrd", "pyxlsb"} else False
-        with tm.assert_produces_warning(expected_warning):
+        msg = f"The {engine} engine is deprecated"
+        with tm.assert_produces_warning(expected_warning, match=msg):
             try:
                 pd.ExcelFile(tmp_excel, engine=engine)
             except errors:

--- a/pandas/tests/io/parser/test_c_parser_only.py
+++ b/pandas/tests/io/parser/test_c_parser_only.py
@@ -110,8 +110,11 @@ nan 2
 """
     # fallback casting, but not castable
     if not WASM:  # no fp exception support in wasm
+        warn_msg = "invalid value encountered in cast"
         with pytest.raises(ValueError, match="cannot safely convert"):
-            with tm.assert_produces_warning(RuntimeWarning, check_stacklevel=False):
+            with tm.assert_produces_warning(
+                RuntimeWarning, check_stacklevel=False, match=warn_msg
+            ):
                 parser.read_csv(
                     StringIO(data),
                     sep=r"\s+",

--- a/pandas/tests/io/parser/test_unsupported.py
+++ b/pandas/tests/io/parser/test_unsupported.py
@@ -53,11 +53,14 @@ class TestUnsupportedFeatures:
             read_csv(StringIO(data), engine="c", skipfooter=1)
 
         # specify C-unsupported options without python-unsupported options
-        with tm.assert_produces_warning(parsers.ParserWarning):
+        msg = "the 'c' engine does not support separators > 1 char"
+        with tm.assert_produces_warning(parsers.ParserWarning, match=msg):
             read_csv(StringIO(data), sep=r"\s")
-        with tm.assert_produces_warning(parsers.ParserWarning):
+        msg = "quotechar is larger than one byte"
+        with tm.assert_produces_warning(parsers.ParserWarning, match=msg):
             read_csv(StringIO(data), sep="\t", quotechar=chr(128))
-        with tm.assert_produces_warning(parsers.ParserWarning):
+        msg = "the 'c' engine does not support skipfooter"
+        with tm.assert_produces_warning(parsers.ParserWarning, match=msg):
             read_csv(StringIO(data), skipfooter=1)
 
         text = """                      A       B       C       D        E

--- a/pandas/tests/io/pytables/test_put.py
+++ b/pandas/tests/io/pytables/test_put.py
@@ -264,7 +264,8 @@ def test_put_mixed_type(temp_hdfstore, performance_warning, using_infer_string):
     df = df._consolidate()
 
     warning = None if using_infer_string else performance_warning
-    with tm.assert_produces_warning(warning):
+    msg = "your performance may suffer as PyTables will pickle object types"
+    with tm.assert_produces_warning(warning, match=msg):
         temp_hdfstore.put("df", df, track_times=False)
 
     expected = temp_hdfstore.get("df")

--- a/pandas/tests/io/pytables/test_retain_attributes.py
+++ b/pandas/tests/io/pytables/test_retain_attributes.py
@@ -31,7 +31,8 @@ def test_retain_index_attributes(temp_hdfstore, unit):
 
     dti2 = date_range("2002-1-1", periods=3, freq="D", unit=unit)
     # try to append a table with a different frequency
-    with tm.assert_produces_warning(errors.AttributeConflictWarning):
+    msg = r"the \[freq\] attribute of the existing index"
+    with tm.assert_produces_warning(errors.AttributeConflictWarning, match=msg):
         df2 = DataFrame({"A": Series(range(3), index=dti2)})
         temp_hdfstore.append("data", df2)
 
@@ -56,7 +57,8 @@ def test_retain_index_attributes(temp_hdfstore, unit):
 
 
 def test_retain_index_attributes2(temp_h5_path):
-    with tm.assert_produces_warning(errors.AttributeConflictWarning):
+    msg = r"the \[freq\] attribute of the existing index"
+    with tm.assert_produces_warning(errors.AttributeConflictWarning, match=msg):
         df = DataFrame(
             {"A": Series(range(3), index=date_range("2000-1-1", periods=3, freq="h"))}
         )
@@ -74,7 +76,8 @@ def test_retain_index_attributes2(temp_h5_path):
 
     assert read_hdf(temp_h5_path, key="data").index.name == "foo"
 
-    with tm.assert_produces_warning(errors.AttributeConflictWarning):
+    msg = r"the \[index_name\] attribute of the existing index"
+    with tm.assert_produces_warning(errors.AttributeConflictWarning, match=msg):
         idx2 = date_range("2001-1-1", periods=3, freq="h")
         idx2.name = "bar"
         df2 = DataFrame({"A": Series(range(3), index=idx2)})

--- a/pandas/tests/io/pytables/test_store.py
+++ b/pandas/tests/io/pytables/test_store.py
@@ -215,7 +215,10 @@ def test_contains(temp_hdfstore):
     assert "bar" not in store
 
     # gh-2694: tables.NaturalNameWarning
-    with tm.assert_produces_warning(tables.NaturalNameWarning, check_stacklevel=False):
+    msg = "object name is not a valid Python identifier"
+    with tm.assert_produces_warning(
+        tables.NaturalNameWarning, check_stacklevel=False, match=msg
+    ):
         store["node())"] = DataFrame(
             1.1 * np.arange(120).reshape((30, 4)),
             columns=Index(list("ABCD")),

--- a/pandas/tests/io/test_sql.py
+++ b/pandas/tests/io/test_sql.py
@@ -1993,7 +1993,8 @@ def test_api_timedelta(conn, request):
     else:
         exp_warning = UserWarning
 
-    with tm.assert_produces_warning(exp_warning, check_stacklevel=False):
+    msg = "the 'timedelta' type is not supported"
+    with tm.assert_produces_warning(exp_warning, check_stacklevel=False, match=msg):
         result_count = df.to_sql(name="test_timedelta", con=conn)
     assert result_count == 2
     result = sql.read_sql_query("SELECT * FROM test_timedelta", conn)

--- a/pandas/tests/io/test_stata.py
+++ b/pandas/tests/io/test_stata.py
@@ -1993,7 +1993,9 @@ the string values returned are correct."""
         # will block pytests skip mechanism from triggering (failing the test)
         # if the path is not present
         path = datapath("io", "data", "stata", "stata1_encoding_118.dta")
-        with tm.assert_produces_warning(UnicodeWarning, filter_level="once") as w:
+        with tm.assert_produces_warning(
+            UnicodeWarning, filter_level="once", match=msg
+        ) as w:
             encoded = read_stata(path)
             # with filter_level="always", produces 151 warnings which can be slow
             assert len(w) == 1


### PR DESCRIPTION
- [x] xref GH-58290
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

Next batch of GH-58290: 12 bare calls across pytables, the c-parser fallback warnings, excel readers, `to_sql` and `read_stata`.

Messages were taken from what the tests actually emit. Two things that are easy to get wrong by reading the warning site instead:

- Several of these messages **wrap across newlines** (`AttributeConflictWarning`, the PyTables pickle `PerformanceWarning`, the stata `UnicodeWarning`). `assert_produces_warning` uses `re.search` without `DOTALL`, so a `match` written as one flat sentence never fires. Each of those matches stays within a single line.
- The `AttributeConflictWarning` messages embed the attribute name in square brackets (`the [freq] attribute ...`). Unescaped, `[freq]` is a regex character class and does not match the literal text, so those use `r"the \[freq\] attribute ..."`.

Two sites are inert in the default configuration and were verified separately rather than assumed:

- `test_put.py` takes `warning = None if using_infer_string else performance_warning`, so it only checks anything under `PANDAS_FUTURE_INFER_STRING=0`. Confirmed the match is really exercised there by temporarily breaking it and watching the test fail.
- `test_readers.py::test_corrupt_files_closed` only expects a warning for the `xlrd` and `pyxlsb` engines, so the match is built from the engine parameter.