### PR TITLE
TST: enforce that assert_produces_warning checks the warning message

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -263,6 +263,12 @@ repos:
         entry: python scripts/validate_unwanted_patterns.py --validation-type="bare_pipe_alternation_in_message"
         types: [python]
         files: ^pandas/tests/
+    -   id: unwanted-patterns-bare-assert-produces-warning
+        name: Check that assert_produces_warning also checks the warning message
+        language: python
+        entry: python scripts/validate_unwanted_patterns.py --validation-type="bare_assert_produces_warning"
+        types: [python]
+        files: ^pandas/tests/
     -   id: no-return-exception
         name: Use raise instead of return for exceptions
         language: pygrep

--- a/pandas/tests/util/test_assert_produces_warning.py
+++ b/pandas/tests/util/test_assert_produces_warning.py
@@ -46,10 +46,12 @@ def test_assert_produces_warning_honors_filter():
     # Raise by default.
     msg = r"Caused unexpected warning\(s\)"
     with pytest.raises(AssertionError, match=msg):
-        with tm.assert_produces_warning(RuntimeWarning):
+        with tm.assert_produces_warning(RuntimeWarning, match="f2"):
             f()
 
-    with tm.assert_produces_warning(RuntimeWarning, raise_on_extra_warnings=False):
+    with tm.assert_produces_warning(
+        RuntimeWarning, raise_on_extra_warnings=False, match="f2"
+    ):
         f()
 
 
@@ -135,13 +137,17 @@ def test_fail_to_catch_actual_warning(pair_different_warnings):
     expected_category, actual_category = pair_different_warnings
     match = "Did not see expected warning of class"
     with pytest.raises(AssertionError, match=match):
-        with tm.assert_produces_warning(expected_category):
+        # match=None: the expected class is never emitted, so the message
+        #  assertion is unreachable -- that is what this test is checking.
+        with tm.assert_produces_warning(expected_category, match=None):
             warnings.warn("warning message", actual_category)
 
 
 def test_ignore_extra_warning(pair_different_warnings):
     expected_category, extra_category = pair_different_warnings
-    with tm.assert_produces_warning(expected_category, raise_on_extra_warnings=False):
+    with tm.assert_produces_warning(
+        expected_category, raise_on_extra_warnings=False, match="Expected warning"
+    ):
         warnings.warn("Expected warning", expected_category)
         warnings.warn("Unexpected warning OK", extra_category)
 
@@ -150,7 +156,7 @@ def test_raise_on_extra_warning(pair_different_warnings):
     expected_category, extra_category = pair_different_warnings
     match = r"Caused unexpected warning\(s\)"
     with pytest.raises(AssertionError, match=match):
-        with tm.assert_produces_warning(expected_category):
+        with tm.assert_produces_warning(expected_category, match="Expected warning"):
             warnings.warn("Expected warning", expected_category)
             warnings.warn("Unexpected warning NOT OK", extra_category)
 
@@ -227,29 +233,35 @@ def test_right_category_wrong_match_raises(pair_different_warnings):
 
 @pytest.mark.parametrize("false_or_none", [False, None])
 class TestFalseOrNoneExpectedWarning:
+    # match=None throughout: false_or_none means no warning is expected, so
+    #  there is no message to assert.
     def test_raise_on_warning(self, false_or_none):
         msg = r"Caused unexpected warning\(s\)"
         with pytest.raises(AssertionError, match=msg):
-            with tm.assert_produces_warning(false_or_none):
+            with tm.assert_produces_warning(false_or_none, match=None):
                 f()
 
     def test_no_raise_without_warning(self, false_or_none):
-        with tm.assert_produces_warning(false_or_none):
+        with tm.assert_produces_warning(false_or_none, match=None):
             pass
 
     def test_no_raise_with_false_raise_on_extra(self, false_or_none):
-        with tm.assert_produces_warning(false_or_none, raise_on_extra_warnings=False):
+        with tm.assert_produces_warning(
+            false_or_none, raise_on_extra_warnings=False, match=None
+        ):
             f()
 
 
 def test_raises_during_exception():
     msg = "Did not see expected warning of class 'UserWarning'"
