### PR TITLE
BUG: remove dangling comma from unnamed MultiIndex repr

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -685,6 +685,7 @@ MultiIndex
 ^^^^^^^^^^
 - Bug in :class:`MultiIndex` where pickling a :class:`DataFrame` with a ``datetime64[ns]`` level raised ``NotImplementedError`` (:issue:`63078`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
+- Bug in :meth:`MultiIndex.__repr__` emitting a trailing comma followed by an empty continuation line when the index has no names (:issue:`66374`)
 - Bug in :meth:`MultiIndex.get_loc` where looking up a tuple key containing a scalar inside an :class:`IntervalIndex` level with overlapping intervals raised ``KeyError`` or returned incorrect results (:issue:`27456`)
 - Bug in :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` raising ``IndexError`` instead of a clear ``ValueError`` when passing an empty sequence with ``level=None`` or a list-like ``level`` (:issue:`16147`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -1486,7 +1486,11 @@ class Index(IndexOpsMixin, PandasObject):
                     line_len += len(sep) + attr_len
 
         prepr = "".join(parts)
-        if prepr.startswith("\n"):
+        if not prepr:
+            # No attrs to follow the data, so drop the separator that
+            # _format_data appends in anticipation of one (GH#66374)
+            data = data.rstrip().removesuffix(",")
+        elif prepr.startswith("\n"):
             # First attr wrapped to a new line; strip trailing whitespace
             # from the data portion (e.g. trailing ", " separator)
             data = data.rstrip()

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -2077,8 +2077,7 @@ class Index(IndexOpsMixin, PandasObject):
         MultiIndex([('python', 2018),
                     ('python', 2019),
                     ( 'cobra', 2018),
-                    ( 'cobra', 2019)],
-                   )
+                    ( 'cobra', 2019)])
         >>> idx = idx.set_names(["kind", "year"])
         >>> idx.set_names("species", level=0)
         MultiIndex([('python', 2018),
@@ -3234,8 +3233,7 @@ class Index(IndexOpsMixin, PandasObject):
         MultiIndex([(1,  'Red'),
             (1, 'Blue'),
             (2,  'Red'),
-            (2, 'Blue')],
-           )
+            (2, 'Blue')])
         >>> idx2 = pd.MultiIndex.from_arrays(
         ...     [[3, 3, 2, 2], ["Red", "Green", "Red", "Green"]]
         ... )
@@ -3243,8 +3241,7 @@ class Index(IndexOpsMixin, PandasObject):
         MultiIndex([(3,   'Red'),
             (3, 'Green'),
             (2,   'Red'),
-            (2, 'Green')],
-           )
+            (2, 'Green')])
         >>> idx1.union(idx2)
         MultiIndex([(1,  'Blue'),
             (1,   'Red'),
@@ -3252,8 +3249,7 @@ class Index(IndexOpsMixin, PandasObject):
             (2, 'Green'),
             (2,   'Red'),
             (3, 'Green'),
-            (3,   'Red')],
-           )
+            (3,   'Red')])
         >>> idx1.union(idx2, sort=False)
         MultiIndex([(1,   'Red'),
             (1,  'Blue'),
@@ -3261,8 +3257,7 @@ class Index(IndexOpsMixin, PandasObject):
             (2,  'Blue'),
             (3,   'Red'),
             (3, 'Green'),
-            (2, 'Green')],
-           )
+            (2, 'Green')])
         """
         self._validate_sort_keyword(sort)
         self._assert_can_do_setop(other)
@@ -8333,8 +8328,7 @@ def ensure_index(index_like: Axes, copy: bool = False) -> Index:
 
     >>> ensure_index([["a", "a"], ["b", "c"]])
     MultiIndex([('a', 'b'),
-            ('a', 'c')],
-           )
+            ('a', 'c')])
     """
     if isinstance(index_like, Index):
         if copy:

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -1116,8 +1116,7 @@ class MultiIndex(Index):
         --------
         >>> mi = pd.MultiIndex.from_arrays([["a"], ["b"], ["c"]])
         >>> mi
-        MultiIndex([('a', 'b', 'c')],
-                   )
+        MultiIndex([('a', 'b', 'c')])
         >>> mi.nlevels
         3
         """
@@ -1144,8 +1143,7 @@ class MultiIndex(Index):
         --------
         >>> mi = pd.MultiIndex.from_arrays([["a"], ["b"], ["c"]])
         >>> mi
-        MultiIndex([('a', 'b', 'c')],
-                   )
+        MultiIndex([('a', 'b', 'c')])
         >>> mi.levshape
         (1, 1, 1)
         """
@@ -1426,11 +1424,9 @@ class MultiIndex(Index):
         --------
         >>> mi = pd.MultiIndex.from_arrays([["a"], ["b"], ["c"]])
         >>> mi
-        MultiIndex([('a', 'b', 'c')],
-                   )
+        MultiIndex([('a', 'b', 'c')])
         >>> mi.copy()
-        MultiIndex([('a', 'b', 'c')],
-                   )
+        MultiIndex([('a', 'b', 'c')])
         """
         names = self._validate_names(name=name, names=names, deep=deep)
         keep_id = not deep
@@ -1505,8 +1501,7 @@ class MultiIndex(Index):
         --------
         >>> mi = pd.MultiIndex.from_arrays([["a"], ["b"], ["c"]])
         >>> mi
-        MultiIndex([('a', 'b', 'c')],
-                   )
+        MultiIndex([('a', 'b', 'c')])
 
         >>> "a" in mi
         True
@@ -2031,12 +2026,10 @@ class MultiIndex(Index):
         --------
         >>> mi = pd.MultiIndex.from_arrays(([np.nan, np.nan, 2.0], [3.0, np.nan, 4.0]))
         >>> mi.dropna()
-        MultiIndex([(2.0, 4.0)],
-                   )
+        MultiIndex([(2.0, 4.0)])
         >>> mi.dropna(how="all")
         MultiIndex([(nan, 3.0),
-                    (2.0, 4.0)],
-                   )
+                    (2.0, 4.0)])
         """
         nans = [level_codes == -1 for level_codes in self.codes]
         if how == "any":
@@ -2173,13 +2166,11 @@ class MultiIndex(Index):
         MultiIndex([('a', 'd'),
                     ('b', 'e'),
                     ('c', 'f'),
-                    ('a', 'd')],
-                   )
+                    ('a', 'd')])
         >>> mi.unique()
         MultiIndex([('a', 'd'),
                     ('b', 'e'),
-                    ('c', 'f')],
-                   )
+                    ('c', 'f')])
         """
         if level is None:
             return self.drop_duplicates()
@@ -2225,8 +2216,7 @@ class MultiIndex(Index):
         >>> mi = pd.MultiIndex.from_arrays([["a", "b"], ["c", "d"]])
         >>> mi
         MultiIndex([('a', 'c'),
-                    ('b', 'd')],
-                   )
+                    ('b', 'd')])
 
         >>> df = mi.to_frame()
         >>> df
@@ -2390,15 +2380,13 @@ class MultiIndex(Index):
         MultiIndex([('a', 'bb'),
                     ('a', 'aa'),
                     ('b', 'bb'),
-                    ('b', 'aa')],
-                   )
+                    ('b', 'aa')])
 
         >>> mi.sort_values()
         MultiIndex([('a', 'aa'),
                     ('a', 'bb'),
                     ('b', 'aa'),
-                    ('b', 'bb')],
-                   )
+                    ('b', 'bb')])
         """
         if self._is_lexsorted() and self.is_monotonic_increasing:
             return self
@@ -2466,13 +2454,11 @@ class MultiIndex(Index):
         MultiIndex([(0, 'a'),
                     (0, 'b'),
                     (1, 'a'),
-                    (1, 'b')],
-                   )
+                    (1, 'b')])
 
         >>> mi[2:]
         MultiIndex([(1, 'a'),
-                    (1, 'b')],
-                   )
+                    (1, 'b')])
 
         The 0 from the first level is not represented
         and can be removed
@@ -2654,14 +2640,12 @@ class MultiIndex(Index):
         >>> idx
         MultiIndex([('a', 1),
                     ('b', 2),
-                    ('c', 3)],
-                   )
+                    ('c', 3)])
         >>> idx.take([2, 2, 1, 0])
         MultiIndex([('c', 3),
                     ('c', 3),
                     ('b', 2),
-                    ('a', 1)],
-                   )
+                    ('a', 1)])
         """
         nv.validate_take((), kwargs)
         indices = ensure_platform_int(indices)
@@ -2738,11 +2722,9 @@ class MultiIndex(Index):
         --------
         >>> mi = pd.MultiIndex.from_arrays([["a"], ["b"]])
         >>> mi
-        MultiIndex([('a', 'b')],
-                   )
+        MultiIndex([('a', 'b')])
         >>> mi.append(mi)
-        MultiIndex([('a', 'b'), ('a', 'b')],
-                   )
+        MultiIndex([('a', 'b'), ('a', 'b')])
         """
         if not isinstance(other, (list, tuple)):
             other = [other]
@@ -2816,8 +2798,7 @@ class MultiIndex(Index):
         >>> midx = pd.MultiIndex.from_arrays([[3, 2], ["e", "c"]])
         >>> midx
         MultiIndex([(3, 'e'),
-                    (2, 'c')],
-                   )
+                    (2, 'c')])
 
         >>> order = midx.argsort()
         >>> order
@@ -2825,8 +2806,7 @@ class MultiIndex(Index):
 
         >>> midx[order]
         MultiIndex([(2, 'c'),
-                    (3, 'e')],
-                  )
+                    (3, 'e')])
 
         >>> midx = pd.MultiIndex.from_arrays([[2, 2], [np.nan, 0]])
         >>> midx.argsort(na_position="first")
@@ -2872,24 +2852,21 @@ class MultiIndex(Index):
         >>> idx
         MultiIndex([('a', 1),
                     ('b', 2),
-                    ('c', 3)],
-                   )
+                    ('c', 3)])
         >>> idx.repeat(2)
         MultiIndex([('a', 1),
                     ('a', 1),
                     ('b', 2),
                     ('b', 2),
                     ('c', 3),
-                    ('c', 3)],
-                   )
+                    ('c', 3)])
         >>> idx.repeat([1, 2, 3])
         MultiIndex([('a', 1),
                     ('b', 2),
                     ('b', 2),
                     ('c', 3),
                     ('c', 3),
-                    ('c', 3)],
-                   )
+                    ('c', 3)])
         """
         nv.validate_repeat((), {"axis": axis})
         # error: Incompatible types in assignment (expression has type "ndarray",
@@ -3079,26 +3056,22 @@ class MultiIndex(Index):
         MultiIndex([('a', 'bb', 'bbb'),
                     ('a', 'aa', 'aaa'),
                     ('b', 'bb', 'bbb'),
-                    ('b', 'aa', 'aaa')],
-                   )
+                    ('b', 'aa', 'aaa')])
         >>> mi.swaplevel()
         MultiIndex([('a', 'bbb', 'bb'),
                     ('a', 'aaa', 'aa'),
                     ('b', 'bbb', 'bb'),
-                    ('b', 'aaa', 'aa')],
-                   )
+                    ('b', 'aaa', 'aa')])
         >>> mi.swaplevel(0)
         MultiIndex([('bbb', 'bb', 'a'),
                     ('aaa', 'aa', 'a'),
                     ('bbb', 'bb', 'b'),
-                    ('aaa', 'aa', 'b')],
-                   )
+                    ('aaa', 'aa', 'b')])
         >>> mi.swaplevel(0, 1)
         MultiIndex([('bb', 'a', 'bbb'),
                     ('aa', 'a', 'aaa'),
                     ('bb', 'b', 'bbb'),
-                    ('aa', 'b', 'aaa')],
-                )
+                    ('aa', 'b', 'aaa')])
         """
         new_levels = list(self.levels)
         new_codes = list(self.codes)
@@ -3268,28 +3241,23 @@ class MultiIndex(Index):
         >>> mi = pd.MultiIndex.from_arrays([[0, 0], [2, 1]])
         >>> mi
         MultiIndex([(0, 2),
-                    (0, 1)],
-                   )
+                    (0, 1)])
 
         >>> mi.sortlevel()
         (MultiIndex([(0, 1),
-                    (0, 2)],
-                   ), array([1, 0]))
+                    (0, 2)]), array([1, 0]))
 
         >>> mi.sortlevel(sort_remaining=False)
         (MultiIndex([(0, 2),
-                    (0, 1)],
-                   ), array([0, 1]))
+                    (0, 1)]), array([0, 1]))
 
         >>> mi.sortlevel(1)
         (MultiIndex([(0, 1),
-                    (0, 2)],
-                   ), array([1, 0]))
+                    (0, 2)]), array([1, 0]))
 
         >>> mi.sortlevel(1, ascending=False)
         (MultiIndex([(0, 2),
-                    (0, 1)],
-                   ), array([0, 1]))
+                    (0, 1)]), array([0, 1]))
         """
         if not is_list_like(level):
             level = [level]
@@ -4548,11 +4516,9 @@ class MultiIndex(Index):
         --------
         >>> mi = pd.MultiIndex.from_arrays([["a", "b", "c"], ["x", "y", "z"]])
         >>> mi
-        MultiIndex([('a', 'x'), ('b', 'y'), ('c', 'z')],
-                   )
+        MultiIndex([('a', 'x'), ('b', 'y'), ('c', 'z')])
         >>> mi.truncate(before="a", after="b")
-        MultiIndex([('a', 'x'), ('b', 'y')],
-                   )
+        MultiIndex([('a', 'x'), ('b', 'y')])
         """
         if after and before and after < before:
             raise ValueError("after < before")
@@ -4771,13 +4737,11 @@ class MultiIndex(Index):
         >>> mi
         MultiIndex([(1, 4),
                     (2, 5),
-                    (3, 6)],
-                   )
+                    (3, 6)])
         >>> mi.astype("object")
         MultiIndex([(1, 4),
                     (2, 5),
-                    (3, 6)],
-                   )
+                    (3, 6)])
         """
         dtype = pandas_dtype(dtype)
         if isinstance(dtype, CategoricalDtype):

--- a/pandas/core/strings/accessor.py
+++ b/pandas/core/strings/accessor.py
@@ -1157,8 +1157,7 @@ class StringMethods(NoNewAttributesMixin):
 
         >>> idx.str.partition()
         MultiIndex([('X', ' ', '123'),
-                    ('Y', ' ', '999')],
-                   )
+                    ('Y', ' ', '999')])
 
         Or an index with tuples with ``expand=False``:
 
@@ -1249,8 +1248,7 @@ class StringMethods(NoNewAttributesMixin):
 
         >>> idx.str.partition()
         MultiIndex([('X', ' ', '123'),
-                    ('Y', ' ', '999')],
-                   )
+                    ('Y', ' ', '999')])
 
         Or an index with tuples with ``expand=False``:
 

--- a/pandas/tests/indexes/multi/test_formats.py
+++ b/pandas/tests/indexes/multi/test_formats.py
@@ -202,6 +202,20 @@ MultiIndex([(  'a',  9, '2000-01-01 00:00:00', '2000-01-01 00:00:00', ...),
 
         expected = (
             "MultiIndex([('cccccccccccccccccccccccccccccccccccccccc"
-            "cccccccccccccccccccccc',)],\n           )"
+            "cccccccccccccccccccccc',)])"
         )
         assert str(data) == expected
+
+    def test_repr_no_names(self):
+        # GH#66374 the repr must not end with a dangling separator when the
+        # index has no names, i.e. when there are no attrs to print at all
+        mi = MultiIndex.from_tuples([("h1", "h3"), ("h2", "h4")])
+
+        expected = "MultiIndex([('h1', 'h3'),\n            ('h2', 'h4')])"
+        assert repr(mi) == expected
+
+    def test_repr_no_names_empty(self):
+        # GH#66374
+        mi = MultiIndex.from_tuples([], names=[None])
+
+        assert repr(mi) == "MultiIndex([])"

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -25,8 +25,7 @@ Index levels are different
 \\[right\\]: 2, MultiIndex\\(\\[\\('A', 1\\),
             \\('A', 2\\),
             \\('B', 3\\),
-            \\('B', 4\\)\\],
-           \\)"""
+            \\('B', 4\\)\\]\\)"""
 
     idx1 = Index([1, 2, 3])
     idx2 = MultiIndex.from_tuples([("A", 1), ("A", 2), ("B", 3), ("B", 4)])


### PR DESCRIPTION
- [x] closes #66374
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (Not applicable: no new arguments, methods, or functions.)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described below how I used it and exactly which tool, model version, and effort setting.

This PR handles the empty `prepr` branch and updates the affected docstring expectations, regression tests, and whatsnew entry. Hope this helps!

AI use disclosure:

- Claude Code using Claude Opus 5 implemented and iteratively verified the code, tests, and release note. The routine did not expose a reasoning-effort setting.
- OpenAI Codex reviewed the contribution gates and diff, rebased the branch, and translated and grammar-edited the description from my Traditional Chinese wording. The client identified the model only as the GPT-5 family and did not expose an exact model version or reasoning-effort setting.