### PR TITLE
TST: skip the iceberg tests when their data file is absent

### DIFF
--- a/pandas/tests/io/test_iceberg.py
+++ b/pandas/tests/io/test_iceberg.py
@@ -26,7 +26,7 @@ Catalog = collections.namedtuple("Catalog", ["name", "uri", "warehouse"])
 
 
 @pytest.fixture
-def catalog(request, tmp_path):
+def catalog(request, tmp_path, datapath):
     # the catalog stores the full path of data files, so the catalog needs to be
     # created dynamically, and not saved in pandas/tests/io/data as other formats
     uri = f"sqlite:///{tmp_path}/catalog.sqlite"
@@ -40,9 +40,7 @@ def catalog(request, tmp_path):
     )
     catalog.create_namespace("ns")
 
-    df = pq.read_table(
-        pathlib.Path(__file__).parent / "data" / "parquet" / "simple.parquet"
-    )
+    df = pq.read_table(datapath("io", "data", "parquet", "simple.parquet"))
     table = catalog.create_table("ns.my_table", schema=df.schema)
     table.append(df)
 


### PR DESCRIPTION
Follow-up to GH-63437, which routed the remaining direct data-file reads through the `datapath` fixture. One was missed: the `catalog` fixture in `pandas/tests/io/test_iceberg.py` builds the path itself

```python
df = pq.read_table(pathlib.Path(__file__).parent / "data" / "parquet" / "simple.parquet")
```

so when the data files are absent — as they are in an sdist install, where `*.parquet` is `export-ignore`d — all 11 tests **error** with `FileNotFoundError` rather than skipping, even with `--no-strict-data-files`:

```
ERROR pandas/tests/io/test_iceberg.py::TestIceberg::test_read - FileNotFoundError: .../pandas/tests/io/data/parquet/simple.parquet
```

Going through `datapath` gives the intended behaviour: 11 skipped with `--no-strict-data-files`, a clear `ValueError` without it. Verified both ways locally, plus 11 passed with the data present.

Independent of GH-67292 (which puts the data back in the sdist) — worth having either way, since nothing in CI runs the suite against a tree without data files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BikukF5FXsTV5ezVg3BozD