+    # match=None below: no UserWarning is emitted at all, so there is no
+    #  message to assert -- the point is that the exception propagates.
     with pytest.raises(AssertionError, match=msg):
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match=None):
             raise ValueError
 
     with pytest.raises(AssertionError, match=msg):
-        with tm.assert_produces_warning(UserWarning):
+        with tm.assert_produces_warning(UserWarning, match=None):
             warnings.warn(
                 "FutureWarning", FutureWarning
             )  # pdlint: ignore[warning_class]

--- a/scripts/tests/test_validate_unwanted_patterns.py
+++ b/scripts/tests/test_validate_unwanted_patterns.py
@@ -406,3 +406,69 @@ def test_bare_pipe_alternation_in_message_raises(data, expected) -> None:
     fd = io.StringIO(data.strip())
     result = list(validate_unwanted_patterns.bare_pipe_alternation_in_message(fd))
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "helper", ["assert_produces_warning", "maybe_produces_warning"]
+)
+@pytest.mark.parametrize(
+    "data",
+    [
+        # a match argument is present
+        'tm.{helper}(FutureWarning, match="some message")',
+        "tm.{helper}(FutureWarning, match=msg)",
+        # explicitly opting out of the message assertion
+        "tm.{helper}(FutureWarning, match=None)",
+        # no warning is expected, so there is no message to match
+        "tm.{helper}(None)",
+        "tm.{helper}(False)",
+        "tm.{helper}(expected_warning=None)",
+        # unrelated call
+        "tm.assert_frame_equal(left, right)",
+    ],
+)
+def test_bare_assert_produces_warning(data, helper) -> None:
+    fd = io.StringIO(data.format(helper=helper).strip())
+    result = list(validate_unwanted_patterns.bare_assert_produces_warning(fd))
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    "helper", ["assert_produces_warning", "maybe_produces_warning"]
+)
+@pytest.mark.parametrize(
+    "data",
+    [
+        "tm.{helper}(FutureWarning)",
+        # imported directly rather than through the tm namespace
+        "{helper}(FutureWarning)",
+        # a non-literal expected warning could still be falsy at runtime, but
+        #  that cannot be seen statically -- flag it and let the author decide
+        "tm.{helper}(warn)",
+        # the default expected_warning is `Warning`, which is truthy
+        "tm.{helper}()",
+        "tm.{helper}(expected_warning=FutureWarning)",
+        # other keywords do not stand in for match
+        "tm.{helper}(FutureWarning, check_stacklevel=False)",
+    ],
+)
+def test_bare_assert_produces_warning_raises(data, helper) -> None:
+    fd = io.StringIO(data.format(helper=helper).strip())
+    result = list(validate_unwanted_patterns.bare_assert_produces_warning(fd))
+    assert len(result) == 1
+    assert result[0][0] == 1
+    assert result[0][1] == (
+        validate_unwanted_patterns.BARE_WARNING_MATCH_MESSAGE.format(name=helper)
+    )
+
+
+def test_bare_assert_produces_warning_pdlint_ignore() -> None:
+    data = """
+with tm.assert_produces_warning(  # pdlint: ignore[bare_warning_match]
+    FutureWarning
+):
+    pass
+"""
+    fd = io.StringIO(data.strip())
+    result = list(validate_unwanted_patterns.bare_assert_produces_warning(fd))
+    assert result == []

