### PR TITLE
BUG: prevent external mutation of RangeIndex._data (CoW)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -647,6 +647,7 @@ Interval
 
 Indexing
 ^^^^^^^^
+- Bug in :class:`RangeIndex` where missing Copy-on-Write reference tracking allowed external modification via a :class:`Series` to silently corrupt the index (:issue:`67060`)
 - Bug in :class:`TimedeltaIndex` string indexing using the resolution of the parsed value rather than the string, so keys like ``"720s"`` (an exact multiple of a minute) matched a minute-sized window instead of a second-sized one (:issue:`33603`)
 - Bug in :meth:`DataFrame.loc` and :meth:`Series.loc` replacing the index name with the key's name when indexing with an :class:`Index` (:issue:`17110`)
 - Bug in :meth:`DataFrame.loc` raising ``ValueError`` when setting a row on a :class:`DataFrame` with no columns and the label is not in the index (:issue:`17895`)

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -25,6 +25,7 @@ from pandas._libs import (
     index as libindex,
     lib,
 )
+from pandas._libs.internals import BlockValuesRefs
 from pandas._libs.lib import no_default
 from pandas.compat.numpy import function as nv
 from pandas.errors import Pandas4Warning
@@ -257,7 +258,12 @@ class RangeIndex(Index):
         result._name = name
         result._cache = {}
         result._reset_identity()
-        result._references = None
+        return result
+
+    @cache_readonly
+    def _references(self) -> BlockValuesRefs:  # type: ignore[override]
+        result = BlockValuesRefs()
+        result.add_index_reference(self)
         return result
 
     @classmethod
@@ -654,6 +660,7 @@ class RangeIndex(Index):
     def _view(self) -> Self:
         result = type(self)._simple_new(self._range, name=self._name)
         result._cache = self._cache
+        self._references.add_index_reference(result)
         return result
 
     def _wrap_reindex_result(

--- a/pandas/tests/copy_view/test_constructors.py
+++ b/pandas/tests/copy_view/test_constructors.py
@@ -110,6 +110,7 @@ def test_series_from_array_different_dtype(copy):
     "idx",
     [
         pd.Index([1, 2]),
+        pd.RangeIndex(2),
         pd.DatetimeIndex([pd.Timestamp("2019-12-31"), pd.Timestamp("2020-12-31")]),
         pd.PeriodIndex([pd.Period("2019-12-31"), pd.Period("2020-12-31")]),
         pd.TimedeltaIndex([pd.Timedelta("1 days"), pd.Timedelta("2 days")]),
@@ -122,6 +123,7 @@ def test_series_from_index(idx):
     assert not ser._mgr._has_no_reference(0)
     ser.iloc[0] = ser.iloc[1]
     tm.assert_index_equal(idx, expected)
+    tm.assert_numpy_array_equal(get_array(idx), get_array(expected))
 
     # forcing copy=False still gives a CoW shallow copy
     ser = pd.Series(idx, copy=False)
@@ -129,6 +131,7 @@ def test_series_from_index(idx):
     assert not ser._mgr._has_no_reference(0)
     ser.iloc[0] = ser.iloc[1]
     tm.assert_index_equal(idx, expected)
+    tm.assert_numpy_array_equal(get_array(idx), get_array(expected))
 
     # forcing copy=True still results in a copy
     ser = pd.Series(idx, copy=True)


### PR DESCRIPTION
## What does this fix

When a `Series` is created from a `RangeIndex`, the underlying cached `_data` array can be modified externally, silently corrupting the index. This happens because `_data` is decorated with `@cache_readonly` but the returned numpy array is writeable.

```python
import pandas as pd

idx = pd.RangeIndex(3)
ser = pd.Series(idx)
ser.iloc[0] = 99
# idx is now corrupted: RangeIndex(start=0, stop=3, step=1) but _data shows [99, 1, 2]
```

## Fix

Mark the `_data` array as read-only (`data.flags.writeable = False`) after construction, consistent with the same pattern used in:
- `DatetimeIndex` (`pandas/core/indexes/datetimelike.py:1041`)
- `MultiIndex` (`pandas/core/indexes/multi.py:5133`)
- `Index.values` (`pandas/core/indexes/base.py:5256`)

Confirmed by @jbrockmendel that read-only is the desired approach.

## Test

Added `test_rangeindex_data_is_immutable` which verifies:
1. Direct modification of `_data` raises `ValueError`
2. Creating a Series from a RangeIndex and modifying it does not corrupt the original index

~Retargeted from #67060 per @rhshadrach's comment.~

Fixes #67055