### PR TITLE
BUILD: ship the test data files in the sdist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -76,10 +76,7 @@ codecov.yml export-ignore
 environment.yml export-ignore
 
 
-# GH 39321
-# csv_dir_path fixture checks the existence of the directory
-# exclude the whole directory to avoid running related tests in sdist
-pandas/tests/io/parser/data export-ignore
-
-# Include cibw script in sdist since it's needed for building wheels
-scripts/cibw_before_build.sh -export-ignore
+# GH#54907
+# The extension-based rules above would otherwise strip the test data files,
+# leaving the test suite unrunnable from the sdist.
+pandas/tests/**/data/** -export-ignore


### PR DESCRIPTION
- [x] closes #54907

The extension-based `export-ignore` rules in `.gitattributes` (`*.csv`, `*.xlsx`, `*.sas7bdat`, `*.parquet`, ...) strip **488 test data files** from the sdist and from the GitHub source archive, so `pandas/tests/io/data`, `pandas/tests/io/sas/data`, `pandas/tests/io/json/data` etc. ship as empty directories. Running the test suite from an sdist therefore requires `--no-strict-data-files`, which silently *skips* every test needing a data file — which is what the distro packagers on the issue are asking not to have to do.

One rule un-ignores all of them. Verified with `git archive HEAD` (what meson-python uses to build the sdist): 0 tracked files under `pandas/` are now missing from the archive, and exactly the 488 test data files were added — nothing outside `pandas/tests/`. The wholesale `pandas/tests/io/parser/data export-ignore` line goes away too; its rationale (GH-39321: `csv_dir_path` checks that the directory exists) no longer applies once the files are actually there.

Also drops a stale line: `scripts/cibw_before_build.sh -export-ignore` refers to a script deleted in GH-64709.

**Size:** sdist 5.21 MB -> 8.37 MB compressed.

**Draft because of the wheel side.** Published wheels are built *from* the sdist (`wheels.yml` hands the sdist to cibuildwheel) and `pandas/meson.build` installs `pandas/tests` unconditionally, so on its own this adds ~3.2 MB to every published wheel, undoing part of GH-54052. That wants a companion knob on the meson side — a `tests`/`test-data` option passed via cibuildwheel `config-settings`, which is also what GH-30741 needs — so that the data is present for anyone who builds a wheel themselves (the packagers' actual workflow: build wheel from sdist, install, run tests) while pandas' own published wheels stay slim. Happy to fold that in here or land it first, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BikukF5FXsTV5ezVg3BozD