--- a/scripts/validate_unwanted_patterns.py
+++ b/scripts/validate_unwanted_patterns.py
@@ -498,6 +498,83 @@ def bare_pipe_alternation_in_message(file_obj: IO[str]) -> Iterable[tuple[int, s
                 yield (value.lineno, BARE_PIPE_MESSAGE)
 
 
+WARNING_ASSERTION_HELPERS = frozenset(
+    {"assert_produces_warning", "maybe_produces_warning"}
+)
+
+BARE_WARNING_MATCH_MESSAGE = (
+    "{name} without a match argument; pass match=... so the warning message is "
+    "checked and not just its class. Use match=None (or "
+    "`# pdlint: ignore[bare_warning_match]`) if the message genuinely cannot be "
+    "asserted here."
+)
+
+
+def bare_assert_produces_warning(file_obj: IO[str]) -> Iterable[tuple[int, str]]:
+    """
+    Check that warning assertions also assert the warning message.
+
+    ``tm.assert_produces_warning(SomeWarning)`` only pins down the class, so a
+    deprecation message can be reworded -- or stop being emitted for the reason
+    the test cares about -- without any test noticing. Passing ``match=``
+    checks what users actually see.
+
+    Calls that expect no warning at all (``assert_produces_warning(None)`` and
+    ``assert_produces_warning(False)``) are exempt, as is an explicit
+    ``match=None``.
+
+    Parameters
+    ----------
+    file_obj : IO
+        File-like object containing the Python code to validate.
+
+    Yields
+    ------
+    line_number : int
+        Line number of the offending call.
+    msg : str
+        Explanation of the error.
+    """
+    contents = file_obj.read()
+    lines = contents.split("\n")
+    tree = ast.parse(contents)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        func = node.func
+        if isinstance(func, ast.Attribute):
+            name = func.attr
+        elif isinstance(func, ast.Name):
+            name = func.id
+        else:
+            continue
+        if name not in WARNING_ASSERTION_HELPERS:
+            continue
+
+        if any(keyword.arg == "match" for keyword in node.keywords):
+            continue
+
+        expected = node.args[0] if node.args else None
+        if expected is None:
+            for keyword in node.keywords:
+                if keyword.arg == "expected_warning":
+                    expected = keyword.value
+        # `assert_produces_warning(None)` / `(False)` assert that nothing is
+        # raised, so there is no message to match.
+        if isinstance(expected, ast.Constant) and not expected.value:
+            continue
+
+        if any(
+            "# pdlint: ignore[bare_warning_match]" in lines[k]
+            for k in range(node.lineno - 1, min(node.end_lineno + 1, len(lines)))
+        ):
+            continue
+
+        yield (node.lineno, BARE_WARNING_MATCH_MESSAGE.format(name=name))
+
+
 def main(
     function: Callable[[IO[str]], Iterable[tuple[int, str]]],
     source_path: str,
@@ -548,6 +625,7 @@ if __name__ == "__main__":
         "nodefault_used_not_only_for_typing",
         "doesnt_use_pandas_warnings",
         "bare_pipe_alternation_in_message",
+        "bare_assert_produces_warning",
     ]
 
     parser = argparse.ArgumentParser(description="Unwanted patterns checker.")


### PR DESCRIPTION
- [x] closes #58290
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).

The enforcement half of GH-58290. The four content PRs it depended on — GH-67270, GH-67271, GH-67273, GH-67274 — have all merged, so this now runs clean; rebased onto their tips.

Adds a `bare_assert_produces_warning` check to `scripts/validate_unwanted_patterns.py`, wired up as a pre-commit hook scoped to `pandas/tests/`. It flags `tm.assert_produces_warning(SomeWarning)` with no `match` argument.

It also covers `tm.maybe_produces_warning`, which forwards `**kwargs` straight into `assert_produces_warning`. Without that, swapping one helper for the other is a one-word way around the check.

**Exemptions.** Calls asserting that nothing is raised — `assert_produces_warning(None)` and `(False)` — are exempt, since there is no message to match. Beyond that an explicit `match=None` opts out, which is roughly the `tm.external_warning_produced` escape hatch suggested in the issue; `# pdlint: ignore[bare_warning_match]` also works, following the existing `pdlint` convention in this script.

The only place needing an exemption today is the helper's own test file, and in each case the message assertion is unreachable by construction rather than merely inconvenient:

- `TestFalseOrNoneExpectedWarning` parametrizes `false_or_none` over `[False, None]`, so no warning is expected at all — but the value is a name, not a literal, so a static check cannot see that.
- `test_fail_to_catch_actual_warning` and `test_raises_during_exception` never emit the expected class, so `assert_produces_warning` raises `Did not see expected warning of class ...` before it ever looks at `match` — which is exactly what those tests assert.

The other four calls in that file did have an assertable message and now check it.

**Verified against the full tree.** `pre-commit run --all-files` passes on the rebased branch with no files modified, so the check reports zero violations across every file in `pandas/tests/` and lands with no exclusion list. (Cross-checked that it is not silently passing by feeding it a deliberately bare call, which it flags.)

`scripts/tests/test_validate_unwanted_patterns.py` covers both helper names, the `tm.`-qualified and bare forms, each exempt spelling, the implicit `Warning` default, and the `pdlint` comment.
