### PR TITLE
TST: add match argument to remaining assert_produces_warning calls

### DIFF
--- a/pandas/tests/api/test_api.py
+++ b/pandas/tests/api/test_api.py
@@ -248,7 +248,7 @@ class TestPDApi(Base):
             + self.deprecated_funcs_in_future
         )
         for depr in deprecated_list:
-            with tm.assert_produces_warning(FutureWarning):
+            with tm.assert_produces_warning(FutureWarning, match="deprecated"):
                 _ = getattr(pd, depr)
 
 

--- a/pandas/tests/api/test_types.py
+++ b/pandas/tests/api/test_types.py
@@ -57,5 +57,5 @@ class TestTypes(Base):
 
     def test_deprecated_from_api_types(self):
         for t in self.deprecated:
-            with tm.assert_produces_warning(FutureWarning):
+            with tm.assert_produces_warning(FutureWarning, match="deprecated"):
                 getattr(types, t)(1)

--- a/pandas/tests/apply/test_str.py
+++ b/pandas/tests/apply/test_str.py
@@ -73,7 +73,8 @@ def test_apply_np_transformer(float_frame, op, how):
     if op in ["log", "sqrt"]:
         warn = RuntimeWarning
 
-    with tm.assert_produces_warning(warn, check_stacklevel=False):
+    msg = f"invalid value encountered in {op}"
+    with tm.assert_produces_warning(warn, check_stacklevel=False, match=msg):
         # float_frame fixture is defined in conftest.py, so we don't check the
         # stacklevel as otherwise the test would fail.
         result = getattr(float_frame, how)(op)

--- a/pandas/tests/arithmetic/test_timedelta64.py
+++ b/pandas/tests/arithmetic/test_timedelta64.py
@@ -2137,8 +2137,9 @@ class TestTimedeltaArraylikeMulDivOps:
         expected = np.array([1.0, 1.0, np.nan], dtype=np.float64)
         expected = tm.box_expected(expected, xbox)
 
+        msg = "invalid value encountered in floor_divide"
         with tm.maybe_produces_warning(
-            RuntimeWarning, box is pd.array, check_stacklevel=False
+            RuntimeWarning, box is pd.array, check_stacklevel=False, match=msg
         ):
             result = left // right
 
@@ -2146,7 +2147,7 @@ class TestTimedeltaArraylikeMulDivOps:
 
         # case that goes through __rfloordiv__ with arraylike
         with tm.maybe_produces_warning(
-            RuntimeWarning, box is pd.array, check_stacklevel=False
+            RuntimeWarning, box is pd.array, check_stacklevel=False, match=msg
         ):
             result = np.asarray(left) // right
         tm.assert_equal(result, expected)

--- a/pandas/tests/frame/indexing/test_indexing.py
+++ b/pandas/tests/frame/indexing/test_indexing.py
@@ -1497,7 +1497,10 @@ class TestDataFrameIndexing:
             names=["a", "b"],
         )
         df = DataFrame({"c": [1, 2, 3, 4]}, index=midx)
