### PR TITLE
PERF: Defer access of dtype in maybe_unbox_numpy_scalar

### DIFF
--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1447,7 +1447,7 @@ def construct_1d_arraylike_from_scalar(
     return subarr
 
 
-def maybe_unbox_numpy_scalar(value: Any, *, dtype_object: Any = None) -> Any:
+def maybe_unbox_numpy_scalar(value: Any, *, object_with_dtype: Any = None) -> Any:
     """
     Maybe convert a NumPy scalar to its Python equivalent.
 
@@ -1461,7 +1461,7 @@ def maybe_unbox_numpy_scalar(value: Any, *, dtype_object: Any = None) -> Any:
     ----------
     value : Any
         The value to unbox.
-    dtype_object : object with a ``dtype`` attribute, optional
+    object_with_dtype : object with a ``dtype`` attribute, optional
         The data (e.g. a Series or array) that ``value`` came from. Pass this
         whenever ``value`` is an element of the data or is derived from its
         elements: object dtype stores arbitrary user objects, so a NumPy
@@ -1479,7 +1479,7 @@ def maybe_unbox_numpy_scalar(value: Any, *, dtype_object: Any = None) -> Any:
     """
     result = value
     if using_python_scalars() and isinstance(value, np.generic):
-        if dtype_object is not None and dtype_object.dtype == object:
+        if object_with_dtype is not None and object_with_dtype.dtype == object:
             return result
         if isinstance(result, np.longdouble):
             result = float(result)

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -1447,7 +1447,7 @@ def construct_1d_arraylike_from_scalar(
     return subarr
 
 
-def maybe_unbox_numpy_scalar(value: Any, *, dtype: DtypeObj | None = None) -> Any:
+def maybe_unbox_numpy_scalar(value: Any, *, dtype_object: Any = None) -> Any:
     """
     Maybe convert a NumPy scalar to its Python equivalent.
 
@@ -1461,14 +1461,16 @@ def maybe_unbox_numpy_scalar(value: Any, *, dtype: DtypeObj | None = None) -> An
     ----------
     value : Any
         The value to unbox.
-    dtype : DtypeObj or None, default None
-        The dtype of the data ``value`` came from. Pass this whenever
-        ``value`` is an element of the data or is derived from its elements:
-        object dtype stores arbitrary user objects, so a NumPy scalar coming
-        from object-dtype data is a stored value rather than a boxing
-        artifact, and is returned unchanged. Omit for values whose
+    dtype_object : object with a ``dtype`` attribute, optional
+        The data (e.g. a Series or array) that ``value`` came from. Pass this
+        whenever ``value`` is an element of the data or is derived from its
+        elements: object dtype stores arbitrary user objects, so a NumPy
+        scalar coming from object-dtype data is a stored value rather than a
+        boxing artifact, and is returned unchanged. Omit for values whose
         type does not follow the data's dtype, e.g. positions, counts, and
-        the results of any/all.
+        the results of any/all. The ``.dtype`` attribute is only accessed if
+        unboxing is actually going to happen, so passing the object rather
+        than its dtype avoids that cost on hot paths.
 
     Returns
     -------
@@ -1476,7 +1478,9 @@ def maybe_unbox_numpy_scalar(value: Any, *, dtype: DtypeObj | None = None) -> An
         The equivalent Python scalar, or ``value`` unchanged.
     """
     result = value
-    if dtype != object and using_python_scalars() and isinstance(value, np.generic):
+    if using_python_scalars() and isinstance(value, np.generic):
+        if dtype_object is not None and dtype_object.dtype == object:
+            return result
         if isinstance(result, np.longdouble):
             result = float(result)
         elif isinstance(result, np.complex256):

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -16535,7 +16535,7 @@ class DataFrame(NDFrame, OpsMixin):
             values = df.values
             return maybe_unbox_numpy_scalar(
                 func(values),
-                dtype_object=None if name in ["any", "all"] else values,
+                object_with_dtype=None if name in ["any", "all"] else values,
             )
         elif axis == 1:
             if len(df.index) == 0:

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -16532,9 +16532,10 @@ class DataFrame(NDFrame, OpsMixin):
                 df = df.astype(dtype)
                 arr = concat_compat(list(df._iter_column_arrays()))
                 return arr._reduce(name, skipna=skipna, keepdims=False, **kwds)
+            values = df.values
             return maybe_unbox_numpy_scalar(
-                func(df.values),
-                dtype=None if name in ["any", "all"] else dtype,
+                func(values),
+                dtype_object=None if name in ["any", "all"] else values,
             )
         elif axis == 1:
             if len(df.index) == 0:

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -985,10 +985,10 @@ class Index(IndexOpsMixin, PandasObject):
             return tuple(self.__array_wrap__(x) for x in result)
         elif method == "reduce":
             result = lib.item_from_zerodim(result)
-            return maybe_unbox_numpy_scalar(result, dtype_object=self)
+            return maybe_unbox_numpy_scalar(result, object_with_dtype=self)
         elif is_scalar(result):
             # e.g. matmul
-            return maybe_unbox_numpy_scalar(result, dtype_object=self)
+            return maybe_unbox_numpy_scalar(result, object_with_dtype=self)
 
         if result.dtype == np.float16:
             result = result.astype(np.float32)
@@ -8081,7 +8081,7 @@ class Index(IndexOpsMixin, PandasObject):
             # quick check
             first = self[0]
             if not isna(first):
-                return maybe_unbox_numpy_scalar(first, dtype_object=self)
+                return maybe_unbox_numpy_scalar(first, object_with_dtype=self)
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
@@ -8093,7 +8093,7 @@ class Index(IndexOpsMixin, PandasObject):
             return self._values._reduce(name="min", skipna=skipna)
 
         return maybe_unbox_numpy_scalar(
-            nanops.nanmin(self._values, skipna=skipna), dtype_object=self
+            nanops.nanmin(self._values, skipna=skipna), object_with_dtype=self
         )
 
     def max(
@@ -8156,7 +8156,7 @@ class Index(IndexOpsMixin, PandasObject):
             # quick check
             last = self[-1]
             if not isna(last):
-                return maybe_unbox_numpy_scalar(last, dtype_object=self)
+                return maybe_unbox_numpy_scalar(last, object_with_dtype=self)
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
@@ -8168,7 +8168,7 @@ class Index(IndexOpsMixin, PandasObject):
             return self._values._reduce(name="max", skipna=skipna)
 
         return maybe_unbox_numpy_scalar(
-            nanops.nanmax(self._values, skipna=skipna), dtype_object=self
+            nanops.nanmax(self._values, skipna=skipna), object_with_dtype=self
         )
 
     # --------------------------------------------------------------------

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -985,10 +985,10 @@ class Index(IndexOpsMixin, PandasObject):
             return tuple(self.__array_wrap__(x) for x in result)
         elif method == "reduce":
             result = lib.item_from_zerodim(result)
-            return maybe_unbox_numpy_scalar(result, dtype=self.dtype)
+            return maybe_unbox_numpy_scalar(result, dtype_object=self)
         elif is_scalar(result):
             # e.g. matmul
-            return maybe_unbox_numpy_scalar(result, dtype=self.dtype)
+            return maybe_unbox_numpy_scalar(result, dtype_object=self)
 
         if result.dtype == np.float16:
             result = result.astype(np.float32)
@@ -8081,7 +8081,7 @@ class Index(IndexOpsMixin, PandasObject):
             # quick check
             first = self[0]
             if not isna(first):
-                return maybe_unbox_numpy_scalar(first, dtype=self.dtype)
+                return maybe_unbox_numpy_scalar(first, dtype_object=self)
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
@@ -8093,7 +8093,7 @@ class Index(IndexOpsMixin, PandasObject):
             return self._values._reduce(name="min", skipna=skipna)
 
         return maybe_unbox_numpy_scalar(
-            nanops.nanmin(self._values, skipna=skipna), dtype=self.dtype
+            nanops.nanmin(self._values, skipna=skipna), dtype_object=self
         )
 
     def max(
@@ -8156,7 +8156,7 @@ class Index(IndexOpsMixin, PandasObject):
             # quick check
             last = self[-1]
             if not isna(last):
-                return maybe_unbox_numpy_scalar(last, dtype=self.dtype)
+                return maybe_unbox_numpy_scalar(last, dtype_object=self)
 
         if not self._is_multi and self.hasnans:
             # Take advantage of cache
@@ -8168,7 +8168,7 @@ class Index(IndexOpsMixin, PandasObject):
             return self._values._reduce(name="max", skipna=skipna)
 
         return maybe_unbox_numpy_scalar(
-            nanops.nanmax(self._values, skipna=skipna), dtype=self.dtype
+            nanops.nanmax(self._values, skipna=skipna), dtype_object=self
         )
 
     # --------------------------------------------------------------------

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2969,7 +2969,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             return self._constructor(result, index=idx, name=self.name)
         else:
             # scalar
-            return maybe_unbox_numpy_scalar(result.iloc[0], dtype_object=self)
+            return maybe_unbox_numpy_scalar(result.iloc[0], object_with_dtype=self)
 
     def corr(
         self,
@@ -3059,7 +3059,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             result = nanops.nancorr(
                 this_values, other_values, method=method, min_periods=min_periods
             )
-            result = maybe_unbox_numpy_scalar(result, dtype_object=self)
+            result = maybe_unbox_numpy_scalar(result, object_with_dtype=self)
             return result
 
         raise ValueError(
@@ -3115,7 +3115,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         result = nanops.nancov(
             this_values, other_values, min_periods=min_periods, ddof=ddof
         )
-        result = maybe_unbox_numpy_scalar(result, dtype_object=self)
+        result = maybe_unbox_numpy_scalar(result, object_with_dtype=self)
         return result
 
     def describe(
@@ -3434,7 +3434,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             result = np.dot(lvals, rvals)
         else:  # pragma: no cover
             raise TypeError(f"unsupported type: {type(other)}")
-        return maybe_unbox_numpy_scalar(result, dtype_object=self)
+        return maybe_unbox_numpy_scalar(result, object_with_dtype=self)
 
     def __matmul__(self, other):
         """
@@ -6271,7 +6271,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         2    3
         dtype: int64
         """
-        return maybe_unbox_numpy_scalar(super().pop(item=item), dtype_object=self)
+        return maybe_unbox_numpy_scalar(super().pop(item=item), object_with_dtype=self)
 
     def info(
         self,
@@ -8987,7 +8987,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         # any/all coerce to bool for all dtypes, so unbox even for object
         result = maybe_unbox_numpy_scalar(
-            result, dtype_object=None if name in ["any", "all"] else self
+            result, object_with_dtype=None if name in ["any", "all"] else self
         )
         return result
 

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -2969,7 +2969,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             return self._constructor(result, index=idx, name=self.name)
         else:
             # scalar
-            return maybe_unbox_numpy_scalar(result.iloc[0], dtype=self.dtype)
+            return maybe_unbox_numpy_scalar(result.iloc[0], dtype_object=self)
 
     def corr(
         self,
@@ -3059,7 +3059,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             result = nanops.nancorr(
                 this_values, other_values, method=method, min_periods=min_periods
             )
-            result = maybe_unbox_numpy_scalar(result, dtype=self.dtype)
+            result = maybe_unbox_numpy_scalar(result, dtype_object=self)
             return result
 
         raise ValueError(
@@ -3115,7 +3115,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         result = nanops.nancov(
             this_values, other_values, min_periods=min_periods, ddof=ddof
         )
-        result = maybe_unbox_numpy_scalar(result, dtype=self.dtype)
+        result = maybe_unbox_numpy_scalar(result, dtype_object=self)
         return result
 
     def describe(
@@ -3434,7 +3434,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             result = np.dot(lvals, rvals)
         else:  # pragma: no cover
             raise TypeError(f"unsupported type: {type(other)}")
-        return maybe_unbox_numpy_scalar(result, dtype=self.dtype)
+        return maybe_unbox_numpy_scalar(result, dtype_object=self)
 
     def __matmul__(self, other):
         """
@@ -6271,7 +6271,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         2    3
         dtype: int64
         """
-        return maybe_unbox_numpy_scalar(super().pop(item=item), dtype=self.dtype)
+        return maybe_unbox_numpy_scalar(super().pop(item=item), dtype_object=self)
 
     def info(
         self,
@@ -8987,7 +8987,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
 
         # any/all coerce to bool for all dtypes, so unbox even for object
         result = maybe_unbox_numpy_scalar(
-            result, dtype=None if name in ["any", "all"] else self.dtype
+            result, dtype_object=None if name in ["any", "all"] else self
         )
         return result
 

--- a/pandas/tests/dtypes/cast/test_box_unbox.py
+++ b/pandas/tests/dtypes/cast/test_box_unbox.py
@@ -110,6 +110,6 @@ def test_maybe_unbox_numpy_scalar_object_dtype():
     value = np.float32(1.5)
     with option_context("future.python_scalars", True):
         result = maybe_unbox_numpy_scalar(
-            value, dtype_object=np.array([], dtype=object)
+            value, object_with_dtype=np.array([], dtype=object)
         )
     assert result is value

--- a/pandas/tests/dtypes/cast/test_box_unbox.py
+++ b/pandas/tests/dtypes/cast/test_box_unbox.py
@@ -109,5 +109,7 @@ def test_maybe_unbox_numpy_scalar_object_dtype():
     # GH#64266
     value = np.float32(1.5)
     with option_context("future.python_scalars", True):
-        result = maybe_unbox_numpy_scalar(value, dtype=np.dtype(object))
+        result = maybe_unbox_numpy_scalar(
+            value, dtype_object=np.array([], dtype=object)
+        )
     assert result is value


### PR DESCRIPTION
Generated by Claude Fable 5.

Aimed at reducing impact while the option defaults to off by deferring checking the dtype unless it's necessary.

Benchmarks below are built on #67407, timings in nanoseconds.

<details>
<summary>Benchmarks</summary>

```
┌────────────────┬──────────────────────────────────────────┬──────┬─────┐
│ python_scalars │                   case                   │ main │ PR  │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ off            │ np scalar, int64 Series                  │ 282  │ 80  │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ off            │ np scalar, Int64 Series                  │ 365  │ 80  │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ off            │ np scalar, category Series               │ 459  │ 81  │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ off            │ np scalar, object Series                 │ 207  │ 80  │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ off            │ python int, int64 Series                 │ 282  │ 81  │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ off            │ np scalar, no dtype                      │ 93   │ 81  │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ off            │ python int, no dtype                     │ 93   │ 81  │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ on             │ np scalar, int64 Series (unboxes)        │ 743  │ 757 │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ on             │ np scalar, Int64 Series (unboxes)        │ 818  │ 803 │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ on             │ np scalar, category Series (unboxes)     │ 930  │ 926 │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ on             │ np scalar, object Series (returns as-is) │ 206  │ 289 │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ on             │ python int, int64 Series                 │ 332  │ 113 │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ on             │ np scalar, no dtype (unboxes)            │ 501  │ 495 │
├────────────────┼──────────────────────────────────────────┼──────┼─────┤
│ on             │ python int, no dtype                     │ 127  │ 114 │
└────────────────┴──────────────────────────────────────────┴──────┴─────┘
```

</details>