### PR TITLE
CLN: Remove dead code left by the builtin/NumPy alias enforcement

### DIFF
--- a/pandas/_testing/__init__.py
+++ b/pandas/_testing/__init__.py
@@ -86,7 +86,6 @@ if TYPE_CHECKING:
     from collections.abc import (
         Callable,
         Iterable,
-        Sequence,
     )
     from contextlib import AbstractContextManager
 
@@ -403,32 +402,6 @@ def external_error_raised(
     return pytest.raises(expected_exception, match=None)
 
 
-def get_cython_table_params(
-    ndframe: DataFrame | Series,
-    func_names_and_expected: Iterable[Sequence[Any]],
-) -> list[tuple[DataFrame | Series, str, Any]]:
-    """
-    Combine frame, functions from com._cython_table
-    keys and expected result.
-
-    Parameters
-    ----------
-    ndframe : DataFrame or Series
-    func_names_and_expected : Sequence of two items
-        The first item is a name of an NDFrame method ('sum', 'prod') etc.
-        The second item is the expected return value.
-
-    Returns
-    -------
-    list
-        List of three items (DataFrame, function, expected result)
-    """
-    results = []
-    for func_name, expected in func_names_and_expected:
-        results.append((ndframe, func_name, expected))
-    return results
-
-
 def get_op_from_name(op_name: str) -> Callable:
     """
     The operator function for a given op name.
@@ -651,7 +624,6 @@ __all__ = [
     "convert_rows_list_to_csv_str",
     "decompress_file",
     "external_error_raised",
-    "get_cython_table_params",
     "get_dtype",
     "get_finest_unit",
     "get_locales",

--- a/pandas/tests/apply/test_invalid_arg.py
+++ b/pandas/tests/apply/test_invalid_arg.py
@@ -208,14 +208,12 @@ def test_apply_modify_traceback():
         data.apply(transform, axis=1)
 
 
-@pytest.mark.parametrize(
-    "df, func, expected",
-    [(DataFrame([["a", "b"], ["b", "a"]]), "cumprod", TypeError)],
-)
-def test_agg_raises_frame(df, func, expected, axis, using_infer_string):
+def test_agg_raises_frame(axis, using_infer_string):
     # GH 21224
+    df = DataFrame([["a", "b"], ["b", "a"]])
+    expected = TypeError
     if using_infer_string:
-        expected = (expected, NotImplementedError)
+        expected = (TypeError, NotImplementedError)
 
     msg = "|".join(
         [
@@ -227,22 +225,14 @@ def test_agg_raises_frame(df, func, expected, axis, using_infer_string):
         ]
     )
     with pytest.raises(expected, match=msg):
-        df.agg(func, axis=axis)
+        df.agg("cumprod", axis=axis)
 
 
-@pytest.mark.parametrize(
-    "series, func, expected",
-    [
-        (Series("a b c".split()), "mean", TypeError),  # mean raises TypeError
-        (Series("a b c".split()), "prod", TypeError),
-        (Series("a b c".split()), "std", TypeError),
-        (Series("a b c".split()), "var", TypeError),
-        (Series("a b c".split()), "median", TypeError),
-        (Series("a b c".split()), "cumprod", TypeError),
-    ],
-)
-def test_agg_raises_series(series, func, expected, using_infer_string):
+@pytest.mark.parametrize("func", ["mean", "prod", "std", "var", "median", "cumprod"])
+def test_agg_raises_series(func, using_infer_string):
     # GH21224
+    series = Series("a b c".split())
+    expected = TypeError
     msg = "|".join(
         ["[Cc]ould not convert", "can't multiply sequence by non-int of type"]
     )
@@ -250,7 +240,7 @@ def test_agg_raises_series(series, func, expected, using_infer_string):
         msg = r"Cannot convert \['a' 'b' 'c'\] to numeric"
 
     if using_infer_string and func == "cumprod":
-        expected = (expected, NotImplementedError)
+        expected = (TypeError, NotImplementedError)
 
     msg = "|".join(
         [

--- a/pandas/tests/apply/test_invalid_arg.py
+++ b/pandas/tests/apply/test_invalid_arg.py
@@ -6,7 +6,6 @@
 #     4. invalid result shape/type
 # If your test does not fit into one of these categories, add to this list.
 
-from itertools import chain
 import re
 
 import numpy as np
@@ -211,11 +210,9 @@ def test_apply_modify_traceback():
 
 @pytest.mark.parametrize(
     "df, func, expected",
-    tm.get_cython_table_params(
-        DataFrame([["a", "b"], ["b", "a"]]), [["cumprod", TypeError]]
-    ),
+    [(DataFrame([["a", "b"], ["b", "a"]]), "cumprod", TypeError)],
 )
-def test_agg_cython_table_raises_frame(df, func, expected, axis, using_infer_string):
+def test_agg_raises_frame(df, func, expected, axis, using_infer_string):
     # GH 21224
     if using_infer_string:
         expected = (expected, NotImplementedError)
@@ -229,36 +226,27 @@ def test_agg_cython_table_raises_frame(df, func, expected, axis, using_infer_str
             "operation 'cumprod' not supported for dtype 'str'",
         ]
     )
-    warn = None if isinstance(func, str) else FutureWarning
     with pytest.raises(expected, match=msg):
-        with tm.assert_produces_warning(warn, match="using DataFrame.cumprod"):
-            df.agg(func, axis=axis)
+        df.agg(func, axis=axis)
 
 
 @pytest.mark.parametrize(
     "series, func, expected",
-    list(
-        chain(
-            tm.get_cython_table_params(
-                Series("a b c".split()),
-                [
-                    ("mean", TypeError),  # mean raises TypeError
-                    ("prod", TypeError),
-                    ("std", TypeError),
-                    ("var", TypeError),
-                    ("median", TypeError),
-                    ("cumprod", TypeError),
-                ],
-            )
-        )
-    ),
+    [
+        (Series("a b c".split()), "mean", TypeError),  # mean raises TypeError
+        (Series("a b c".split()), "prod", TypeError),
+        (Series("a b c".split()), "std", TypeError),
+        (Series("a b c".split()), "var", TypeError),
+        (Series("a b c".split()), "median", TypeError),
+        (Series("a b c".split()), "cumprod", TypeError),
+    ],
 )
-def test_agg_cython_table_raises_series(series, func, expected, using_infer_string):
+def test_agg_raises_series(series, func, expected, using_infer_string):
     # GH21224
     msg = "|".join(
         ["[Cc]ould not convert", "can't multiply sequence by non-int of type"]
     )
-    if func == "median" or func is np.nanmedian or func is np.median:
+    if func == "median":
         msg = r"Cannot convert \['a' 'b' 'c'\] to numeric"
 
     if using_infer_string and func == "cumprod":
@@ -274,12 +262,9 @@ def test_agg_cython_table_raises_series(series, func, expected, using_infer_stri
             "operation",
         ]
     )
-    warn = None if isinstance(func, str) else FutureWarning
-
     with pytest.raises(expected, match=msg):
         # e.g. Series('a b'.split()).cumprod() will raise
-        with tm.assert_produces_warning(warn, match="is currently using Series.*"):
-            series.agg(func)
+        series.agg(func)
 
 
 def test_agg_none_to_type():

--- a/pandas/tests/apply/test_str.py
+++ b/pandas/tests/apply/test_str.py
@@ -1,4 +1,3 @@
-from itertools import chain
 import operator
 
 import numpy as np
@@ -83,58 +82,37 @@ def test_apply_np_transformer(float_frame, op, how):
 
 @pytest.mark.parametrize(
     "series, func, expected",
-    list(
-        chain(
-            tm.get_cython_table_params(
-                Series(dtype=np.float64),
-                [
-                    ("sum", 0),
-                    ("max", np.nan),
-                    ("min", np.nan),
-                    ("all", True),
-                    ("any", False),
-                    ("mean", np.nan),
-                    ("prod", 1),
-                    ("std", np.nan),
-                    ("var", np.nan),
-                    ("median", np.nan),
-                ],
-            ),
-            tm.get_cython_table_params(
-                Series([np.nan, 1, 2, 3]),
-                [
-                    ("sum", 6),
-                    ("max", 3),
-                    ("min", 1),
-                    ("all", True),
-                    ("any", True),
-                    ("mean", 2),
-                    ("prod", 6),
-                    ("std", 1),
-                    ("var", 1),
-                    ("median", 2),
-                ],
-            ),
-            tm.get_cython_table_params(
-                Series("a b c".split()),
-                [
-                    ("sum", "abc"),
-                    ("max", "c"),
-                    ("min", "a"),
-                    ("all", True),
-                    ("any", True),
-                ],
-            ),
-        )
-    ),
+    [
+        (Series(dtype=np.float64), "sum", 0),
+        (Series(dtype=np.float64), "max", np.nan),
+        (Series(dtype=np.float64), "min", np.nan),
+        (Series(dtype=np.float64), "all", True),
+        (Series(dtype=np.float64), "any", False),
+        (Series(dtype=np.float64), "mean", np.nan),
+        (Series(dtype=np.float64), "prod", 1),
+        (Series(dtype=np.float64), "std", np.nan),
+        (Series(dtype=np.float64), "var", np.nan),
+        (Series(dtype=np.float64), "median", np.nan),
+        (Series([np.nan, 1, 2, 3]), "sum", 6),
+        (Series([np.nan, 1, 2, 3]), "max", 3),
+        (Series([np.nan, 1, 2, 3]), "min", 1),
+        (Series([np.nan, 1, 2, 3]), "all", True),
+        (Series([np.nan, 1, 2, 3]), "any", True),
+        (Series([np.nan, 1, 2, 3]), "mean", 2),
+        (Series([np.nan, 1, 2, 3]), "prod", 6),
+        (Series([np.nan, 1, 2, 3]), "std", 1),
+        (Series([np.nan, 1, 2, 3]), "var", 1),
+        (Series([np.nan, 1, 2, 3]), "median", 2),
+        (Series("a b c".split()), "sum", "abc"),
+        (Series("a b c".split()), "max", "c"),
+        (Series("a b c".split()), "min", "a"),
+        (Series("a b c".split()), "all", True),
+        (Series("a b c".split()), "any", True),
+    ],
 )
-def test_agg_cython_table_series(series, func, expected):
+def test_agg_reduction_series(series, func, expected):
     # GH21224
-    # test reducing functions in
-    # pandas.core.base.SelectionMixin._cython_table
-    warn = None if isinstance(func, str) else FutureWarning
-    with tm.assert_produces_warning(warn, match="is currently using Series.*"):
-        result = series.agg(func)
+    result = series.agg(func)
     if is_number(expected):
         assert np.isclose(result, expected, equal_nan=True)
     else:
@@ -143,115 +121,71 @@ def test_agg_cython_table_series(series, func, expected):
 
 @pytest.mark.parametrize(
     "series, func, expected",
-    list(
-        chain(
-            tm.get_cython_table_params(
-                Series(dtype=np.float64),
-                [
-                    ("cumprod", Series([], dtype=np.float64)),
-                    ("cumsum", Series([], dtype=np.float64)),
-                ],
-            ),
-            tm.get_cython_table_params(
-                Series([np.nan, 1, 2, 3]),
-                [
-                    ("cumprod", Series([np.nan, 1, 2, 6])),
-                    ("cumsum", Series([np.nan, 1, 3, 6])),
-                ],
-            ),
-            tm.get_cython_table_params(
-                Series("a b c".split()), [("cumsum", Series(["a", "ab", "abc"]))]
-            ),
-        )
-    ),
+    [
+        (Series(dtype=np.float64), "cumprod", Series([], dtype=np.float64)),
+        (Series(dtype=np.float64), "cumsum", Series([], dtype=np.float64)),
+        (Series([np.nan, 1, 2, 3]), "cumprod", Series([np.nan, 1, 2, 6])),
+        (Series([np.nan, 1, 2, 3]), "cumsum", Series([np.nan, 1, 3, 6])),
+        (Series("a b c".split()), "cumsum", Series(["a", "ab", "abc"])),
+    ],
 )
-def test_agg_cython_table_transform_series(series, func, expected):
+def test_agg_transform_series(series, func, expected):
     # GH21224
-    # test transforming functions in
-    # pandas.core.base.SelectionMixin._cython_table (cumprod, cumsum)
-    warn = None if isinstance(func, str) else FutureWarning
-    with tm.assert_produces_warning(warn, match="is currently using Series.*"):
-        result = series.agg(func)
+    result = series.agg(func)
     tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(
     "df, func, expected",
-    list(
-        chain(
-            tm.get_cython_table_params(
-                DataFrame(),
-                [
-                    ("sum", Series(dtype="float64")),
-                    ("max", Series(dtype="float64")),
-                    ("min", Series(dtype="float64")),
-                    ("all", Series(dtype=bool)),
-                    ("any", Series(dtype=bool)),
-                    ("mean", Series(dtype="float64")),
-                    ("prod", Series(dtype="float64")),
-                    ("std", Series(dtype="float64")),
-                    ("var", Series(dtype="float64")),
-                    ("median", Series(dtype="float64")),
-                ],
-            ),
-            tm.get_cython_table_params(
-                DataFrame([[np.nan, 1], [1, 2]]),
-                [
-                    ("sum", Series([1.0, 3])),
-                    ("max", Series([1.0, 2])),
-                    ("min", Series([1.0, 1])),
-                    ("all", Series([True, True])),
-                    ("any", Series([True, True])),
-                    ("mean", Series([1, 1.5])),
-                    ("prod", Series([1.0, 2])),
-                    ("std", Series([np.nan, 0.707107])),
-                    ("var", Series([np.nan, 0.5])),
-                    ("median", Series([1, 1.5])),
-                ],
-            ),
-        )
-    ),
+    [
+        (DataFrame(), "sum", Series(dtype="float64")),
+        (DataFrame(), "max", Series(dtype="float64")),
+        (DataFrame(), "min", Series(dtype="float64")),
+        (DataFrame(), "all", Series(dtype=bool)),
+        (DataFrame(), "any", Series(dtype=bool)),
+        (DataFrame(), "mean", Series(dtype="float64")),
+        (DataFrame(), "prod", Series(dtype="float64")),
+        (DataFrame(), "std", Series(dtype="float64")),
+        (DataFrame(), "var", Series(dtype="float64")),
+        (DataFrame(), "median", Series(dtype="float64")),
+        (DataFrame([[np.nan, 1], [1, 2]]), "sum", Series([1.0, 3])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "max", Series([1.0, 2])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "min", Series([1.0, 1])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "all", Series([True, True])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "any", Series([True, True])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "mean", Series([1, 1.5])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "prod", Series([1.0, 2])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "std", Series([np.nan, 0.707107])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "var", Series([np.nan, 0.5])),
+        (DataFrame([[np.nan, 1], [1, 2]]), "median", Series([1, 1.5])),
+    ],
 )
-def test_agg_cython_table_frame(df, func, expected, axis):
+def test_agg_reduction_frame(df, func, expected, axis):
     # GH 21224
-    # test reducing functions in
-    # pandas.core.base.SelectionMixin._cython_table
-    warn = None if isinstance(func, str) else FutureWarning
-    with tm.assert_produces_warning(warn, match="is currently using DataFrame.*"):
-        # GH#53425
-        result = df.agg(func, axis=axis)
+    result = df.agg(func, axis=axis)
     tm.assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize(
     "df, func, expected",
-    list(
-        chain(
-            tm.get_cython_table_params(
-                DataFrame(), [("cumprod", DataFrame()), ("cumsum", DataFrame())]
-            ),
-            tm.get_cython_table_params(
-                DataFrame([[np.nan, 1], [1, 2]]),
-                [
-                    ("cumprod", DataFrame([[np.nan, 1], [1, 2]])),
-                    ("cumsum", DataFrame([[np.nan, 1], [1, 3]])),
-                ],
-            ),
-        )
-    ),
+    [
+        (DataFrame(), "cumprod", DataFrame()),
+        (DataFrame(), "cumsum", DataFrame()),
+        (
+            DataFrame([[np.nan, 1], [1, 2]]),
+            "cumprod",
+            DataFrame([[np.nan, 1], [1, 2]]),
+        ),
+        (DataFrame([[np.nan, 1], [1, 2]]), "cumsum", DataFrame([[np.nan, 1], [1, 3]])),
+    ],
 )
-def test_agg_cython_table_transform_frame(df, func, expected, axis):
+def test_agg_transform_frame(df, func, expected, axis):
     # GH 21224
-    # test transforming functions in
-    # pandas.core.base.SelectionMixin._cython_table (cumprod, cumsum)
     if axis in ("columns", 1):
         # operating blockwise doesn't let us preserve dtypes
         expected = expected.astype("float64")
 
-    warn = None if isinstance(func, str) else FutureWarning
-    with tm.assert_produces_warning(warn, match="is currently using DataFrame.*"):
-        # GH#53425
-        result = df.agg(func, axis=axis)
+    result = df.agg(func, axis=axis)
     tm.assert_frame_equal(result, expected)
 
 
@@ -262,14 +196,9 @@ def test_transform_groupby_kernel_series(request, string_series, op):
         request.applymarker(
             pytest.mark.xfail(raises=ValueError, reason="ngroup not valid for NDFrame")
         )
-    args = [0.0] if op == "fillna" else []
     ones = np.ones(string_series.shape[0])
-
-    warn = FutureWarning if op == "fillna" else None
-    msg = "SeriesGroupBy.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=msg):
-        expected = string_series.groupby(ones).transform(op, *args)
-    result = string_series.transform(op, 0, *args)
+    expected = string_series.groupby(ones).transform(op)
+    result = string_series.transform(op, 0)
     tm.assert_series_equal(result, expected)
 
 
@@ -282,16 +211,11 @@ def test_transform_groupby_kernel_frame(request, float_frame, op):
 
     # GH 35964
 
-    args = [0.0] if op == "fillna" else []
     ones = np.ones(float_frame.shape[0])
     gb = float_frame.groupby(ones)
+    expected = gb.transform(op)
 
-    warn = FutureWarning if op == "fillna" else None
-    op_msg = "DataFrameGroupBy.fillna is deprecated"
-    with tm.assert_produces_warning(warn, match=op_msg):
-        expected = gb.transform(op, *args)
-
-    result = float_frame.transform(op, 0, *args)
+    result = float_frame.transform(op, 0)
     tm.assert_frame_equal(result, expected)
 
     # same thing, but ensuring we have multiple blocks
@@ -301,8 +225,8 @@ def test_transform_groupby_kernel_frame(request, float_frame, op):
 
     ones = np.ones(float_frame.shape[0])
     gb2 = float_frame.groupby(ones)
-    expected2 = gb2.transform(op, *args)
-    result2 = float_frame.transform(op, 0, *args)
+    expected2 = gb2.transform(op)
+    result2 = float_frame.transform(op, 0)
     tm.assert_frame_equal(result2, expected2)
 
 

--- a/pandas/tests/arrays/categorical/test_indexing.py
+++ b/pandas/tests/arrays/categorical/test_indexing.py
@@ -358,27 +358,6 @@ def test_mask_with_boolean_na_treated_as_false(index):
     tm.assert_series_equal(result, expected)
 
 
-@pytest.fixture
-def non_coercible_categorical(monkeypatch):
-    """
-    Monkeypatch Categorical.__array__ to ensure no implicit conversion.
-
-    Raises
-    ------
-    ValueError
-        When Categorical.__array__ is called.
-    """
-
-    # TODO(Categorical): identify other places where this may be
-    # useful and move to a conftest.py
-    def array(self, dtype=None):
-        raise ValueError("I cannot be converted.")
-
-    with monkeypatch.context() as m:
-        m.setattr(Categorical, "__array__", array)
-        yield
-
-
 def test_series_at():
     arr = Categorical(["a", "b", "c"])
     ser = Series(arr)


### PR DESCRIPTION
Fallout from GH-57444, which enforced the deprecation of substituting pandas methods for builtin/NumPy funcs in `agg`/`apply`/`transform` (GH-53425). That enforcement gutted `tm.get_cython_table_params` down to an identity function — it no longer combines anything with `_cython_table`, it just returns `(ndframe, func_name, expected)` — and left the tests that consumed it holding branches that can no longer be reached.

- Delete `tm.get_cython_table_params` and inline its call sites as plain parametrize tuples.
- Drop `warn = None if isinstance(func, str) else FutureWarning` and the accompanying `assert_produces_warning` wrappers in `test_str.py` / `test_invalid_arg.py`. `func` is now always a string, so the warning was never produced and never asserted; `--collect-only` confirms every param id is a string kernel.
- Drop the stale comments pointing at `pandas.core.base.SelectionMixin._cython_table` (that attribute moved to `pandas/core/common.py` long ago and no longer governs this path), and the now-misleading `cython_table` test names.
- Drop the `op == "fillna"` branches in `test_transform_groupby_kernel_{series,frame}`: `fillna` is no longer a transform kernel and `SeriesGroupBy.fillna` no longer exists.
- Drop the parametrization from `test_agg_raises_frame` (one param set) and reduce `test_agg_raises_series` to varying `func` (the series and the expected exception were constant in every row).
- Drop the unused `non_coercible_categorical` fixture, which nothing has requested since GH-24204 and which GH-45692's unused-fixture sweep missed.

No behavior change, and the test count is unchanged (229 collected in `test_str.py` before and after, which is itself the proof that the helper was an identity).

Noticed while investigating GH-20674, which asked for a fixture enumerating the `np.*` entries of that same alias table — I think that issue is obsolete for the same reason and can be closed separately.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the dead branches, made the edits, and ran the test/lint/mypy checks.