-        with tm.maybe_produces_warning(performance_warning, isinstance(indexer, tuple)):
+        msg = "indexing past lexsort depth may impact performance"
+        with tm.maybe_produces_warning(
+            performance_warning, isinstance(indexer, tuple), match=msg
+        ):
             result = df.loc[indexer]
         expected = DataFrame(
             {"c": [1, 2]}, index=Index([True, False], name="b", dtype=dtype)

--- a/pandas/tests/indexes/test_common.py
+++ b/pandas/tests/indexes/test_common.py
@@ -384,10 +384,12 @@ class TestCommon:
         is_pyarrow_str = str(index.dtype) == "string[pyarrow]" and dtype == "category"
         try:
             # Some of these conversions cannot succeed so we use a try / except
+            msg = "Casting complex values to real discards the imaginary part"
             with tm.assert_produces_warning(
                 warn,
                 raise_on_extra_warnings=is_pyarrow_str,
                 check_stacklevel=False,
+                match=msg,
             ):
                 result = index.astype(dtype)
         except (ValueError, TypeError, NotImplementedError, SystemError):

--- a/pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py
+++ b/pandas/tests/scalar/timestamp/methods/test_to_pydatetime.py
@@ -59,8 +59,9 @@ class TestTimestampToPyDatetime:
     def test_to_pydatetime_bijective(self):
         # Ensure that converting to datetime and back only loses precision
         # by going from nanoseconds to microseconds.
+        msg = "Discarding nonzero nanoseconds in conversion"
         exp_warning = None if Timestamp.max.nanosecond == 0 else UserWarning
-        with tm.assert_produces_warning(exp_warning):
+        with tm.assert_produces_warning(exp_warning, match=msg):
             pydt_max = Timestamp.max.to_pydatetime()
 
         assert (
@@ -69,7 +70,7 @@ class TestTimestampToPyDatetime:
         )
 
         exp_warning = None if Timestamp.min.nanosecond == 0 else UserWarning
-        with tm.assert_produces_warning(exp_warning):
+        with tm.assert_produces_warning(exp_warning, match=msg):
             pydt_min = Timestamp.min.to_pydatetime()
 
         # The next assertion can be enabled once GH#39221 is merged

--- a/pandas/tests/series/accessors/test_cat_accessor.py
+++ b/pandas/tests/series/accessors/test_cat_accessor.py
@@ -205,17 +205,22 @@ class TestCatAccessor:
 
         for func, args, kwargs in func_defs:
             warn_cls = []
+            warn_msg = []
             if func == "to_period" and getattr(idx, "tz", None) is not None:
                 # dropping TZ
                 warn_cls.append(UserWarning)
+                warn_msg.append("will drop timezone information")
             elif func == "to_pytimedelta":
                 # GH 57463
                 warn_cls.append(Pandas4Warning)
+                warn_msg.append("to_pytimedelta is deprecated")
             if warn_cls:
                 warn_cls = tuple(warn_cls)
+                warn_msg = tuple(warn_msg)
             else:
                 warn_cls = None
-            with tm.assert_produces_warning(warn_cls):
+                warn_msg = None
+            with tm.assert_produces_warning(warn_cls, match=warn_msg):
                 res = getattr(cat.dt, func)(*args, **kwargs)
                 exp = getattr(ser.dt, func)(*args, **kwargs)
 
@@ -230,7 +235,8 @@ class TestCatAccessor:
                 warn_cls = Pandas4Warning
             else:
                 warn_cls = None
-            with tm.assert_produces_warning(warn_cls):
+            msg = "will return a BaseOffset object instead of a string"
+            with tm.assert_produces_warning(warn_cls, match=msg):
                 res = getattr(cat.dt, attr)
                 exp = getattr(ser.dt, attr)
 

--- a/pandas/tests/test_errors.py
+++ b/pandas/tests/test_errors.py
@@ -123,7 +123,7 @@ def test_AbstractMethodError_classmethod():
 )
 def test_pandas_warnings(warn_category, catch_category):
     # https://github.com/pandas-dev/pandas/pull/61468
-    with tm.assert_produces_warning(catch_category):
+    with tm.assert_produces_warning(catch_category, match="test"):
         warnings.warn("test", category=warn_category)
 
 

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -289,8 +289,9 @@ def test_parsers_month_freq(date_str, expected):
     ],
 )
 def test_guess_datetime_format_with_parseable_formats(string, fmt):
+    msg = r"when dayfirst=False \(the default\) was specified"
     with tm.maybe_produces_warning(
-        UserWarning, fmt is not None and re.search(r"%d.*%m", fmt)
+        UserWarning, fmt is not None and re.search(r"%d.*%m", fmt), match=msg
     ):
         result = parsing.guess_datetime_format(string)
     assert result == fmt


### PR DESCRIPTION
- [x] xref GH-58290
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

The long tail of GH-58290: nine scattered single call sites, plus the four remaining `tm.maybe_produces_warning` calls. That helper forwards `**kwargs` straight into `assert_produces_warning`, so it accepts `match` as well — worth covering, or it is a one-word way around the check.

Where the expected warning is computed, the match is computed the same way, so each parametrization checks its own message (`f"invalid value encountered in {op}"`, and a `tuple` of matches alongside the `tuple` of classes in `test_dt_accessor_api_for_categorical`).

Two sites are only reachable when a condition holds, so they were verified by deliberately breaking the match and confirming the test goes red rather than by assuming:
- `test_dt_accessor_api_for_categorical` — both the `to_period`-with-tz and `to_pytimedelta` branches do fire, against `Converting to PeriodArray/Index representation will drop timezone information.` and `The behavior of TimedeltaProperties.to_pytimedelta is deprecated ...`.
- `test_guess_datetime_format_with_parseable_formats` — fires only for formats matching `%d.*%m`. The message embeds the format itself, so the match uses the format-independent tail, with the parentheses escaped: `r"when dayfirst=False \(the default\) was specified"`.

`test_api.py` / `test_types.py` are the one place a match cannot be verified: both loops iterate over a `deprecated` list that is currently empty, so nothing is emitted. They use `match="deprecated"`.

Note `pandas/tests/api/test_api.py::TestApi::test_api` fails on main when `pandas/tests/api/` is run on its own — it needs something else to have imported `pandas.api.internals` first. Unrelated to this PR and not touched here.