### PR TITLE
TST: DataFrame operations with ExtensionArrays (GH#28506)

### DIFF
--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -11,6 +11,14 @@ import pandas as pd
 import pandas._testing as tm
 from pandas.core import ops
 
+# The axis=0 frame dispatch is the same code path for every op, so checking all of
+#  them multiplies runtime without adding coverage. The arithmetic and comparison
+#  flex methods use separate dispatch helpers, so keep one comparison plus the
+#  non-reflected arithmetic ops; reflected ops reflect before dispatching.
+_AXIS0_CHECKED_OPS = frozenset(
+    ["eq", "add", "sub", "mul", "truediv", "floordiv", "mod", "pow"]
+)
+
 
 class BaseOpsUtil:
     series_scalar_exc: type[Exception] | None = TypeError
@@ -75,6 +83,22 @@ class BaseOpsUtil:
 
     # see comment on check_opname
     @final
+    def _check_frame_op_axis0(self, ser, other, op_name: str, expected_column) -> None:
+        # GH#28506 a DataFrame op with axis=0 dispatches column-by-column, so
+        #  it needs to match the Series result we just checked.
+        if not (isinstance(ser, pd.Series) and isinstance(other, pd.Series)):
+            return
+        flex_name = op_name.strip("_")
+        if flex_name not in _AXIS0_CHECKED_OPS:
+            return
+
+        df = pd.DataFrame({"A": ser, "B": ser})
+        result = getattr(df, flex_name)(other, axis=0)
+        expected = pd.DataFrame({"A": expected_column, "B": expected_column})
+        tm.assert_frame_equal(result, expected)
+
+    # see comment on check_opname
+    @final
     def _check_op(
         self, ser: pd.Series, op, other, op_name: str, exc=NotImplementedError
     ):
@@ -87,6 +111,7 @@ class BaseOpsUtil:
             expected = self._cast_pointwise_result(op_name, ser, other, expected)
             assert isinstance(result, type(ser))
             tm.assert_equal(result, expected)
+            self._check_frame_op_axis0(ser, other, op_name, result)
         else:
             with pytest.raises(exc):
                 op(ser, other)
@@ -217,6 +242,7 @@ class BaseComparisonOpsTests(BaseOpsUtil):
             expected = ser.combine(other, op)
             expected = self._cast_pointwise_result(op.__name__, ser, other, expected)
             tm.assert_series_equal(result, expected)
+            self._check_frame_op_axis0(ser, other, op.__name__, result)
 
         else:
             exc = None
@@ -232,6 +258,7 @@ class BaseComparisonOpsTests(BaseOpsUtil):
                     op.__name__, ser, other, expected
                 )
                 tm.assert_series_equal(result, expected)
+                self._check_frame_op_axis0(ser, other, op.__name__, result)
             else:
                 with pytest.raises(type(exc)):
                     ser.combine(other, op)

--- a/pandas/tests/extension/decimal/test_decimal.py
+++ b/pandas/tests/extension/decimal/test_decimal.py
@@ -459,3 +459,31 @@ def test_array_copy_on_write():
         {"a": [decimal.Decimal(2), decimal.Decimal(3)]}, dtype=DecimalDtype()
     )
     tm.assert_equal(df2.values, expected.values)
+
+
+def test_dataframe_arith_with_numpy_dtype_frame(all_arithmetic_operators):
+    # GH#28506 the numpy-dtype operand is a single 2D block that has to be
+    #  split up to be combined with the 1D decimal blocks
+    op = tm.get_op_from_name(all_arithmetic_operators)
+    ea_df = pd.DataFrame({"a": to_decimal([1, 2, 3]), "b": to_decimal([4, 5, 6])})
+    np_df = pd.DataFrame({"a": np.arange(1, 4), "b": np.arange(4, 7)})
+
+    result = op(ea_df, np_df)
+    expected = pd.DataFrame({col: op(ea_df[col], np_df[col]) for col in ea_df.columns})
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("ea_frame", [True, False])
+def test_dataframe_arith_with_series_axis0(all_arithmetic_operators, ea_frame):
+    # GH#28506 decimal dtype on either the frame or the series side
+    op_name = all_arithmetic_operators.strip("_")
+    if ea_frame:
+        df = pd.DataFrame({"a": to_decimal([1, 2, 3]), "b": to_decimal([4, 5, 6])})
+        ser = pd.Series(np.arange(7, 10))
+    else:
+        df = pd.DataFrame({"a": np.arange(1, 4), "b": np.arange(4, 7)})
+        ser = pd.Series(to_decimal([7, 8, 9]))
+
+    result = getattr(df, op_name)(ser, axis=0)
+    expected = pd.DataFrame({col: getattr(df[col], op_name)(ser) for col in df.columns})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #28506

Both behaviors the issue asks about work correctly on main today, including `df2.add(df1["a"], axis=0)`, which the issue reported as raising. What was missing is the coverage it asked for.

DataFrame-level arithmetic where only one operand has extension dtype was untested. The base ops suite has exactly one frame-level arithmetic test, and it is a *one-column* frame against a *scalar*; `BaseOpsUtil._combine` raises `NotImplementedError` for multi-column frames, so the shared harness could not reach these cases at all.

The `axis=0` half generalizes, so it goes in `base/ops.py` as a `_check_frame_op_axis0` helper called from `_check_op` and both branches of `_compare_other`. It is folded in rather than added as a new test method for the reason found in GH-40624: subclasses set `series_scalar_exc` / `series_array_exc` *inside* their overrides, so a separately-named base test runs with class-level defaults and fails en masse. Folded in, every existing override and xfail keeps applying, and third-party EAs get the coverage too.

The helper is gated on a small set of ops. The frame dispatch is op-agnostic and the per-op semantics are already asserted at the Series level immediately above, so `ne`/`lt`/`le`/`gt`/`ge` re-run an identical path and reflected ops reflect before dispatching. One comparison plus the non-reflected arithmetic ops still exercises both dispatch helpers (`_flex_cmp_method` and `_flex_arith_method`). Checking every op instead costs +6.2s on a 41.9s `pandas/tests/extension/` run (+15%); gated, it is 40.4s against a 40.3s baseline, i.e. within noise. The dtype axis is deliberately not trimmed, since running across every EA is the point.

The EA-vs-numpy crossings cannot be expressed generically: they need a numpy-dtype operand the EA can actually operate with, and the base fixtures only supply same-dtype operands. Two EA frames are all 1D blocks, so they pair up 1:1 and never exercise the 2D-block split. Those tests live in `pandas/tests/extension/decimal/test_decimal.py` and cover the issue's literal `df1 + df2` plus `axis=0` in both directions.

No behavior change and no whatsnew entry, as this is test-only. Full `pandas/tests/extension/` is green (45386 passed, 3825 skipped, 813 xfailed); no new bugs surfaced.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which ran the repros, surveyed existing coverage, wrote the tests, and measured the runtime A/B.