### PR TITLE
TST: cover negative nanosecond merge_asof tolerance (GH#58517)

### DIFF
--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -2004,9 +2004,7 @@ class TestAsOfMerge:
         msg = "tolerance must be positive"
 
         with pytest.raises(MergeError, match=msg):
-            merge_asof(
-                trades, quotes, on="time", by="ticker", tolerance=Timedelta(-1)
-            )
+            merge_asof(trades, quotes, on="time", by="ticker", tolerance=Timedelta(-1))
 
     def test_non_sorted(self, trades, quotes):
         trades = trades.sort_values("time", ascending=False)

--- a/pandas/tests/reshape/merge/test_merge_asof.py
+++ b/pandas/tests/reshape/merge/test_merge_asof.py
@@ -1999,6 +1999,15 @@ class TestAsOfMerge:
                 tolerance=-1,
             )
 
+    def test_tolerance_negative_one_nanosecond(self, trades, quotes):
+        # GH#58517
+        msg = "tolerance must be positive"
+
+        with pytest.raises(MergeError, match=msg):
+            merge_asof(
+                trades, quotes, on="time", by="ticker", tolerance=Timedelta(-1)
+            )
+
     def test_non_sorted(self, trades, quotes):
         trades = trades.sort_values("time", ascending=False)
         quotes = quotes.sort_values("time", ascending=False)


### PR DESCRIPTION
- [x] xref #58517
- [x] Tests added and passed where the local environment permits
- [x] All applicable code checks passed
- [x] I have reviewed and followed the contribution guidelines
- [x] I used AI to develop this pull request and prompted it to follow `AGENTS.md`

Adds regression coverage for the negative-tolerance boundary in `merge_asof`. The existing test uses `-Timedelta("1s")`, which does not distinguish the correct `tolerance < Timedelta(0)` check from the surviving mutation `tolerance < Timedelta(-1)`. The new test uses exactly `Timedelta(-1)` (negative one nanosecond), so it fails under that mutation.

No whatsnew entry is needed because this is a test-only change.

Validation:
- `python3 -m py_compile pandas/tests/reshape/merge/test_merge_asof.py`
- `git diff --check`
- The exact behavior was validated with pandas 3.0.0.
- The focused pytest run could not be executed locally because the available environment has pytest 7.3.1, NumPy 1.24.3, and no compiled development extensions.

AI assistance: OpenAI Codex using GPT-5; the reasoning-effort setting is not exposed.
