### PR TITLE
BUG: infer mixed boolean, float, and integer dtype

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -452,6 +452,7 @@ Bug fixes
 ~~~~~~~~~
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :class:`Series` where empty frozensets were formatted incorrectly (:issue:`66192`)
+- Fixed bug in :func:`api.types.infer_dtype` returning ``"mixed-integer"`` instead of ``"mixed"`` for object arrays containing integer, float, and boolean values (:issue:`62033`)
 - Fixed bug in :func:`testing.assert_frame_equal` incorrectly raising when equivalent :class:`MultiIndex` column labels contained missing values (:issue:`54521`)
 - Fixed bug in :func:`testing.assert_frame_equal`, :func:`testing.assert_index_equal`, :func:`testing.assert_series_equal` and :func:`testing.assert_extension_array_equal` where ``rtol`` and ``atol`` were applied after casting to ``float64``, so integers above ``2**53`` could compare equal while differing by more than the tolerance, or unequal while within it (:issue:`66400`)
 - Fixed bug in :func:`testing.assert_series_equal` showing a misleading class mismatch message when Series values were backed by different :class:`numpy.ndarray` subclasses (:issue:`65770`)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1878,6 +1878,9 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
         Py_ssize_t _, n
         object val
         ndarray values
+        bint seen_bool = False
+        bint seen_float = False
+        bint seen_integer = False
         bint seen_pdnat = False
         bint seen_val = False
         flatiter it
@@ -1963,7 +1966,6 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
                 return "integer-na"
             else:
                 return "mixed-integer-float"
-        return "mixed-integer"
 
     elif PyDateTime_Check(val):
         if is_datetime_array(values, skipna=skipna):
@@ -2022,7 +2024,16 @@ def infer_dtype(value: object, skipna: bool = True) -> str:
         PyArray_ITER_NEXT(it)
 
         if util.is_integer_object(val):
-            return "mixed-integer"
+            seen_integer = True
+        elif util.is_bool_object(val):
+            seen_bool = True
+        elif util.is_float_object(val) and not util.is_nan(val):
+            seen_float = True
+
+    if seen_integer and seen_bool and seen_float:
+        return "mixed"
+    if seen_integer:
+        return "mixed-integer"
 
     return "mixed"
 

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -945,8 +945,10 @@ def nanmedian(
                 raise TypeError(f"Cannot convert {values} to numeric")
         try:
             values = values.astype("f8")
-        except ValueError as err:
+        except (TypeError, ValueError) as err:
             # e.g. "could not convert string to float: 'a'"
+            if values.dtype == object:
+                raise TypeError(f"Cannot convert {values} to numeric") from err
             raise TypeError(str(err)) from err
     if not using_nan_sentinel and mask is not None:
         if not values.flags.writeable:

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -939,7 +939,9 @@ def nanmedian(
         if values.dtype == object:
             # GH#34671 avoid casting strings to numeric
             inferred = lib.infer_dtype(values)
-            if inferred in ["string", "mixed"]:
+            if inferred == "string" or (
+                inferred == "mixed" and any(isinstance(x, str) for x in values.ravel())
+            ):
                 raise TypeError(f"Cannot convert {values} to numeric")
         try:
             values = values.astype("f8")

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -939,9 +939,7 @@ def nanmedian(
         if values.dtype == object:
             # GH#34671 avoid casting strings to numeric
             inferred = lib.infer_dtype(values)
-            if inferred == "string" or (
-                inferred == "mixed" and any(isinstance(x, str) for x in values.ravel())
-            ):
+            if inferred == "string":
                 raise TypeError(f"Cannot convert {values} to numeric")
         try:
             values = values.astype("f8")

--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -946,7 +946,7 @@ def nanmedian(
         except (TypeError, ValueError) as err:
             # e.g. "could not convert string to float: 'a'"
             if values.dtype == object:
-                raise TypeError(f"Cannot convert {values} to numeric") from err
+                raise TypeError("Cannot convert values to numeric") from err
             raise TypeError(str(err)) from err
     if not using_nan_sentinel and mask is not None:
         if not values.flags.writeable:

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -1452,6 +1452,23 @@ class TestTypeInference:
     @pytest.mark.parametrize(
         "arr",
         [
+            np.array([1, 1.0, True], dtype=object),
+            np.array([1.0, True, 1], dtype=object),
+            np.array([True, 1, 1.0], dtype=object),
+        ],
+    )
+    def test_infer_dtype_mixed_integer_float_bool(self, arr):
+        # GH 62033
+        assert lib.infer_dtype(arr, skipna=False) == "mixed"
+
+    def test_infer_dtype_mixed_integer_bool_nan(self):
+        # GH 62033
+        arr = np.array([1, True, np.nan], dtype=object)
+        assert lib.infer_dtype(arr, skipna=False) == "mixed-integer"
+
+    @pytest.mark.parametrize(
+        "arr",
+        [
             [Timestamp("2011-01-01"), Timestamp("2011-01-02")],
             [datetime(2011, 1, 1), datetime(2012, 2, 1)],
             [datetime(2011, 1, 1), Timestamp("2011-01-02")],

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -506,6 +506,12 @@ class TestnanopsDataFrame:
             allow_obj="convert",
         )
 
+    def test_nanmedian_mixed_integer_float_bool_object(self, skipna):
+        # GH 62033
+        arr = np.array([1, 1.0, True], dtype=object)
+        result = nanops.nanmedian(arr, skipna=skipna)
+        assert result == 1.0
+
     @pytest.mark.parametrize("ddof", range(3))
     def test_nanvar(self, ddof, skipna):
         self.check_funs(


### PR DESCRIPTION
- [x] closes #62033
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (N/A: no new arguments/methods/functions added.)
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting: Codex, GPT-5.5 medium.