### PR TITLE
ENH: Add pyarrow/auto engine options to DataFrame.to_csv

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -46,6 +46,7 @@ Other enhancements
 - Added :meth:`Index.replace` method to support value replacement functionality similar to :meth:`Series.replace` (:issue:`19495`)
 - Added ``union_categories`` parameter to :func:`concat` to preserve categorical dtype by unioning categories when concatenating categoricals with different categories (:issue:`14177`)
 - Added reduction methods as public API on pandas-implemented extension arrays where applicable (:issue:`63512`)
+- :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` gained an ``engine`` parameter to optionally use pyarrow to serialize CSV data, which is generally faster than the existing python engine. ``engine="auto"``, the new default, uses pyarrow when it is installed and the data/options are fully supported, and otherwise transparently falls back to the python engine; ``engine="python"`` and ``engine="pyarrow"`` force one or the other (:issue:`53618`)
 - Building from source no longer fails on a checkout with CRLF line endings, such as under WSL (:issue:`64272`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
@@ -226,6 +227,7 @@ Other API changes
 - APIs that accept an ``engine="numba"`` parameter with ``engine_kwargs`` will no longer pass through a ``nopython`` argument to ``numba.jit``. This argument has had no effect since numba 0.59.0 (:issue:`64483`).
 - Removed the ``freq`` and ``freqstr`` attributes from :class:`.DatetimeArray` and :class:`.TimedeltaArray`. Frequency is now stored only on :class:`DatetimeIndex` and :class:`TimedeltaIndex`; access ``Series.dt.freq`` or wrap the array in an Index to retrieve a frequency. The ``check_freq`` keyword on :func:`testing.assert_extension_array_equal` for these array types has also been removed (:issue:`24566`).
 - The ``year`` column of :meth:`DatetimeIndex.isocalendar` and :meth:`Series.dt.isocalendar` is now ``Int32`` instead of ``UInt32``, so that years before year 1 are representable (:issue:`66549`)
+- The default ``engine`` used by :meth:`DataFrame.to_csv` and :meth:`Series.to_csv` is now ``"auto"`` instead of ``"python"``. When pyarrow is installed, this changes the exact text written for most calls: string, categorical, and object-dtype columns (and the header row) are now always quoted. The values themselves are unchanged and round-trip the same way through :func:`read_csv` (columns whose rendering would otherwise differ, e.g. bool, timedelta64, timezone-aware datetime64, or a whole-number float column, are still written by the python engine). Pass ``engine="python"`` to keep the previous output exactly (:issue:`53618`)
 -
 
 .. _whatsnew_310.api_breaking.build:

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -3882,7 +3882,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         header: bool | list[str] = ...,
         index: bool = ...,
         index_label: IndexLabel | None = ...,
-        mode: str = ...,
+        mode: str | None = ...,
         encoding: str | None = ...,
         compression: CompressionOptions = ...,
         quoting: int | None = ...,
@@ -3895,6 +3895,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ...,
         errors: OpenFileErrors = ...,
         storage_options: StorageOptions = ...,
+        engine: str = "auto",
     ) -> str: ...
 
     @overload
@@ -3909,7 +3910,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         header: bool | list[str] = ...,
         index: bool = ...,
         index_label: IndexLabel | None = ...,
-        mode: str = ...,
+        mode: str | None = ...,
         encoding: str | None = ...,
         compression: CompressionOptions = ...,
         quoting: int | None = ...,
@@ -3922,6 +3923,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ...,
         errors: OpenFileErrors = ...,
         storage_options: StorageOptions = ...,
+        engine: str = "auto",
     ) -> None: ...
 
     @final
@@ -3936,7 +3938,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         header: bool | list[str] = True,
         index: bool = True,
         index_label: IndexLabel | None = None,
-        mode: str = "w",
+        mode: str | None = None,
         encoding: str | None = None,
         compression: CompressionOptions = "infer",
         quoting: int | None = None,
@@ -3949,6 +3951,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         decimal: str = ".",
         errors: OpenFileErrors = "strict",
         storage_options: StorageOptions | None = None,
+        engine: str = "auto",
     ) -> str | None:
         r"""
         Write object to a comma-separated values (csv) file.
@@ -3986,13 +3989,20 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             sequence should be given if the object uses MultiIndex. If
             False do not print fields for index names. Use index_label=False
             for easier importing in R.
-        mode : {'w', 'x', 'a'}, default 'w'
+        mode : {'w', 'x', 'a'}, default 'w' (python or pyarrow engine) or 'wb'
+            (pyarrow engine when `path_or_buf` is a file path)
             Forwarded to either `open(mode=)` or `fsspec.open(mode=)` to control
             the file opening. Typical values include:
 
             - 'w', truncate the file first.
             - 'x', exclusive creation, failing if the file already exists.
             - 'a', append to the end of file if it exists.
+
+            .. note::
+                The pyarrow engine can only write to binary buffers. When
+                writing to a file path with ``mode`` left unspecified, the
+                mode is chosen automatically based on which engine ends up
+                being used (see ``engine`` below).
 
         encoding : str, optional
             A string representing the encoding to use in the output file,
@@ -4059,6 +4069,71 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             <https://pandas.pydata.org/docs/user_guide/io.html?
             highlight=storage_options#reading-writing-remote-files>`_.
 
+        engine : {'auto', 'pyarrow', 'python'}, default 'auto'
+            The engine to use to write the CSV data.
+
+            - 'python' always uses pandas' built-in, pure Python writer.
+            - 'pyarrow' uses :func:`pyarrow.csv.write_csv`, which is
+              generally faster than the python engine, but requires the
+              pyarrow library to be installed, does not support every
+              option supported by the python engine, and renders some
+              values differently (see the notes below). A ``ValueError``
+              is raised if the current data or options are not supported
+              by the pyarrow engine.
+            - 'auto' uses the pyarrow engine when it is installed and the
+              data and options passed are fully supported by it, and
+              silently falls back to the python engine otherwise. This
+              never changes the *values* represented (round-tripping
+              through :func:`~pandas.read_csv` gives back the same data
+              either way), but, whenever pyarrow ends up being used, the
+              exact text written differs from the python engine as
+              described below.
+
+            The pyarrow engine cannot be used, and 'auto' will use the
+            python engine instead, when:
+
+            * any of ``na_rep``, ``float_format``, ``date_format``,
+              ``decimal``, ``lineterminator``, ``encoding``, ``errors``,
+              ``escapechar``, or ``doublequote`` is set to a non-default
+              value (``encoding`` may still be a spelling of ``"utf-8"``,
+              since that is what the pyarrow engine always writes), or
+              ``quotechar`` is set to something other than ``'"'``.
+            * the columns being written have a :class:`MultiIndex`.
+            * any row being written would be entirely missing values,
+              since the pyarrow engine has no way to mark a missing value
+              other than leaving the field blank, which
+              :func:`~pandas.read_csv` would otherwise silently treat as a
+              blank line and skip.
+            * a column holds only whole-number float values (e.g. ``1.0``,
+              ignoring missing values), since the pyarrow engine omits the
+              trailing ``.0`` (writing ``1``), which can change the dtype
+              :func:`~pandas.read_csv` infers for that column on
+              round-trip.
+            * the data cannot be represented by `pyarrow`, e.g.
+              :class:`~pandas.Period`, :class:`~pandas.Interval`,
+              ``complex`` dtype, or :class:`~pandas.arrays.SparseArray`
+              columns, or an ``object`` column pyarrow cannot infer a
+              single type for.
+
+            Additionally, whenever the pyarrow engine is used (via
+            ``engine='pyarrow'``, or via ``engine='auto'`` when none of
+            the above apply), string, categorical, and ``object``-dtype
+            values (including the header row) are always quoted, unlike
+            the python engine, which only quotes a value when the
+            delimiter, quote character, or a newline appears in it.
+            ``bool`` and nullable ``boolean`` columns are written as
+            ``true``/``false`` instead of ``True``/``False``,
+            ``timedelta64`` columns are written as integer nanoseconds
+            instead of e.g. ``"1 days 00:00:00"``, and timezone-aware
+            ``datetime64`` columns use a different offset format and are
+            limited to microsecond precision. With ``engine='auto'``,
+            columns with any of these three dtypes are written with the
+            python engine instead. With ``engine='pyarrow'``, a
+            ``UserWarning`` is raised and the pyarrow engine is used
+            anyway.
+
+            .. versionadded:: 3.1.0
+
         Returns
         -------
         None or str
@@ -4082,7 +4157,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         Create 'out.zip' containing 'out.csv'
 
-        >>> df.to_csv(index=False)
+        >>> df.to_csv(index=False, engine="python")
         'name,mask,weapon\nRaphael,red,sai\nDonatello,purple,bo staff\n'
         >>> compression_opts = dict(
         ...     method="zip", archive_name="out.csv"
@@ -4124,6 +4199,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         return DataFrameRenderer(formatter).to_csv(
             path_or_buf,
+            engine=engine,
             lineterminator=lineterminator,
             sep=sep,
             encoding=encoding,

--- a/pandas/io/formats/csvs.py
+++ b/pandas/io/formats/csvs.py
@@ -11,18 +11,28 @@ from collections.abc import (
     Sequence,
 )
 import csv as csvlib
+import io
 import os
 from typing import (
+    IO,
     TYPE_CHECKING,
     Any,
+    AnyStr,
     cast,
 )
+import warnings
 
 import numpy as np
 
 from pandas._libs import writers as libwriters
+from pandas.compat._optional import import_optional_dependency
 from pandas.util._decorators import cache_readonly
+from pandas.util._exceptions import find_stack_level
 
+from pandas.core.dtypes.dtypes import (
+    ArrowDtype,
+    DatetimeTZDtype,
+)
 from pandas.core.dtypes.generic import (
     ABCDatetimeIndex,
     ABCIndex,
@@ -38,6 +48,7 @@ from pandas.io.common import get_handle
 if TYPE_CHECKING:
     from pandas._typing import (
         CompressionOptions,
+        DtypeObj,
         FilePath,
         FloatFormatType,
         IndexLabel,
@@ -59,11 +70,12 @@ class CSVFormatter:
     def __init__(
         self,
         formatter: DataFrameFormatter,
-        path_or_buf: FilePath | WriteBuffer[str] | WriteBuffer[bytes] = "",
+        path_or_buf: FilePath | WriteBuffer[str] | WriteBuffer[bytes] | None = None,
+        engine: str = "auto",
         sep: str = ",",
         cols: Sequence[Hashable] | None = None,
         index_label: IndexLabel | None = None,
-        mode: str = "w",
+        mode: str | None = None,
         encoding: str | None = None,
         errors: str = "strict",
         compression: CompressionOptions = "infer",
@@ -97,6 +109,10 @@ class CSVFormatter:
         self.date_format = date_format
         self.cols = self._initialize_columns(cols)
         self.chunksize = self._initialize_chunksize(chunksize)
+
+        # only set once engine resolution succeeds with engine="pyarrow"
+        self._arrow_table: Any | None = None
+        self.engine = self._resolve_engine(engine)
 
     @property
     def na_rep(self) -> str:
@@ -243,10 +259,242 @@ class CSVFormatter:
 
         return encoded_labels
 
+    def _pyarrow_option_incompatibility(self) -> str | None:
+        """
+        Return a reason the pyarrow engine cannot honor the requested
+        options, or None if the options are compatible. These are options
+        for which the pyarrow CSV writer has no equivalent, so silently
+        using pyarrow would produce output that quietly ignores the option
+        rather than applying it.
+        """
+        if isinstance(self.filepath_or_buffer, io.TextIOBase):
+            return "The pyarrow engine can only write to a binary buffer or file path."
+        if self.mode is not None and "b" not in self.mode:
+            return "The pyarrow engine can only write in binary mode."
+
+        if self.quotechar is not None and self.quotechar != '"':
+            return 'The pyarrow engine only supports " as a quotechar.'
+
+        unsupported_options = [
+            # each pair is (option value, default, option name)
+            (self.decimal, ".", "decimal"),
+            (self.float_format, None, "float_format"),
+            (self.na_rep, "", "na_rep"),
+            (self.date_format, None, "date_format"),
+            (self.lineterminator, os.linesep, "lineterminator"),
+            (self.errors, "strict", "errors"),
+            (self.escapechar, None, "escapechar"),
+            (self.doublequote, True, "doublequote"),
+        ]
+        for opt_val, default, option in unsupported_options:
+            if opt_val != default:
+                return f"The {option} option is not supported with the pyarrow engine."
+
+        # pyarrow's CSV writer always writes utf-8, so an explicit request
+        # for utf-8 is compatible even though it differs from the sentinel
+        # (None) used to detect a non-default `encoding`.
+        if self.encoding is not None and self.encoding.replace("-", "").replace(
+            "_", ""
+        ).lower() not in ("utf8", "u8"):
+            return "The encoding option is not supported with the pyarrow engine."
+
+        if self.has_mi_columns:
+            return "The pyarrow engine does not support a MultiIndex on the columns."
+
+        return None
+
+    def _iter_written_dtypes(self) -> Iterator[DtypeObj]:
+        """Dtypes of every column that will actually be written, incl. the index."""
+        if self.index:
+            index = self.obj.index
+            if isinstance(index, ABCMultiIndex):
+                yield from index.dtypes
+            else:
+                yield index.dtype
+        yield from self.obj.dtypes
+
+    @staticmethod
+    def _is_tz_aware_dtype(dtype: DtypeObj) -> bool:
+        if isinstance(dtype, DatetimeTZDtype):
+            return True
+        if isinstance(dtype, ArrowDtype):
+            pa = import_optional_dependency("pyarrow")
+            pa_dtype = dtype.pyarrow_dtype
+            return pa.types.is_timestamp(pa_dtype) and pa_dtype.tz is not None
+        return False
+
+    def _pyarrow_renders_differently(self) -> bool:
+        """
+        Whether any column/index level being written has a dtype that
+        the pyarrow engine renders in a materially different (though
+        still value-preserving) textual form than the python engine:
+        bool -> "true"/"false" instead of "True"/"False", timedelta64 ->
+        raw integer nanoseconds instead of a human-readable duration, and
+        timezone-aware datetime64 -> a different offset/precision format.
+        """
+        for dtype in self._iter_written_dtypes():
+            if dtype.kind in ("b", "m") or self._is_tz_aware_dtype(dtype):
+                return True
+        return False
+
+    @staticmethod
+    def _has_whole_number_float_column(obj) -> bool:
+        """
+        Whether any float-dtype column in `obj` (which already has any
+        index moved into a column by _build_arrow_obj) holds only
+        whole-number values (ignoring missing values). The python engine
+        always writes a trailing ".0" for such values (e.g. "1.0"), which
+        is what lets read_csv infer a float dtype back on round-trip; the
+        pyarrow engine omits it (writing "1"), which can silently change
+        the dtype read_csv infers to an integer type instead.
+        """
+        for _, col in obj.items():
+            if col.dtype.kind != "f":
+                continue
+            non_null = col[col.notna()]
+            if len(non_null) and (non_null % 1 == 0).all():
+                return True
+        return False
+
+    def _build_arrow_obj(self):
+        """
+        Return self.obj with the index moved into columns (mirroring how
+        the python engine writes the index), ready for pa.Table.from_pandas.
+        """
+        obj = self.obj
+        if self._has_aliases:
+            # header=[...] aliases only rename the CSV output, not obj
+            # itself, but pyarrow's writer has no separate notion of a
+            # header distinct from the table's own schema, so give it
+            # column names that already match the requested aliases.
+            obj = obj.rename(columns=dict(zip(self.obj.columns, self.write_cols)))
+
+        if not self.index:
+            return obj
+        # Use unique placeholder names to reset_index with, since the
+        # index levels may be unnamed (and thus collide with each other,
+        # or with "") once converted to their final header labels.
+        nlevels = self.obj.index.nlevels
+        placeholders = [f"__pandas_index_level_{i}__" for i in range(nlevels)]
+        obj = obj.reset_index(names=placeholders)
+        target_names = [
+            name if name is not None else "" for name in self.obj.index.names
+        ]
+        return obj.rename(columns=dict(zip(placeholders, target_names)))
+
+    def _resolve_engine(self, requested_engine: str) -> str:
+        """
+        Resolve the user-requested engine ("python", "pyarrow", or "auto")
+        to the concrete engine ("python" or "pyarrow") that will actually
+        be used, validating/warning/falling back as appropriate.
+        """
+        if requested_engine not in ("python", "pyarrow", "auto"):
+            raise ValueError(
+                "engine must be one of 'python', 'pyarrow', or 'auto', "
+                f"got {requested_engine!r}"
+            )
+        if requested_engine == "python":
+            return "python"
+
+        explicit = requested_engine == "pyarrow"
+
+        option_incompatibility = self._pyarrow_option_incompatibility()
+        if option_incompatibility is not None:
+            if explicit:
+                raise ValueError(option_incompatibility)
+            return "python"
+
+        pa = import_optional_dependency(
+            "pyarrow", errors="raise" if explicit else "ignore"
+        )
+        if pa is None:
+            return "python"
+
+        arrow_obj = self._build_arrow_obj()
+
+        if self._pyarrow_renders_differently() or self._has_whole_number_float_column(
+            arrow_obj
+        ):
+            if explicit:
+                warnings.warn(
+                    "The pyarrow engine renders bool, timedelta64, and "
+                    "timezone-aware datetime64 columns differently than "
+                    "the python engine (e.g. 'true'/'false' instead of "
+                    "'True'/'False'), and omits the trailing '.0' on a "
+                    "whole-number float column (e.g. '1' instead of "
+                    "'1.0'), which can change the dtype read_csv infers "
+                    "on round-trip.",
+                    UserWarning,
+                    stacklevel=find_stack_level(),
+                )
+            else:
+                return "python"
+
+        if arrow_obj.isna().all(axis=1).any():
+            reason = (
+                "The pyarrow engine cannot represent a row that is "
+                "entirely missing values without writing a blank output "
+                "line, which would be silently dropped when the file is "
+                "read back with the default skip_blank_lines=True."
+            )
+            if explicit:
+                raise ValueError(reason)
+            return "python"
+
+        try:
+            # preserve_index=False: the index (if any) is already moved
+            # into a column by _build_arrow_obj above; letting pyarrow's
+            # own preserve_index heuristic run too would either duplicate
+            # it or -- when self.index is False -- add it back as an
+            # unwanted extra column.
+            table = pa.Table.from_pandas(arrow_obj, preserve_index=False)
+        except (pa.lib.ArrowException, TypeError, ValueError):
+            if explicit:
+                raise
+            return "python"
+
+        # Some dtypes (e.g. Period, Interval extension types, or Python
+        # list/dict objects that pyarrow infers as a list/struct type)
+        # convert to a pyarrow Table successfully, but pyarrow's CSV writer
+        # cannot serialize them and only raises once actually writing.
+        # Detect that up front with a cheap trial write of a small slice
+        # (never more than a handful of rows), rather than letting it raise
+        # mid-write into the real destination -- and rather than trying to
+        # maintain a list of every pyarrow type the CSV writer rejects.
+        pa_csv = import_optional_dependency("pyarrow.csv")
+        write_options = self._build_pyarrow_write_options(pa_csv)
+        try:
+            pa_csv.write_csv(table.slice(0, 1), io.BytesIO(), write_options)
+        except (pa.lib.ArrowException, TypeError, ValueError, NotImplementedError):
+            reason = (
+                "The pyarrow engine cannot write one or more columns in "
+                "this data (e.g. Period/Interval dtype, or an object "
+                "column of list/dict values)."
+            )
+            if explicit:
+                raise ValueError(reason) from None
+            return "python"
+
+        self._arrow_table = table
+        return "pyarrow"
+
     def save(self) -> None:
         """
         Create the writer & save.
         """
+        if self.mode is None:
+            self.mode = "w" + ("b" if self.engine == "pyarrow" else "")
+
+        if self.filepath_or_buffer is None:
+            self.filepath_or_buffer = (
+                io.BytesIO() if self.engine == "pyarrow" else io.StringIO()
+            )
+
+        if self.engine == "pyarrow" and (
+            "b" not in self.mode or isinstance(self.filepath_or_buffer, io.TextIOBase)
+        ):
+            raise ValueError("The pyarrow engine can only open files in binary mode.")
+
         # apply compression and byte/text conversion
         with get_handle(
             self.filepath_or_buffer,
@@ -255,12 +503,63 @@ class CSVFormatter:
             errors=self.errors,
             compression=self.compression,
             storage_options=self.storage_options,
+            # pyarrow engine exclusively writes bytes
+            is_text=self.engine == "python",
         ) as handles:
             # Note: self.encoding is irrelevant here
-            # error: Argument "quoting" to "writer" has incompatible type "int";
-            # expected "Literal[0, 1, 2, 3]"
+
+            # This is a mypy bug?
+            # error: Cannot infer type argument 1 of "_save" of "CSVFormatter"  [misc]
+            self._save(handles.handle)  # type: ignore[misc]
+
+    def _save_pyarrow(self, handle: IO[AnyStr]) -> None:
+        pa_csv = import_optional_dependency("pyarrow.csv")
+
+        # built and validated during engine resolution in __init__
+        table = self._arrow_table
+        write_options = self._build_pyarrow_write_options(pa_csv)
+        pa_csv.write_csv(table, handle, write_options)
+
+    def _build_pyarrow_write_options(self, pa_csv):
+        # Map quoting arg to pyarrow equivalents. QUOTE_NONE is checked
+        # before the quotechar-is-None case below, since quotechar is
+        # legitimately None whenever quoting=QUOTE_NONE and no escapechar
+        # was given (see _initialize_quotechar).
+        if self.quoting == csvlib.QUOTE_MINIMAL:
+            pa_quoting = "needed"
+        elif self.quoting == csvlib.QUOTE_NONE:
+            pa_quoting = "none"
+        elif self.quotechar is None:
+            raise TypeError("quotechar must be set if quoting enabled")
+        elif self.quoting == csvlib.QUOTE_ALL:
+            # TODO: Is this a 1-1 mapping?
+            # This doesn't quote nulls, check if Python does this
+            pa_quoting = "all_valid"
+        else:
+            raise NotImplementedError(
+                f"Quoting option {self.quoting} is not supported with engine='pyarrow'"
+            )
+
+        kwargs: dict[str, Any] = {
+            "include_header": self._need_to_save_header,
+            "batch_size": self.chunksize,
+        }
+        kwargs["delimiter"] = self.sep
+        kwargs["quoting_style"] = pa_quoting
+
+        return pa_csv.WriteOptions(**kwargs)
+
+    def _save(self, handle: IO[AnyStr]) -> None:
+        if self.engine == "pyarrow":
+            self._save_pyarrow(handle)
+        else:
             self.writer = csvlib.writer(
-                handles.handle,
+                # error: Argument of type "IO[AnyStr@_save]" cannot be assigned
+                # to parameter "csvfile" of type "SupportsWrite[str]"
+                # in function "writer"
+                # error: Argument "quoting" to "writer" has incompatible type "int";
+                # expected "Literal[0, 1, 2, 3]"
+                handle,  # type: ignore[arg-type]
                 lineterminator=self.lineterminator,
                 delimiter=self.sep,
                 quoting=self.quoting,  # type: ignore[arg-type]
@@ -268,13 +567,9 @@ class CSVFormatter:
                 escapechar=self.escapechar,
                 quotechar=self.quotechar,
             )
-
-            self._save()
-
-    def _save(self) -> None:
-        if self._need_to_save_header:
-            self._save_header()
-        self._save_body()
+            if self._need_to_save_header:
+                self._save_header()
+            self._save_body()
 
     def _save_header(self) -> None:
         if not self.has_mi_columns or self._has_aliases:

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -16,13 +16,17 @@ from contextlib import contextmanager
 from csv import QUOTE_NONE
 from decimal import Decimal
 from functools import partial
-from io import StringIO
+from io import (
+    BytesIO,
+    StringIO,
+)
 import math
 import re
 from shutil import get_terminal_size
 from typing import (
     TYPE_CHECKING,
     Any,
+    Union,
     cast,
 )
 import warnings
@@ -979,11 +983,12 @@ class DataFrameRenderer:
     def to_csv(
         self,
         path_or_buf: FilePath | WriteBuffer[bytes] | WriteBuffer[str] | None = None,
+        engine: str = "auto",
         encoding: str | None = None,
         sep: str = ",",
         columns: Sequence[Hashable] | None = None,
         index_label: IndexLabel | None = None,
-        mode: str = "w",
+        mode: str | None = None,
         compression: CompressionOptions = "infer",
         quoting: int | None = None,
         quotechar: str = '"',
@@ -1000,14 +1005,11 @@ class DataFrameRenderer:
         """
         from pandas.io.formats.csvs import CSVFormatter
 
-        if path_or_buf is None:
-            created_buffer = True
-            path_or_buf = StringIO()
-        else:
-            created_buffer = False
+        created_buffer = path_or_buf is None
 
         csv_formatter = CSVFormatter(
             path_or_buf=path_or_buf,
+            engine=engine,
             lineterminator=lineterminator,
             sep=sep,
             encoding=encoding,
@@ -1028,9 +1030,13 @@ class DataFrameRenderer:
         csv_formatter.save()
 
         if created_buffer:
-            assert isinstance(path_or_buf, StringIO)
-            content = path_or_buf.getvalue()
-            path_or_buf.close()
+            buf = cast("Union[BytesIO, StringIO]", csv_formatter.filepath_or_buffer)
+            content = buf.getvalue()
+            if isinstance(content, bytes):
+                # Need to decode into string since the
+                # pyarrow engine only writes binary data
+                content = content.decode("utf-8")
+            buf.close()
             return content
 
         return None

--- a/pandas/tests/frame/methods/test_to_csv.py
+++ b/pandas/tests/frame/methods/test_to_csv.py
@@ -172,7 +172,10 @@ class TestDataFrameToCSV:
         cols = [cs[2], cs[0]]
 
         path = str(temp_file)
-        df.to_csv(path, columns=cols, chunksize=chunksize)
+        # engine="python": round-trip dtype stability for whole-number
+        # floats isn't guaranteed with the pyarrow engine, which omits the
+        # trailing ".0" that read_csv's type inference relies on
+        df.to_csv(path, columns=cols, chunksize=chunksize, engine="python")
         rs_c = read_csv(path, index_col=0)
 
         tm.assert_frame_equal(df[cols], rs_c, check_names=False)
@@ -847,7 +850,10 @@ class TestDataFrameToCSV:
         aa["D"] = aa.A + 3.0
 
         path = str(temp_file)
-        aa.to_csv(path, chunksize=chunksize)
+        # engine="python": these are whole-number floats, whose round-trip
+        # dtype isn't guaranteed with the pyarrow engine (see
+        # test_to_csv_cols_reordering)
+        aa.to_csv(path, chunksize=chunksize, engine="python")
         rs = read_csv(path, index_col=0)
         tm.assert_frame_equal(rs, aa)
 
@@ -873,7 +879,10 @@ class TestDataFrameToCSV:
         newdf = DataFrame({"t": df[df.columns[0]]})
 
         path = str(temp_file)
-        newdf.to_csv(path)
+        # engine="python": "t" is a whole-number float column, whose
+        # round-trip dtype isn't guaranteed with the pyarrow engine (see
+        # test_to_csv_cols_reordering)
+        newdf.to_csv(path, engine="python")
 
         recons = read_csv(path, index_col=0)
         # don't check_names as t != 1
@@ -988,11 +997,15 @@ class TestDataFrameToCSV:
 
     def test_to_csv_lineterminators2(self, temp_file):
         # see gh-20353
+        # engine="python": on platforms where os.linesep == "\n" this
+        # lineterminator is indistinguishable from the (pyarrow-compatible)
+        # default, so the pyarrow/auto engines would otherwise be used and
+        # quote the (string-typed) header
         df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["one", "two", "three"])
 
         path = str(temp_file)
         # case 2: LF as line terminator
-        df.to_csv(path, lineterminator="\n")
+        df.to_csv(path, lineterminator="\n", engine="python")
         expected = b",A,B\none,1,4\ntwo,2,5\nthree,3,6\n"
 
         with open(path, mode="rb") as f:
@@ -1000,10 +1013,11 @@ class TestDataFrameToCSV:
 
     def test_to_csv_lineterminators3(self, temp_file):
         # see gh-20353
+        # engine="python": exercises the exact unquoted default rendering
         df = DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["one", "two", "three"])
         path = str(temp_file)
         # case 3: The default line terminator(=os.linesep)(gh-21406)
-        df.to_csv(path)
+        df.to_csv(path, engine="python")
         os_linesep = os.linesep.encode("utf-8")
         expected = (
             b",A,B"
@@ -1374,7 +1388,8 @@ class TestDataFrameToCSV:
         file_path = tmp_path / "__test_gz_lineend.csv.gz"
         file_path.touch()
         path = str(file_path)
-        df.to_csv(path, index=False)
+        # engine="python": exercises the exact unquoted default rendering
+        df.to_csv(path, index=False, engine="python")
         with tm.decompress_file(path, compression="gzip") as f:
             result = f.read().decode("utf-8")
 
@@ -1405,7 +1420,8 @@ class TestDataFrameToCSV:
         df = DataFrame({"a": "x", "b": [1, pd.NA]})
         df["b"] = df["b"].astype("Int16")
         df["b"] = df["b"].astype("category")
-        result = df.to_csv()
+        # engine="python": exercises the exact unquoted default rendering
+        result = df.to_csv(engine="python")
         expected_rows = [",a,b", "0,x,1", "1,x,"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
         assert result == expected

--- a/pandas/tests/io/formats/test_to_csv.py
+++ b/pandas/tests/io/formats/test_to_csv.py
@@ -1,3 +1,4 @@
+import contextlib
 import csv
 from datetime import (
     UTC,
@@ -22,8 +23,137 @@ from pandas.core.arrays import FloatingArray
 from pandas.core.indexes.base import get_values_for_csv
 
 
+@pytest.fixture(params=["python", "pyarrow", "auto"])
+def engine(request):
+    if request.param in ("pyarrow", "auto"):
+        pytest.importorskip("pyarrow")
+    return request.param
+
+
+def check_raises_if_pyarrow(option, engine):
+    """
+    Returns a context manager that ensures that the pyarrow engine raises an
+    exception for unsupported options. The "auto" engine falls back to the
+    python engine (silently) for the same options, so it does not raise.
+    """
+    if engine == "pyarrow":
+        raises_if_pyarrow = pytest.raises(
+            ValueError,
+            match=f"The {option} option is not supported with the pyarrow engine.",
+        )
+    else:
+        raises_if_pyarrow = contextlib.nullcontext()
+    return raises_if_pyarrow
+
+
+def uses_pyarrow(engine: str) -> bool:
+    """
+    Whether the given engine actually uses pyarrow to render *compatible*
+    data (no bool/timedelta64/timezone-aware/unsupported-option content):
+    true for "pyarrow" (forced) and "auto" (pyarrow is available and there
+    is nothing for it to fall back from). Used to predict pyarrow's
+    cosmetic-only differences from the python engine, e.g. always quoting
+    string values/headers, or omitting a redundant trailing ".0" on floats.
+    """
+    return engine in ("pyarrow", "auto")
+
+
+def check_warns_if_pyarrow_renders_differently(engine):
+    """
+    Returns a context manager that ensures that explicit engine="pyarrow"
+    warns (and "python"/"auto" do not) when the data contains a
+    bool/timedelta64/timezone-aware-datetime64/whole-number-float column,
+    which pyarrow renders differently than the python engine.
+    """
+    if engine == "pyarrow":
+        return tm.assert_produces_warning(
+            UserWarning,
+            match="renders bool, timedelta64",
+            # pyarrow's own Table.from_pandas may itself emit unrelated
+            # incidental warnings (e.g. converting a tz-aware column)
+            raise_on_extra_warnings=False,
+        )
+    return tm.assert_produces_warning(None)
+
+
+def check_raises_if_pyarrow_all_na_row(engine):
+    """
+    Returns a context manager that ensures that the pyarrow engine raises an
+    exception when a row is entirely composed of missing values, since it
+    would otherwise write a blank line that read_csv silently drops.
+    """
+    if engine == "pyarrow":
+        raises_if_pyarrow = pytest.raises(
+            ValueError,
+            match="cannot represent a row that is entirely missing values",
+        )
+    else:
+        raises_if_pyarrow = contextlib.nullcontext()
+    return raises_if_pyarrow
+
+
+def check_raises_if_pyarrow_lineterminator(lineterminator, engine):
+    """
+    Returns a context manager that ensures that the pyarrow engine raises an
+    exception for a non-default `lineterminator`. Note the default is
+    platform-dependent (`os.linesep`), so a given literal terminator (e.g.
+    "\\n") may or may not actually be non-default depending on the platform.
+    """
+    if lineterminator == os.linesep:
+        return contextlib.nullcontext()
+    return check_raises_if_pyarrow("lineterminator", engine)
+
+
+def check_raises_if_pyarrow_binary_only(engine):
+    """
+    Returns a context manager that ensures that the pyarrow engine raises an
+    exception when asked to write to something that is not a binary buffer
+    or file path (e.g. an already-open text file object, or sys.stdout).
+    """
+    if engine == "pyarrow":
+        raises_if_pyarrow = pytest.raises(
+            ValueError,
+            match="The pyarrow engine can only write",
+        )
+    else:
+        raises_if_pyarrow = contextlib.nullcontext()
+    return raises_if_pyarrow
+
+
+def check_raises_if_pyarrow_mi_columns(engine):
+    """
+    Returns a context manager that ensures that the pyarrow engine raises an
+    exception when the columns are a MultiIndex, which it cannot represent
+    with pandas' usual multi-row header.
+    """
+    if engine == "pyarrow":
+        raises_if_pyarrow = pytest.raises(
+            ValueError,
+            match="does not support a MultiIndex on the columns",
+        )
+    else:
+        raises_if_pyarrow = contextlib.nullcontext()
+    return raises_if_pyarrow
+
+
+def check_raises_if_pyarrow_unsupported_data(engine):
+    """
+    Returns a context manager that ensures that the pyarrow engine raises an
+    exception when the data cannot be represented by pyarrow at all (e.g.
+    Period, Interval, complex, or Sparse dtype columns).
+    """
+    if engine == "pyarrow":
+        raises_if_pyarrow = pytest.raises(
+            ValueError,
+            match="cannot write one or more columns",
+        )
+    else:
+        raises_if_pyarrow = contextlib.nullcontext()
+    return raises_if_pyarrow
+
+
 class TestToCSV:
-    def test_to_csv_with_single_column(self, temp_file):
+    def test_to_csv_with_single_column(self, temp_file, engine):
         # see gh-18676, https://bugs.python.org/issue32255
         #
         # Python's CSV library adds an extraneous '""'
@@ -31,41 +161,51 @@ class TestToCSV:
         # the first row. Otherwise, only the newline
         # character is added. This behavior is inconsistent
         # and was patched in https://bugs.python.org/pull_request4672.
+        #
+        # A single (unheadered, unindexed) column with a missing value is
+        # exactly a row that is entirely missing values, which the pyarrow
+        # engine cannot represent (see test_to_csv_pyarrow_all_na_row_raises)
+        raises_if_pyarrow = check_raises_if_pyarrow_all_na_row(engine)
+
         df1 = DataFrame([None, 1])
         expected1 = """\
 ""
 1.0
 """
-        df1.to_csv(temp_file, header=None, index=None)
-        with open(temp_file, encoding="utf-8") as f:
-            assert f.read() == expected1
+        with raises_if_pyarrow:
+            df1.to_csv(temp_file, header=None, index=None, engine=engine)
+            with open(temp_file, encoding="utf-8") as f:
+                assert f.read() == expected1
 
         df2 = DataFrame([1, None])
         expected2 = """\
 1.0
 ""
 """
-        df2.to_csv(temp_file, header=None, index=None)
-        with open(temp_file, encoding="utf-8") as f:
-            assert f.read() == expected2
+        with raises_if_pyarrow:
+            df2.to_csv(temp_file, header=None, index=None, engine=engine)
+            with open(temp_file, encoding="utf-8") as f:
+                assert f.read() == expected2
 
-    def test_to_csv_default_encoding(self, temp_file):
+    def test_to_csv_default_encoding(self, temp_file, engine):
         # GH17097
         df = DataFrame({"col": ["AAAAA", "ÄÄÄÄÄ", "ßßßßß", "聞聞聞聞聞"]})
 
-        # the default to_csv encoding is uft-8.
-        df.to_csv(temp_file)
+        # the default to_csv encoding is utf-8.
+        df.to_csv(temp_file, engine=engine)
         tm.assert_frame_equal(pd.read_csv(temp_file, index_col=0), df)
 
     @pytest.mark.parametrize("encoding", ["utf-16", "utf-16-le", "utf-16-be"])
-    def test_to_csv_utf16_encoding(self, encoding, temp_file):
+    def test_to_csv_utf16_encoding(self, encoding, temp_file, engine):
         # GH#10755
+        raises_if_pyarrow = check_raises_if_pyarrow("encoding", engine)
         df = DataFrame({"col": ["abc", "déf", "日本語"]})
-        df.to_csv(temp_file, encoding=encoding)
-        result = pd.read_csv(temp_file, index_col=0, encoding=encoding)
-        tm.assert_frame_equal(result, df)
+        with raises_if_pyarrow:
+            df.to_csv(temp_file, encoding=encoding, engine=engine)
+            result = pd.read_csv(temp_file, index_col=0, encoding=encoding)
+            tm.assert_frame_equal(result, df)
 
-    def test_to_csv_quotechar(self, temp_file):
+    def test_to_csv_quotechar(self, temp_file, engine):
         df = DataFrame({"col": [1, 2]})
         expected = """\
 "","col"
@@ -73,7 +213,7 @@ class TestToCSV:
 "1","2"
 """
 
-        df.to_csv(temp_file, quoting=1)  # 1=QUOTE_ALL
+        df.to_csv(temp_file, quoting=1, engine=engine)  # 1=QUOTE_ALL
         with open(temp_file, encoding="utf-8") as f:
             assert f.read() == expected
 
@@ -83,14 +223,23 @@ $0$,$1$
 $1$,$2$
 """
 
-        df.to_csv(temp_file, quoting=1, quotechar="$")
-        with open(temp_file, encoding="utf-8") as f:
-            assert f.read() == expected
+        if engine == "pyarrow":
+            raises_if_pyarrow = pytest.raises(
+                ValueError,
+                match='The pyarrow engine only supports " as a quotechar.',
+            )
+        else:
+            raises_if_pyarrow = contextlib.nullcontext()
+        with raises_if_pyarrow:
+            df.to_csv(temp_file, quoting=1, quotechar="$", engine=engine)
+        if engine != "pyarrow":
+            with open(temp_file, encoding="utf-8") as f:
+                assert f.read() == expected
 
         with pytest.raises(TypeError, match="quotechar"):
-            df.to_csv(temp_file, quoting=1, quotechar=None)
+            df.to_csv(temp_file, quoting=1, quotechar=None, engine=engine)
 
-    def test_to_csv_doublequote(self, temp_file):
+    def test_to_csv_doublequote(self, temp_file, engine):
         df = DataFrame({"col": ['a"a', '"bb"']})
         expected = '''\
 "","col"
@@ -98,14 +247,26 @@ $1$,$2$
 "1","""bb"""
 '''
 
-        df.to_csv(temp_file, quoting=1, doublequote=True)  # QUOTE_ALL
+        df.to_csv(temp_file, quoting=1, doublequote=True, engine=engine)  # QUOTE_ALL
         with open(temp_file, encoding="utf-8") as f:
             assert f.read() == expected
 
-        with pytest.raises(csv.Error, match="escapechar"):
-            df.to_csv(temp_file, doublequote=False)  # no escapechar set
+        # no escapechar set: the python engine (used directly, or via auto's
+        # fallback, since pyarrow cannot honor doublequote=False either way)
+        # raises trying to escape the embedded quote; pyarrow raises its own
+        # ValueError before ever reaching a writer
+        if engine == "pyarrow":
+            with pytest.raises(
+                ValueError,
+                match="The doublequote option is not supported with the pyarrow engine.",
+            ):
+                df.to_csv(temp_file, doublequote=False, engine=engine)
+        else:
+            with pytest.raises(csv.Error, match="escapechar"):
+                df.to_csv(temp_file, doublequote=False, engine=engine)
 
-    def test_to_csv_escapechar(self, temp_file):
+    def test_to_csv_escapechar(self, temp_file, engine):
+        raises_if_pyarrow = check_raises_if_pyarrow("escapechar", engine)
         df = DataFrame({"col": ['a"a', '"bb"']})
         expected = """\
 "","col"
@@ -113,9 +274,12 @@ $1$,$2$
 "1","\\"bb\\""
 """
 
-        df.to_csv(temp_file, quoting=1, doublequote=False, escapechar="\\")
-        with open(temp_file, encoding="utf-8") as f:
-            assert f.read() == expected
+        with raises_if_pyarrow:
+            df.to_csv(
+                temp_file, quoting=1, doublequote=False, escapechar="\\", engine=engine
+            )
+            with open(temp_file, encoding="utf-8") as f:
+                assert f.read() == expected
 
         df = DataFrame({"col": ["a,a", ",bb,"]})
         expected = """\
@@ -124,119 +288,183 @@ $1$,$2$
 1,\\,bb\\,
 """
 
-        df.to_csv(temp_file, quoting=3, escapechar="\\")  # QUOTE_NONE
-        with open(temp_file, encoding="utf-8") as f:
-            assert f.read() == expected
+        with raises_if_pyarrow:
+            df.to_csv(
+                temp_file, quoting=3, escapechar="\\", engine=engine
+            )  # QUOTE_NONE
+            with open(temp_file, encoding="utf-8") as f:
+                assert f.read() == expected
 
-    def test_csv_to_string(self):
+    def test_csv_to_string(self, engine):
         df = DataFrame({"col": [1, 2]})
-        expected_rows = [",col", "0,1", "1,2"]
+        if uses_pyarrow(engine):
+            # pyarrow always quotes string-typed values, including headers
+            expected_rows = ['"","col"', "0,1", "1,2"]
+        else:
+            expected_rows = [",col", "0,1", "1,2"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv() == expected
+        assert df.to_csv(engine=engine) == expected
 
-    def test_to_csv_decimal(self):
+    def test_to_csv_decimal(self, engine):
         # see gh-781
+        raises_if_pyarrow = check_raises_if_pyarrow("decimal", engine)
         df = DataFrame({"col1": [1], "col2": ["a"], "col3": [10.1]})
 
-        expected_rows = [",col1,col2,col3", "0,1,a,10.1"]
+        if uses_pyarrow(engine):
+            # pyarrow always quotes string-typed values, including headers
+            expected_rows = ['"","col1","col2","col3"', '0,1,"a",10.1']
+        else:
+            expected_rows = [",col1,col2,col3", "0,1,a,10.1"]
         expected_default = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv() == expected_default
+        assert df.to_csv(engine=engine) == expected_default
 
         expected_rows = [";col1;col2;col3", "0;1;a;10,1"]
         expected_european_excel = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv(decimal=",", sep=";") == expected_european_excel
+        with raises_if_pyarrow:
+            assert (
+                df.to_csv(engine=engine, decimal=",", sep=";")
+                == expected_european_excel
+            )
 
         expected_rows = [",col1,col2,col3", "0,1,a,10.10"]
         expected_float_format_default = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv(float_format="%.2f") == expected_float_format_default
+        with check_raises_if_pyarrow("float_format", engine):
+            assert (
+                df.to_csv(engine=engine, float_format="%.2f")
+                == expected_float_format_default
+            )
 
         expected_rows = [";col1;col2;col3", "0;1;a;10,10"]
         expected_float_format = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert (
-            df.to_csv(decimal=",", sep=";", float_format="%.2f")
-            == expected_float_format
-        )
+        with raises_if_pyarrow:
+            assert (
+                df.to_csv(engine=engine, decimal=",", sep=";", float_format="%.2f")
+                == expected_float_format
+            )
 
         # see gh-11553: testing if decimal is taken into account for '0.0'
         df = DataFrame({"a": [0, 1.1], "b": [2.2, 3.3], "c": 1})
 
         expected_rows = ["a,b,c", "0^0,2^2,1", "1^1,3^3,1"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv(index=False, decimal="^") == expected
+        with raises_if_pyarrow:
+            assert df.to_csv(engine=engine, index=False, decimal="^") == expected
 
         # same but for an index
-        assert df.set_index("a").to_csv(decimal="^") == expected
+        with raises_if_pyarrow:
+            assert df.set_index("a").to_csv(engine=engine, decimal="^") == expected
 
         # same for a multi-index
-        assert df.set_index(["a", "b"]).to_csv(decimal="^") == expected
+        with raises_if_pyarrow:
+            assert (
+                df.set_index(["a", "b"]).to_csv(engine=engine, decimal="^") == expected
+            )
 
-    def test_to_csv_float_format(self):
+    def test_to_csv_float_format(self, engine):
         # testing if float_format is taken into account for the index
         # GH 11553
+        raises_if_pyarrow = check_raises_if_pyarrow("float_format", engine)
         df = DataFrame({"a": [0, 1], "b": [2.2, 3.3], "c": 1})
 
         expected_rows = ["a,b,c", "0,2.20,1", "1,3.30,1"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.set_index("a").to_csv(float_format="%.2f") == expected
+        with raises_if_pyarrow:
+            assert (
+                df.set_index("a").to_csv(engine=engine, float_format="%.2f") == expected
+            )
 
         # same for a multi-index
-        assert df.set_index(["a", "b"]).to_csv(float_format="%.2f") == expected
+        with raises_if_pyarrow:
+            assert (
+                df.set_index(["a", "b"]).to_csv(engine=engine, float_format="%.2f")
+                == expected
+            )
 
-    def test_to_csv_na_rep(self):
+    def test_to_csv_na_rep(self, engine):
         # see gh-11553
         #
         # Testing if NaN values are correctly represented in the index.
+        raises_if_pyarrow = check_raises_if_pyarrow("na_rep", engine)
         df = DataFrame({"a": [0, np.nan], "b": [0, 1], "c": [2, 3]})
         expected_rows = ["a,b,c", "0.0,0,2", "_,1,3"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
 
-        assert df.set_index("a").to_csv(na_rep="_") == expected
-        assert df.set_index(["a", "b"]).to_csv(na_rep="_") == expected
+        with raises_if_pyarrow:
+            assert df.set_index("a").to_csv(engine=engine, na_rep="_") == expected
+        with raises_if_pyarrow:
+            assert (
+                df.set_index(["a", "b"]).to_csv(engine=engine, na_rep="_") == expected
+            )
 
         # now with an index containing only NaNs
         df = DataFrame({"a": np.nan, "b": [0, 1], "c": [2, 3]})
         expected_rows = ["a,b,c", "_,0,2", "_,1,3"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
 
-        assert df.set_index("a").to_csv(na_rep="_") == expected
-        assert df.set_index(["a", "b"]).to_csv(na_rep="_") == expected
+        with raises_if_pyarrow:
+            assert df.set_index("a").to_csv(engine=engine, na_rep="_") == expected
+        with raises_if_pyarrow:
+            assert (
+                df.set_index(["a", "b"]).to_csv(engine=engine, na_rep="_") == expected
+            )
 
         # check if na_rep parameter does not break anything when no NaN
         df = DataFrame({"a": 0, "b": [0, 1], "c": [2, 3]})
         expected_rows = ["a,b,c", "0,0,2", "0,1,3"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
 
-        assert df.set_index("a").to_csv(na_rep="_") == expected
-        assert df.set_index(["a", "b"]).to_csv(na_rep="_") == expected
+        with raises_if_pyarrow:
+            assert df.set_index("a").to_csv(engine=engine, na_rep="_") == expected
+        with raises_if_pyarrow:
+            assert (
+                df.set_index(["a", "b"]).to_csv(engine=engine, na_rep="_") == expected
+            )
 
-        csv = pd.Series(["a", pd.NA, "c"]).to_csv(na_rep="ZZZZZ")
-        expected = tm.convert_rows_list_to_csv_str([",0", "0,a", "1,ZZZZZ", "2,c"])
-        assert expected == csv
+        with raises_if_pyarrow:
+            csv = pd.Series(["a", pd.NA, "c"]).to_csv(engine=engine, na_rep="ZZZZZ")
+            expected = tm.convert_rows_list_to_csv_str([",0", "0,a", "1,ZZZZZ", "2,c"])
+            assert expected == csv
 
-    def test_to_csv_na_rep_nullable_string(self, nullable_string_dtype):
+    def test_to_csv_na_rep_nullable_string(self, nullable_string_dtype, engine):
         # GH 29975
         # Make sure full na_rep shows up when a dtype is provided
+        raises_if_pyarrow = check_raises_if_pyarrow("na_rep", engine)
         expected = tm.convert_rows_list_to_csv_str([",0", "0,a", "1,ZZZZZ", "2,c"])
-        csv = pd.Series(["a", pd.NA, "c"], dtype=nullable_string_dtype).to_csv(
-            na_rep="ZZZZZ"
-        )
-        assert expected == csv
+        with raises_if_pyarrow:
+            csv = pd.Series(["a", pd.NA, "c"], dtype=nullable_string_dtype).to_csv(
+                engine=engine, na_rep="ZZZZZ"
+            )
+            assert expected == csv
 
-    def test_to_csv_date_format(self):
+    def test_to_csv_date_format(self, engine):
         # GH 10209
+        raises_if_pyarrow = check_raises_if_pyarrow("date_format", engine)
         df_sec = DataFrame({"A": pd.date_range("20130101", periods=5, freq="s")})
         df_day = DataFrame({"A": pd.date_range("20130101", periods=5, freq="D")})
 
-        expected_rows = [
-            ",A",
-            "0,2013-01-01 00:00:00",
-            "1,2013-01-01 00:00:01",
-            "2,2013-01-01 00:00:02",
-            "3,2013-01-01 00:00:03",
-            "4,2013-01-01 00:00:04",
-        ]
+        if uses_pyarrow(engine):
+            # The python engine drops the (all-zero) fractional seconds for
+            # this column (GH#62111); pyarrow's writer always shows the
+            # column's full declared (here, microsecond) precision.
+            expected_rows = [
+                '"","A"',
+                "0,2013-01-01 00:00:00.000000",
+                "1,2013-01-01 00:00:01.000000",
+                "2,2013-01-01 00:00:02.000000",
+                "3,2013-01-01 00:00:03.000000",
+                "4,2013-01-01 00:00:04.000000",
+            ]
+        else:
+            expected_rows = [
+                ",A",
+                "0,2013-01-01 00:00:00",
+                "1,2013-01-01 00:00:01",
+                "2,2013-01-01 00:00:02",
+                "3,2013-01-01 00:00:03",
+                "4,2013-01-01 00:00:04",
+            ]
         expected_default_sec = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df_sec.to_csv() == expected_default_sec
+        assert df_sec.to_csv(engine=engine) == expected_default_sec
 
         expected_rows = [
             ",A",
@@ -247,7 +475,11 @@ $1$,$2$
             "4,2013-01-05 00:00:00",
         ]
         expected_ymdhms_day = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df_day.to_csv(date_format="%Y-%m-%d %H:%M:%S") == expected_ymdhms_day
+        with raises_if_pyarrow:
+            assert (
+                df_day.to_csv(date_format="%Y-%m-%d %H:%M:%S", engine=engine)
+                == expected_ymdhms_day
+            )
 
         expected_rows = [
             ",A",
@@ -258,19 +490,46 @@ $1$,$2$
             "4,2013-01-01",
         ]
         expected_ymd_sec = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df_sec.to_csv(date_format="%Y-%m-%d") == expected_ymd_sec
+        with raises_if_pyarrow:
+            assert (
+                df_sec.to_csv(date_format="%Y-%m-%d", engine=engine) == expected_ymd_sec
+            )
 
-        expected_rows = [
-            ",A",
-            "0,2013-01-01",
-            "1,2013-01-02",
-            "2,2013-01-03",
-            "3,2013-01-04",
-            "4,2013-01-05",
-        ]
-        expected_default_day = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df_day.to_csv() == expected_default_day
-        assert df_day.to_csv(date_format="%Y-%m-%d") == expected_default_day
+        expected_short_day = tm.convert_rows_list_to_csv_str(
+            [
+                ",A",
+                "0,2013-01-01",
+                "1,2013-01-02",
+                "2,2013-01-03",
+                "3,2013-01-04",
+                "4,2013-01-05",
+            ]
+        )
+        if uses_pyarrow(engine):
+            # see the freq="s" case above: the python engine drops the
+            # (all-zero) time-of-day here entirely, pyarrow does not.
+            expected_default_day = tm.convert_rows_list_to_csv_str(
+                [
+                    '"","A"',
+                    "0,2013-01-01 00:00:00.000000",
+                    "1,2013-01-02 00:00:00.000000",
+                    "2,2013-01-03 00:00:00.000000",
+                    "3,2013-01-04 00:00:00.000000",
+                    "4,2013-01-05 00:00:00.000000",
+                ]
+            )
+        else:
+            expected_default_day = expected_short_day
+        # no date_format passed: reflects whichever engine actually runs
+        assert df_day.to_csv(engine=engine) == expected_default_day
+        # date_format="%Y-%m-%d" passed explicitly: unsupported by pyarrow
+        # (raises), and produces the same short-date text on both python
+        # and auto (which falls back to python for this call)
+        with raises_if_pyarrow:
+            assert (
+                df_day.to_csv(date_format="%Y-%m-%d", engine=engine)
+                == expected_short_day
+            )
 
         # see gh-7791
         #
@@ -283,9 +542,13 @@ $1$,$2$
         expected_ymd_sec = tm.convert_rows_list_to_csv_str(expected_rows)
 
         df_sec_grouped = df_sec.groupby([pd.Grouper(key="A", freq="1h"), "B"])
-        assert df_sec_grouped.mean().to_csv(date_format="%Y-%m-%d") == expected_ymd_sec
+        with raises_if_pyarrow:
+            assert (
+                df_sec_grouped.mean().to_csv(date_format="%Y-%m-%d", engine=engine)
+                == expected_ymd_sec
+            )
 
-    def test_to_csv_different_datetime_formats(self):
+    def test_to_csv_different_datetime_formats(self, engine):
         # GH#21734
         df = DataFrame(
             {
@@ -293,16 +556,28 @@ $1$,$2$
                 "datetime": pd.date_range("1970-01-01", periods=2, freq="h"),
             }
         )
-        expected_rows = [
-            "date,datetime",
-            "1970-01-01,1970-01-01 00:00:00",
-            "1970-01-01,1970-01-01 01:00:00",
-        ]
+        if uses_pyarrow(engine):
+            # the "date" column is entirely midnight, so the python engine
+            # drops the (all-zero) time-of-day (GH#62111); pyarrow does not,
+            # and also always quotes the (string) header
+            expected_rows = [
+                '"date","datetime"',
+                "1970-01-01 00:00:00.000000,1970-01-01 00:00:00.000000",
+                "1970-01-01 00:00:00.000000,1970-01-01 01:00:00.000000",
+            ]
+        else:
+            expected_rows = [
+                "date,datetime",
+                "1970-01-01,1970-01-01 00:00:00",
+                "1970-01-01,1970-01-01 01:00:00",
+            ]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv(index=False) == expected
+        assert df.to_csv(index=False, engine=engine) == expected
 
-    def test_to_csv_period_columns(self):
+    def test_to_csv_period_columns(self, engine):
         # GH#55426 - exercise the column path for PeriodArray
+        # Period dtype can't be represented by pyarrow at all
+        raises_if_pyarrow = check_raises_if_pyarrow_unsupported_data(engine)
         df = DataFrame(
             {
                 "a": pd.period_range("2020-01-01", periods=2, freq="D"),
@@ -315,11 +590,15 @@ $1$,$2$
             "2020-01-02,2020-03-02",
         ]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv(index=False) == expected
+        with raises_if_pyarrow:
+            assert df.to_csv(index=False, engine=engine) == expected
 
-    def test_to_csv_period_columns_date_format(self):
+    def test_to_csv_period_columns_date_format(self, engine):
         # GH#51621 - date_format is honored for a PeriodArray column, not just
         # a PeriodIndex
+        # date_format is unsupported by pyarrow regardless of the Period
+        # dtype also being unsupported
+        raises_if_pyarrow = check_raises_if_pyarrow("date_format", engine)
         df = DataFrame({"a": pd.period_range("2000-01-01", periods=2, freq="h")})
         expected_rows = [
             ",a",
@@ -327,10 +606,15 @@ $1$,$2$
             "1,2000-01-01___01:00:00",
         ]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv(date_format="%Y-%m-%d___%H:%M:%S") == expected
+        with raises_if_pyarrow:
+            assert (
+                df.to_csv(date_format="%Y-%m-%d___%H:%M:%S", engine=engine) == expected
+            )
 
-    def test_to_csv_interval_columns(self):
+    def test_to_csv_interval_columns(self, engine):
         # GH#55426 - exercise the column path for IntervalArray
+        # Interval dtype can't be represented by pyarrow at all
+        raises_if_pyarrow = check_raises_if_pyarrow_unsupported_data(engine)
         df = DataFrame(
             {
                 "a": pd.arrays.IntervalArray.from_breaks([0, 1, 2]),
@@ -343,14 +627,20 @@ $1$,$2$
             '"(1, 2]","(4, 5]"',
         ]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert df.to_csv(index=False) == expected
+        with raises_if_pyarrow:
+            assert df.to_csv(index=False, engine=engine) == expected
 
-    def test_to_csv_date_format_in_categorical(self):
+    def test_to_csv_date_format_in_categorical(self, engine):
         # GH#40754
+        raises_if_pyarrow = check_raises_if_pyarrow("date_format", engine)
+        # a single unindexed column with a missing value in it is a row
+        # that is entirely missing values, which pyarrow cannot represent
+        raises_if_pyarrow_na_row = check_raises_if_pyarrow_all_na_row(engine)
         ser = pd.Series(pd.to_datetime(["2021-03-27", pd.NaT], format="%Y-%m-%d"))
         ser = ser.astype("category")
         expected = tm.convert_rows_list_to_csv_str(["0", "2021-03-27", '""'])
-        assert ser.to_csv(index=False) == expected
+        with raises_if_pyarrow_na_row:
+            assert ser.to_csv(index=False, engine=engine) == expected
 
         ser = pd.Series(
             pd.date_range(
@@ -358,48 +648,93 @@ $1$,$2$
             ).append(pd.DatetimeIndex([pd.NaT]))
         )
         ser = ser.astype("category")
-        assert ser.to_csv(index=False, date_format="%Y-%m-%d") == expected
+        with raises_if_pyarrow:
+            assert (
+                ser.to_csv(index=False, engine=engine, date_format="%Y-%m-%d")
+                == expected
+            )
 
-    def test_to_csv_float_ea_float_format(self):
+    def test_to_csv_float_ea_float_format(self, engine):
+        # GH#45991
+        raises_if_pyarrow = check_raises_if_pyarrow("float_format", engine)
+        df = DataFrame({"a": [1.1, 2.02, pd.NA, 6.000006], "b": "c"})
+        df["a"] = df["a"].astype("Float64")
+        with raises_if_pyarrow:
+            result = df.to_csv(index=False, engine=engine, float_format="%.5f")
+            expected = tm.convert_rows_list_to_csv_str(
+                ["a,b", "1.10000,c", "2.02000,c", ",c", "6.00001,c"]
+            )
+            assert result == expected
+
+    def test_to_csv_float_ea_no_float_format(self, engine):
         # GH#45991
         df = DataFrame({"a": [1.1, 2.02, pd.NA, 6.000006], "b": "c"})
         df["a"] = df["a"].astype("Float64")
-        result = df.to_csv(index=False, float_format="%.5f")
-        expected = tm.convert_rows_list_to_csv_str(
-            ["a,b", "1.10000,c", "2.02000,c", ",c", "6.00001,c"]
-        )
+        result = df.to_csv(index=False, engine=engine)
+        if uses_pyarrow(engine):
+            # pyarrow always quotes string-typed values, including headers
+            expected = tm.convert_rows_list_to_csv_str(
+                ['"a","b"', '1.1,"c"', '2.02,"c"', ',"c"', '6.000006,"c"']
+            )
+        else:
+            expected = tm.convert_rows_list_to_csv_str(
+                ["a,b", "1.1,c", "2.02,c", ",c", "6.000006,c"]
+            )
         assert result == expected
 
-    def test_to_csv_float_ea_no_float_format(self):
-        # GH#45991
-        df = DataFrame({"a": [1.1, 2.02, pd.NA, 6.000006], "b": "c"})
-        df["a"] = df["a"].astype("Float64")
-        result = df.to_csv(index=False)
-        expected = tm.convert_rows_list_to_csv_str(
-            ["a,b", "1.1,c", "2.02,c", ",c", "6.000006,c"]
-        )
-        assert result == expected
-
-    def test_to_csv_float_ea_nan_distinguish(self, using_nan_is_na):
+    def test_to_csv_float_ea_nan_distinguish(self, using_nan_is_na, engine):
         # GH#61617, GH#65227 - to_csv should not crash when FloatingArray
         # contains unmasked NaN (with distinguish_nan_and_na=True)
         df = DataFrame({"a": pd.array([np.nan, pd.NA, 3.0], dtype="Float64"), "b": "c"})
-        result = df.to_csv(index=False)
+        result = df.to_csv(index=False, engine=engine)
+        # pyarrow always quotes string-typed values (incl. headers), and
+        # drops the redundant trailing ".0" on whole-number floats; "auto"
+        # only actually uses pyarrow here when the unmasked NaN is visible
+        # (using_nan_is_na=False), since an unmasked NaN otherwise makes
+        # column "a" look like a whole-number-only float column, which
+        # "auto" avoids rendering with pyarrow
+        pyarrow_used = engine == "pyarrow" or (engine == "auto" and not using_nan_is_na)
+        col_b = '"c"' if pyarrow_used else "c"
+        val_a = "3" if pyarrow_used else "3.0"
+        header = '"a","b"' if pyarrow_used else "a,b"
         if using_nan_is_na:
-            expected = tm.convert_rows_list_to_csv_str(["a,b", ",c", ",c", "3.0,c"])
+            expected = tm.convert_rows_list_to_csv_str(
+                [header, f",{col_b}", f",{col_b}", f"{val_a},{col_b}"]
+            )
         else:
-            expected = tm.convert_rows_list_to_csv_str(["a,b", "nan,c", ",c", "3.0,c"])
+            expected = tm.convert_rows_list_to_csv_str(
+                [header, f"nan,{col_b}", f",{col_b}", f"{val_a},{col_b}"]
+            )
         assert result == expected
 
-    def test_to_csv_float_ea_nan_distinguish_series(self, using_nan_is_na):
+    def test_to_csv_float_ea_nan_distinguish_series(self, using_nan_is_na, engine):
         # GH#65227 - Series.to_csv with FloatingArray containing both NaN and NA
         ser = pd.Series((1, pd.NA, 0), index=["a", "b", "c"], dtype="Float64", name="x")
         ser = ser / ser
-        result = ser.to_csv()
-        if using_nan_is_na:
-            expected = tm.convert_rows_list_to_csv_str([",x", "a,1.0", "b,", "c,"])
+        result = ser.to_csv(engine=engine)
+        # pyarrow always quotes string-typed values (incl. headers/index),
+        # and drops the redundant trailing ".0" on whole-number floats;
+        # see test_to_csv_float_ea_nan_distinguish for why "auto" only
+        # actually uses pyarrow when using_nan_is_na=False
+        pyarrow_used = engine == "pyarrow" or (engine == "auto" and not using_nan_is_na)
+        if pyarrow_used:
+            header, idx_a, idx_b, idx_c, val_a = (
+                '"","x"',
+                '"a"',
+                '"b"',
+                '"c"',
+                "1",
+            )
         else:
-            expected = tm.convert_rows_list_to_csv_str([",x", "a,1.0", "b,", "c,nan"])
+            header, idx_a, idx_b, idx_c, val_a = ",x", "a", "b", "c", "1.0"
+        if using_nan_is_na:
+            expected = tm.convert_rows_list_to_csv_str(
+                [header, f"{idx_a},{val_a}", f"{idx_b},", f"{idx_c},"]
+            )
+        else:
+            expected = tm.convert_rows_list_to_csv_str(
+                [header, f"{idx_a},{val_a}", f"{idx_b},", f"{idx_c},nan"]
+            )
         assert result == expected
 
     def test_to_csv_2d_float_ea(self):
@@ -418,17 +753,20 @@ $1$,$2$
         expected = np.array([["1.0", "NA"], ["3.0", "4.0"]], dtype=object)
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_to_csv_multi_index(self):
+    def test_to_csv_multi_index(self, engine):
         # see gh-6618
+        raises_if_pyarrow = check_raises_if_pyarrow_mi_columns(engine)
         df = DataFrame([1], columns=pd.MultiIndex.from_arrays([[1], [2]]))
 
         exp_rows = [",1", ",2", "0,1"]
         exp = tm.convert_rows_list_to_csv_str(exp_rows)
-        assert df.to_csv() == exp
+        with raises_if_pyarrow:
+            assert df.to_csv(engine=engine) == exp
 
         exp_rows = ["1", "2", "1"]
         exp = tm.convert_rows_list_to_csv_str(exp_rows)
-        assert df.to_csv(index=False) == exp
+        with raises_if_pyarrow:
+            assert df.to_csv(index=False, engine=engine) == exp
 
         df = DataFrame(
             [1],
@@ -438,46 +776,60 @@ $1$,$2$
 
         exp_rows = [",,1", ",,2", "1,2,1"]
         exp = tm.convert_rows_list_to_csv_str(exp_rows)
-        assert df.to_csv() == exp
+        with raises_if_pyarrow:
+            assert df.to_csv(engine=engine) == exp
 
         exp_rows = ["1", "2", "1"]
         exp = tm.convert_rows_list_to_csv_str(exp_rows)
-        assert df.to_csv(index=False) == exp
+        with raises_if_pyarrow:
+            assert df.to_csv(index=False, engine=engine) == exp
 
         df = DataFrame([1], columns=pd.MultiIndex.from_arrays([["foo"], ["bar"]]))
 
         exp_rows = [",foo", ",bar", "0,1"]
         exp = tm.convert_rows_list_to_csv_str(exp_rows)
-        assert df.to_csv() == exp
+        with raises_if_pyarrow:
+            assert df.to_csv(engine=engine) == exp
 
         exp_rows = ["foo", "bar", "1"]
         exp = tm.convert_rows_list_to_csv_str(exp_rows)
-        assert df.to_csv(index=False) == exp
+        with raises_if_pyarrow:
+            assert df.to_csv(index=False, engine=engine) == exp
 
     @pytest.mark.parametrize(
-        "ind,expected",
+        "ind,expected,expected_pyarrow",
         [
             (
                 pd.MultiIndex(levels=[[1.0]], codes=[[0]], names=["x"]),
                 "x,data\n1.0,1\n",
+                '"x","data"\n1,1\n',
             ),
             (
                 pd.MultiIndex(
                     levels=[[1.0], [2.0]], codes=[[0], [0]], names=["x", "y"]
                 ),
                 "x,y,data\n1.0,2.0,1\n",
+                '"x","y","data"\n1,2,1\n',
             ),
         ],
     )
-    def test_to_csv_single_level_multi_index(self, ind, expected, frame_or_series):
+    def test_to_csv_single_level_multi_index(
+        self, ind, expected, expected_pyarrow, frame_or_series, engine
+    ):
         # see gh-19589
+        # pyarrow always quotes string-typed values/headers, and drops the
+        # redundant trailing ".0" on whole-number floats (here, the index);
+        # "auto" falls back to python for this whole-number-float data, so
+        # only explicit engine="pyarrow" actually renders this differently
+        if engine == "pyarrow":
+            expected = expected_pyarrow
         obj = frame_or_series(pd.Series([1], ind, name="data"))
-
-        result = obj.to_csv(lineterminator="\n", header=True)
+        result = obj.to_csv(lineterminator="\n", header=True, engine=engine)
         assert result == expected
 
-    def test_to_csv_string_array_ascii(self, temp_file):
+    def test_to_csv_string_array_ascii(self, temp_file, engine):
         # GH 10813
+        raises_if_pyarrow = check_raises_if_pyarrow("encoding", engine)
         str_array = [{"names": ["foo", "bar"]}, {"names": ["baz", "qux"]}]
         df = DataFrame(str_array)
         expected_ascii = """\
@@ -485,12 +837,24 @@ $1$,$2$
 0,"['foo', 'bar']"
 1,"['baz', 'qux']"
 """
-        df.to_csv(temp_file, encoding="ascii")
-        with open(temp_file, encoding="utf-8") as f:
-            assert f.read() == expected_ascii
+        with raises_if_pyarrow:
+            df.to_csv(temp_file, encoding="ascii", engine=engine)
+            with open(temp_file, encoding="utf-8") as f:
+                assert f.read() == expected_ascii
 
-    def test_to_csv_string_array_utf8(self, temp_file):
+    def test_to_csv_string_array_utf8(self, temp_file, engine):
         # GH 10813
+        # explicitly requesting "utf-8" is compatible with the pyarrow
+        # engine (it always writes utf-8), but the "names" column here
+        # holds actual Python list objects, which pyarrow infers as a list
+        # type that its CSV writer cannot serialize
+        if engine == "pyarrow":
+            raises_if_pyarrow = pytest.raises(
+                ValueError,
+                match="cannot write one or more columns",
+            )
+        else:
+            raises_if_pyarrow = contextlib.nullcontext()
         str_array = [{"names": ["foo", "bar"]}, {"names": ["baz", "qux"]}]
         df = DataFrame(str_array)
         expected_utf8 = """\
@@ -498,97 +862,150 @@ $1$,$2$
 0,"['foo', 'bar']"
 1,"['baz', 'qux']"
 """
-        df.to_csv(temp_file, encoding="utf-8")
-        with open(temp_file, encoding="utf-8") as f:
-            assert f.read() == expected_utf8
+        with raises_if_pyarrow:
+            df.to_csv(temp_file, encoding="utf-8", engine=engine)
+            with open(temp_file, encoding="utf-8") as f:
+                assert f.read() == expected_utf8
 
-    def test_to_csv_roundtrip_with_newline_in_field(self, temp_file):
+    def test_to_csv_roundtrip_with_newline_in_field(self, temp_file, engine):
         # GH#22497 - embedded newlines in field values should survive roundtrip
         df = DataFrame({"A": ["test", "te\nst"]})  # codespell:ignore te
-        df.to_csv(temp_file, index=False)
+        df.to_csv(temp_file, index=False, engine=engine)
         result = pd.read_csv(temp_file)
         tm.assert_frame_equal(result, df)
 
-    def test_to_csv_string_with_lf(self, temp_file):
+    def test_to_csv_string_with_lf(self, temp_file, engine):
         # GH 20353
         data = {"int": [1, 2, 3], "str_lf": ["abc", "d\nef", "g\nh\n\ni"]}
         df = DataFrame(data)
 
         # case 1: The default line terminator(=os.linesep)(PR 21406)
         os_linesep = os.linesep.encode("utf-8")
-        expected_noarg = (
-            b"int,str_lf"
-            + os_linesep
-            + b"1,abc"
-            + os_linesep
-            + b'2,"d\nef"'
-            + os_linesep
-            + b'3,"g\nh\n\ni"'
-            + os_linesep
-        )
-        df.to_csv(temp_file, index=False)
+        if uses_pyarrow(engine):
+            # pyarrow always quotes string-typed values, including headers
+            expected_noarg = (
+                b'"int","str_lf"'
+                + os_linesep
+                + b'1,"abc"'
+                + os_linesep
+                + b'2,"d\nef"'
+                + os_linesep
+                + b'3,"g\nh\n\ni"'
+                + os_linesep
+            )
+        else:
+            expected_noarg = (
+                b"int,str_lf"
+                + os_linesep
+                + b"1,abc"
+                + os_linesep
+                + b'2,"d\nef"'
+                + os_linesep
+                + b'3,"g\nh\n\ni"'
+                + os_linesep
+            )
+        df.to_csv(temp_file, index=False, engine=engine)
         with open(temp_file, "rb") as f:
             assert f.read() == expected_noarg
 
         # case 2: LF as line terminator
-        expected_lf = b'int,str_lf\n1,abc\n2,"d\nef"\n3,"g\nh\n\ni"\n'
-        df.to_csv(temp_file, lineterminator="\n", index=False)
-        with open(temp_file, "rb") as f:
-            assert f.read() == expected_lf
+        if uses_pyarrow(engine) and "\n" == os.linesep:
+            expected_lf = b'"int","str_lf"\n1,"abc"\n2,"d\nef"\n3,"g\nh\n\ni"\n'
+        else:
+            expected_lf = b'int,str_lf\n1,abc\n2,"d\nef"\n3,"g\nh\n\ni"\n'
+        with check_raises_if_pyarrow_lineterminator("\n", engine):
+            df.to_csv(temp_file, lineterminator="\n", index=False, engine=engine)
+            with open(temp_file, "rb") as f:
+                assert f.read() == expected_lf
 
         # case 3: CRLF as line terminator
         # 'lineterminator' should not change inner element
-        expected_crlf = b'int,str_lf\r\n1,abc\r\n2,"d\nef"\r\n3,"g\nh\n\ni"\r\n'
-        df.to_csv(temp_file, lineterminator="\r\n", index=False)
-        with open(temp_file, "rb") as f:
-            assert f.read() == expected_crlf
+        if uses_pyarrow(engine) and "\r\n" == os.linesep:
+            expected_crlf = (
+                b'"int","str_lf"\r\n1,"abc"\r\n2,"d\nef"\r\n3,"g\nh\n\ni"\r\n'
+            )
+        else:
+            expected_crlf = b'int,str_lf\r\n1,abc\r\n2,"d\nef"\r\n3,"g\nh\n\ni"\r\n'
+        with check_raises_if_pyarrow_lineterminator("\r\n", engine):
+            df.to_csv(temp_file, lineterminator="\r\n", index=False, engine=engine)
+            with open(temp_file, "rb") as f:
+                assert f.read() == expected_crlf
 
-    def test_to_csv_string_with_crlf(self, temp_file):
+    def test_to_csv_string_with_crlf(self, temp_file, engine):
         # GH 20353
         data = {"int": [1, 2, 3], "str_crlf": ["abc", "d\r\nef", "g\r\nh\r\n\r\ni"]}
         df = DataFrame(data)
         # case 1: The default line terminator(=os.linesep)(PR 21406)
         os_linesep = os.linesep.encode("utf-8")
-        expected_noarg = (
-            b"int,str_crlf"
-            + os_linesep
-            + b"1,abc"
-            + os_linesep
-            + b'2,"d\r\nef"'
-            + os_linesep
-            + b'3,"g\r\nh\r\n\r\ni"'
-            + os_linesep
-        )
-        df.to_csv(temp_file, index=False)
+        if uses_pyarrow(engine):
+            # pyarrow always quotes string-typed values, including headers
+            expected_noarg = (
+                b'"int","str_crlf"'
+                + os_linesep
+                + b'1,"abc"'
+                + os_linesep
+                + b'2,"d\r\nef"'
+                + os_linesep
+                + b'3,"g\r\nh\r\n\r\ni"'
+                + os_linesep
+            )
+        else:
+            expected_noarg = (
+                b"int,str_crlf"
+                + os_linesep
+                + b"1,abc"
+                + os_linesep
+                + b'2,"d\r\nef"'
+                + os_linesep
+                + b'3,"g\r\nh\r\n\r\ni"'
+                + os_linesep
+            )
+        df.to_csv(temp_file, index=False, engine=engine)
         with open(temp_file, "rb") as f:
             assert f.read() == expected_noarg
 
         # case 2: LF as line terminator
-        expected_lf = b'int,str_crlf\n1,abc\n2,"d\r\nef"\n3,"g\r\nh\r\n\r\ni"\n'
-        df.to_csv(temp_file, lineterminator="\n", index=False)
-        with open(temp_file, "rb") as f:
-            assert f.read() == expected_lf
+        if uses_pyarrow(engine) and "\n" == os.linesep:
+            expected_lf = (
+                b'"int","str_crlf"\n1,"abc"\n2,"d\r\nef"\n3,"g\r\nh\r\n\r\ni"\n'
+            )
+        else:
+            expected_lf = b'int,str_crlf\n1,abc\n2,"d\r\nef"\n3,"g\r\nh\r\n\r\ni"\n'
+        with check_raises_if_pyarrow_lineterminator("\n", engine):
+            df.to_csv(temp_file, lineterminator="\n", index=False, engine=engine)
+            with open(temp_file, "rb") as f:
+                assert f.read() == expected_lf
 
         # case 3: CRLF as line terminator
         # 'lineterminator' should not change inner element
-        expected_crlf = (
-            b'int,str_crlf\r\n1,abc\r\n2,"d\r\nef"\r\n3,"g\r\nh\r\n\r\ni"\r\n'
-        )
-        df.to_csv(temp_file, lineterminator="\r\n", index=False)
-        with open(temp_file, "rb") as f:
-            assert f.read() == expected_crlf
+        if uses_pyarrow(engine) and "\r\n" == os.linesep:
+            expected_crlf = (
+                b'"int","str_crlf"\r\n1,"abc"\r\n2,"d\r\nef"\r\n3,"g\r\nh\r\n\r\ni"\r\n'
+            )
+        else:
+            expected_crlf = (
+                b'int,str_crlf\r\n1,abc\r\n2,"d\r\nef"\r\n3,"g\r\nh\r\n\r\ni"\r\n'
+            )
+        with check_raises_if_pyarrow_lineterminator("\r\n", engine):
+            df.to_csv(temp_file, lineterminator="\r\n", index=False, engine=engine)
+            with open(temp_file, "rb") as f:
+                assert f.read() == expected_crlf
 
-    def test_to_csv_stdout_file(self, capsys):
+    def test_to_csv_stdout_file(self, capsys, engine):
         # GH 21561
+        # sys.stdout is a text stream, which the pyarrow engine cannot
+        # write to (nor can it honor a non-default `encoding`)
+        raises_if_pyarrow = check_raises_if_pyarrow_binary_only(engine)
         df = DataFrame([["foo", "bar"], ["baz", "qux"]], columns=["name_1", "name_2"])
         expected_rows = [",name_1,name_2", "0,foo,bar", "1,baz,qux"]
         expected_ascii = tm.convert_rows_list_to_csv_str(expected_rows)
 
-        df.to_csv(sys.stdout, encoding="ascii")
-        captured = capsys.readouterr()
+        with raises_if_pyarrow:
+            df.to_csv(sys.stdout, encoding="ascii", engine=engine)
+            captured = capsys.readouterr()
 
-        assert captured.out == expected_ascii
-        assert not sys.stdout.closed
+            assert captured.out == expected_ascii
+            assert not sys.stdout.closed
 
     @pytest.mark.xfail(
         compat.is_platform_windows(),
@@ -598,8 +1015,11 @@ $1$,$2$
             "(https://docs.python.org/3/library/csv.html#csv.writer)"
         ),
     )
-    def test_to_csv_write_to_open_file(self, temp_file):
+    def test_to_csv_write_to_open_file(self, temp_file, engine):
         # GH 21696
+        # an already-open text file object is another destination the
+        # pyarrow engine cannot write to
+        raise_if_pyarrow = check_raises_if_pyarrow_binary_only(engine)
         df = DataFrame({"a": ["x", "y", "z"]})
         expected = """\
 manual header
@@ -609,23 +1029,29 @@ z
 """
         with open(temp_file, "w", encoding="utf-8") as f:
             f.write("manual header\n")
-            df.to_csv(f, header=None, index=None)
-        with open(temp_file, encoding="utf-8") as f:
-            assert f.read() == expected
+            with raise_if_pyarrow:
+                df.to_csv(f, header=None, index=None, engine=engine)
+        if engine != "pyarrow":
+            with open(temp_file, encoding="utf-8") as f:
+                assert f.read() == expected
 
-    def test_to_csv_write_to_open_file_with_newline_py3(self, temp_file):
+    def test_to_csv_write_to_open_file_with_newline_py3(self, temp_file, engine):
         # see gh-21696
         # see gh-20353
+        raise_if_pyarrow = check_raises_if_pyarrow_binary_only(engine)
         df = DataFrame({"a": ["x", "y", "z"]})
         expected_rows = ["x", "y", "z"]
         expected = "manual header\n" + tm.convert_rows_list_to_csv_str(expected_rows)
 
+        # TODO: Open in bytes mode for pyarrow
         with open(temp_file, "w", newline="", encoding="utf-8") as f:
             f.write("manual header\n")
-            df.to_csv(f, header=None, index=None)
+            with raise_if_pyarrow:
+                df.to_csv(f, header=None, index=None, engine=engine)
 
-        with open(temp_file, "rb") as f:
-            assert f.read() == bytes(expected, "utf-8")
+        if engine != "pyarrow":
+            with open(temp_file, "rb") as f:
+                assert f.read() == bytes(expected, "utf-8")
 
     @pytest.mark.parametrize("to_infer", [True, False])
     @pytest.mark.parametrize("read_infer", [True, False])
@@ -636,6 +1062,7 @@ z
         to_infer,
         compression_to_extension,
         temp_file,
+        engine,
     ):
         # see gh-15008
         compression = compression_only
@@ -646,11 +1073,11 @@ z
         read_compression = "infer" if read_infer else compression
 
         path_ext = str(temp_file) + "." + compression_to_extension[compression]
-        df.to_csv(path_ext, compression=to_compression)
+        df.to_csv(path_ext, compression=to_compression, engine=engine)
         result = pd.read_csv(path_ext, index_col=0, compression=read_compression)
         tm.assert_frame_equal(result, df)
 
-    def test_to_csv_compression_dict(self, compression_only, temp_file):
+    def test_to_csv_compression_dict(self, compression_only, temp_file, engine):
         # GH 26023
         method = compression_only
         df = DataFrame({"ABC": [1]})
@@ -660,28 +1087,30 @@ z
         }.get(method, method)
 
         path = str(temp_file) + "." + extension
-        df.to_csv(path, compression={"method": method})
+        df.to_csv(path, compression={"method": method}, engine=engine)
         read_df = pd.read_csv(path, index_col=0)
         tm.assert_frame_equal(read_df, df)
 
-    def test_to_csv_compression_dict_no_method_raises(self, temp_file):
+    def test_to_csv_compression_dict_no_method_raises(self, temp_file, engine):
         # GH 26023
         df = DataFrame({"ABC": [1]})
         compression = {"some_option": True}
         msg = "must have key 'method'"
 
         with pytest.raises(ValueError, match=msg):
-            df.to_csv(temp_file, compression=compression)
+            df.to_csv(temp_file, compression=compression, engine=engine)
 
     @pytest.mark.parametrize("compression", ["zip", "infer"])
     @pytest.mark.parametrize("archive_name", ["test_to_csv.csv", "test_to_csv.zip"])
-    def test_to_csv_zip_arguments(self, compression, archive_name, temp_file):
+    def test_to_csv_zip_arguments(self, compression, archive_name, temp_file, engine):
         # GH 26023
         df = DataFrame({"ABC": [1]})
 
         path = str(temp_file) + ".zip"
         df.to_csv(
-            path, compression={"method": compression, "archive_name": archive_name}
+            path,
+            compression={"method": compression, "archive_name": archive_name},
+            engine=engine,
         )
         with ZipFile(path) as zp:
             assert len(zp.filelist) == 1
@@ -698,68 +1127,83 @@ z
             ("archive.zip", "archive"),
         ],
     )
-    def test_to_csv_zip_infer_name(self, tmp_path, filename, expected_arcname):
+    def test_to_csv_zip_infer_name(self, tmp_path, filename, expected_arcname, engine):
         # GH 39465
         df = DataFrame({"ABC": [1]})
         path = tmp_path / filename
-        df.to_csv(path, compression="zip")
+        df.to_csv(path, compression="zip", engine=engine)
         with ZipFile(path) as zp:
             assert len(zp.filelist) == 1
             archived_file = zp.filelist[0].filename
             assert archived_file == expected_arcname
 
     @pytest.mark.parametrize("df_new_type", ["Int64"])
-    def test_to_csv_na_rep_long_string(self, df_new_type):
+    def test_to_csv_na_rep_long_string(self, df_new_type, engine):
         # see gh-25099
+        raises_if_pyarrow = check_raises_if_pyarrow("na_rep", engine)
         df = DataFrame({"c": [pd.NA] * 3})
         df = df.astype(df_new_type)
         expected_rows = ["c", "mynull", "mynull", "mynull"]
         expected = tm.convert_rows_list_to_csv_str(expected_rows)
 
-        result = df.to_csv(index=False, na_rep="mynull", encoding="ascii")
+        with raises_if_pyarrow:
+            result = df.to_csv(
+                index=False, na_rep="mynull", encoding="ascii", engine=engine
+            )
 
-        assert expected == result
+            assert expected == result
 
-    def test_to_csv_timedelta_precision(self):
+    def test_to_csv_timedelta_precision(self, engine):
         # GH 6783
+        # writing to a StringIO (a text buffer) is itself incompatible with
+        # the pyarrow engine, regardless of the timedelta64 dtype
+        raises_if_pyarrow = check_raises_if_pyarrow_binary_only(engine)
         s = pd.Series([1, 1]).astype("timedelta64[ns]")
         buf = io.StringIO()
-        s.to_csv(buf)
-        result = buf.getvalue()
-        expected_rows = [
-            ",0",
-            "0,0 days 00:00:00.000000001",
-            "1,0 days 00:00:00.000000001",
-        ]
-        expected = tm.convert_rows_list_to_csv_str(expected_rows)
-        assert result == expected
+        with raises_if_pyarrow:
+            s.to_csv(buf, engine=engine)
+            result = buf.getvalue()
+            expected_rows = [
+                ",0",
+                "0,0 days 00:00:00.000000001",
+                "1,0 days 00:00:00.000000001",
+            ]
+            expected = tm.convert_rows_list_to_csv_str(expected_rows)
+            assert result == expected
 
-    def test_na_rep_truncated(self):
+    def test_na_rep_truncated(self, engine):
         # https://github.com/pandas-dev/pandas/issues/31447
-        result = pd.Series(range(8, 12)).to_csv(na_rep="-")
-        expected = tm.convert_rows_list_to_csv_str([",0", "0,8", "1,9", "2,10", "3,11"])
-        assert result == expected
+        raises_if_pyarrow = check_raises_if_pyarrow("na_rep", engine)
+        with raises_if_pyarrow:
+            result = pd.Series(range(8, 12)).to_csv(na_rep="-", engine=engine)
+            expected = tm.convert_rows_list_to_csv_str(
+                [",0", "0,8", "1,9", "2,10", "3,11"]
+            )
+            assert result == expected
 
-        result = pd.Series([True, False]).to_csv(na_rep="nan")
-        expected = tm.convert_rows_list_to_csv_str([",0", "0,True", "1,False"])
-        assert result == expected
+        with raises_if_pyarrow:
+            result = pd.Series([True, False]).to_csv(na_rep="nan", engine=engine)
+            expected = tm.convert_rows_list_to_csv_str([",0", "0,True", "1,False"])
+            assert result == expected
 
-        result = pd.Series([1.1, 2.2]).to_csv(na_rep=".")
-        expected = tm.convert_rows_list_to_csv_str([",0", "0,1.1", "1,2.2"])
-        assert result == expected
+        with raises_if_pyarrow:
+            result = pd.Series([1.1, 2.2]).to_csv(na_rep=".", engine=engine)
+            expected = tm.convert_rows_list_to_csv_str([",0", "0,1.1", "1,2.2"])
+            assert result == expected
 
     @pytest.mark.parametrize("errors", ["surrogatepass", "ignore", "replace"])
-    def test_to_csv_errors(self, errors, temp_file):
+    def test_to_csv_errors(self, errors, temp_file, engine):
         # GH 22610
+        raises_if_pyarrow = check_raises_if_pyarrow("errors", engine)
         data = ["\ud800foo"]
-        ser = pd.Series(data, index=Index(data, dtype=object), dtype=object)
-
-        ser.to_csv(temp_file, errors=errors)
+        with raises_if_pyarrow:
+            ser = pd.Series(data, index=Index(data, dtype=object), dtype=object)
+            ser.to_csv(temp_file, errors=errors, engine=engine)
         # No use in reading back the data as it is not the same anymore
         # due to the error handling
 
     @pytest.mark.parametrize("mode", ["wb", "w"])
-    def test_to_csv_binary_handle(self, mode, temp_file):
+    def test_to_csv_binary_handle(self, mode, temp_file, engine):
         """
         Binary file objects should work (if 'mode' contains a 'b') or even without
         it in most cases.
@@ -773,48 +1217,68 @@ z
         )
 
         with open(temp_file, mode="w+b") as handle:
-            df.to_csv(handle, mode=mode)
-        tm.assert_frame_equal(df, pd.read_csv(temp_file, index_col=0))
+            if mode == "w":
+                raises_if_pyarrow = check_raises_if_pyarrow_binary_only(engine)
+            else:
+                raises_if_pyarrow = contextlib.nullcontext()
+            with raises_if_pyarrow:
+                df.to_csv(handle, mode=mode, engine=engine)
+        if not engine == "pyarrow" and mode == "w":
+            tm.assert_frame_equal(df, pd.read_csv(temp_file, index_col=0))
 
     @pytest.mark.parametrize("mode", ["wb", "w"])
-    def test_to_csv_encoding_binary_handle(self, mode, temp_file):
+    def test_to_csv_encoding_binary_handle(self, mode, temp_file, engine, request):
         """
         Binary file objects should honor a specified encoding.
 
         GH 23854 and GH 13068 with binary handles
         """
+
+        if mode == "w" and engine == "pyarrow":
+            mark = pytest.mark.xfail(
+                reason="pyarrow doesn't support non-binary handles."
+            )
+            request.applymarker(mark)
+
+        raises_if_pyarrow = check_raises_if_pyarrow("encoding", engine)
         # example from GH 23854
         content = "a, b, 🐟".encode("utf-8-sig")
         buffer = io.BytesIO(content)
         df = pd.read_csv(buffer, encoding="utf-8-sig")
 
         buffer = io.BytesIO()
-        df.to_csv(buffer, mode=mode, encoding="utf-8-sig", index=False)
-        buffer.seek(0)  # tests whether file handle wasn't closed
-        assert buffer.getvalue().startswith(content)
+        with raises_if_pyarrow:
+            df.to_csv(
+                buffer, mode=mode, encoding="utf-8-sig", index=False, engine=engine
+            )
+            buffer.seek(0)  # tests whether file handle wasn't closed
+            assert buffer.getvalue().startswith(content)
 
         # example from GH 13068
         with open(temp_file, "w+b") as handle:
-            DataFrame().to_csv(handle, mode=mode, encoding="utf-8-sig")
+            with raises_if_pyarrow:
+                DataFrame().to_csv(
+                    handle, mode=mode, encoding="utf-8-sig", engine=engine
+                )
 
-            handle.seek(0)
-            assert handle.read().startswith(b'\xef\xbb\xbf""')
+                handle.seek(0)
+                assert handle.read().startswith(b'\xef\xbb\xbf""')
 
 
-def test_to_csv_iterative_compression_name(compression, temp_file):
+def test_to_csv_iterative_compression_name(compression, temp_file, engine):
     # GH 38714
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
         columns=Index(list("ABCD")),
         index=Index([f"i-{i}" for i in range(30)]),
     )
-    df.to_csv(temp_file, compression=compression, chunksize=1)
+    df.to_csv(temp_file, compression=compression, chunksize=1, engine=engine)
     tm.assert_frame_equal(
         pd.read_csv(temp_file, compression=compression, index_col=0), df
     )
 
 
-def test_to_csv_iterative_compression_buffer(compression):
+def test_to_csv_iterative_compression_buffer(compression, engine):
     # GH 38714
     df = DataFrame(
         1.1 * np.arange(120).reshape((30, 4)),
@@ -822,7 +1286,7 @@ def test_to_csv_iterative_compression_buffer(compression):
         index=Index([f"i-{i}" for i in range(30)]),
     )
     with io.BytesIO() as buffer:
-        df.to_csv(buffer, compression=compression, chunksize=1)
+        df.to_csv(buffer, compression=compression, chunksize=1, engine=engine)
         buffer.seek(0)
         tm.assert_frame_equal(
             pd.read_csv(buffer, compression=compression, index_col=0), df
@@ -899,8 +1363,11 @@ def test_callable_float_format_compatibility():
 
 
 def test_no_float_format():
+    # engine="python": float_format=None (the default) does not disqualify
+    # the pyarrow engine, but this test is about float_format handling, not
+    # engine choice
     df = DataFrame({"A": [1.23, 4.56]})
-    result = df.to_csv(float_format=None, lineterminator="\n")
+    result = df.to_csv(float_format=None, lineterminator="\n", engine="python")
     expected = ",A\n0,1.23\n1,4.56\n"
     assert result == expected
 
@@ -970,8 +1437,9 @@ def test_new_style_with_template():
 def test_to_csv_null_byte_no_escapechar():
     # GH#47871 a null byte does not require escapechar to be set
     # (was a CPython _csv regression on 3.10, fixed in 3.11)
+    # engine="python": this specifically exercises the python csv module
     df = DataFrame({"A": ["\x00"]})
-    result = df.to_csv(index=False, lineterminator="\n")
+    result = df.to_csv(index=False, lineterminator="\n", engine="python")
     assert result == "A\n\x00\n"
 
 
@@ -1003,8 +1471,11 @@ def test_to_csv_categorical_tz_timestamp_with_na_rep():
     assert r"\N" in result_na
 
 
-def test_to_csv_datetime_tz_consistent_format():
+def test_to_csv_datetime_tz_consistent_format(engine):
     # GH#62111
+    # timezone-aware datetime64 is rendered differently under pyarrow: a
+    # "Z" suffix instead of "+00:00", and always at microsecond precision
+    # rather than dropping trailing zeros
     df = DataFrame(
         {
             "timestamp": [
@@ -1013,12 +1484,20 @@ def test_to_csv_datetime_tz_consistent_format():
             ]
         }
     )
-    result = df.to_csv(index=False)
-    expected_rows = [
-        "timestamp",
-        "2025-08-14 12:34:56.000000+00:00",
-        "2025-08-14 12:34:56.000001+00:00",
-    ]
+    with check_warns_if_pyarrow_renders_differently(engine):
+        result = df.to_csv(index=False, engine=engine)
+    if engine == "pyarrow":
+        expected_rows = [
+            '"timestamp"',
+            "2025-08-14 12:34:56.000000Z",
+            "2025-08-14 12:34:56.000001Z",
+        ]
+    else:
+        expected_rows = [
+            "timestamp",
+            "2025-08-14 12:34:56.000000+00:00",
+            "2025-08-14 12:34:56.000001+00:00",
+        ]
     expected = tm.convert_rows_list_to_csv_str(expected_rows)
     assert result == expected
 
@@ -1030,11 +1509,19 @@ def test_to_csv_datetime_tz_consistent_format():
             ]
         }
     )
-    result = df.to_csv(index=False)
-    expected_rows = [
-        "timestamp",
-        "2025-08-14 12:34:56+00:00",
-        "2025-08-14 12:34:57+00:00",
-    ]
+    with check_warns_if_pyarrow_renders_differently(engine):
+        result = df.to_csv(index=False, engine=engine)
+    if engine == "pyarrow":
+        expected_rows = [
+            '"timestamp"',
+            "2025-08-14 12:34:56.000000Z",
+            "2025-08-14 12:34:57.000000Z",
+        ]
+    else:
+        expected_rows = [
+            "timestamp",
+            "2025-08-14 12:34:56+00:00",
+            "2025-08-14 12:34:57+00:00",
+        ]
     expected = tm.convert_rows_list_to_csv_str(expected_rows)
     assert result == expected

--- a/pandas/tests/io/parser/test_parse_dates.py
+++ b/pandas/tests/io/parser/test_parse_dates.py
@@ -97,7 +97,10 @@ def test_nat_parse(all_parsers, temp_file):
     df.iloc[3:6, :] = np.nan
 
     path = temp_file
-    df.to_csv(path)
+    # engine="python": this is about read_csv's NaT parsing, not to_csv's
+    # write engine, and the pyarrow write engine's datetime rendering
+    # would change the resolution read.csv infers for column "B"
+    df.to_csv(path, engine="python")
 
     result = parser.read_csv(path, index_col=0, parse_dates=["B"])
     tm.assert_frame_equal(result, df)

--- a/pandas/tests/io/test_clipboard.py
+++ b/pandas/tests/io/test_clipboard.py
@@ -228,7 +228,10 @@ class TestClipboard:
     def test_clipboard_copy_tabs_default(self, sep, excel, df, clipboard):
         kwargs = build_kwargs(sep, excel)
         df.to_clipboard(**kwargs)
-        assert clipboard.text() == df.to_csv(sep="\t")
+        # engine="python": to_clipboard always writes through a text
+        # buffer internally, which the pyarrow engine cannot use, so its
+        # output always matches the python engine's rendering
+        assert clipboard.text() == df.to_csv(sep="\t", engine="python")
 
     # Tests reading of white space separated tables
     @pytest.mark.parametrize("sep", [None, "default"])

--- a/pandas/tests/io/test_compression.py
+++ b/pandas/tests/io/test_compression.py
@@ -425,10 +425,13 @@ def test_ambiguous_archive_closes_fsspec_handle(monkeypatch):
 
 def test_tar_gz_to_different_filename(temp_file):
     file = temp_file.parent / "archive.foo"
+    # engine="python": exercises the exact unquoted default rendering
     pd.DataFrame(
         [["1", "2"]],
         columns=["foo", "bar"],
-    ).to_csv(file, compression={"method": "tar", "mode": "w:gz"}, index=False)
+    ).to_csv(
+        file, compression={"method": "tar", "mode": "w:gz"}, index=False, engine="python"
+    )
     with gzip.open(file) as uncompressed:
         with tarfile.TarFile(fileobj=uncompressed) as archive:
             members = archive.getmembers()

--- a/pandas/tests/io/xml/test_to_xml.py
+++ b/pandas/tests/io/xml/test_to_xml.py
@@ -1170,7 +1170,9 @@ def test_style_to_csv(geom_df):
     </xsl:template>
 </xsl:stylesheet>"""
 
-    out_csv = geom_df.to_csv(lineterminator="\n")
+    # engine="python": this compares to_csv's exact text against to_xml's,
+    # which the pyarrow write engine's header quoting would break
+    out_csv = geom_df.to_csv(lineterminator="\n", engine="python")
 
     if out_csv is not None:
         out_csv = out_csv.strip()


### PR DESCRIPTION
Adds an `engine` parameter ("python", "pyarrow", "auto") to to_csv/Series.to_csv. "auto", the new default, uses the pyarrow writer when it's installed and the data/options are fully supported, and transparently falls back to "python" otherwise -- never changing the values written or their round-trip fidelity through read_csv, only formatting for the calls where pyarrow ends up being used.

"auto" avoids pyarrow for: MultiIndex columns; rows that are entirely missing values (would collapse to a blank line that read_csv silently drops); and data pyarrow's CSV writer can't represent (Period, Interval, complex, Sparse, object columns of list/dict values, etc). bool, timedelta64, timezone-aware datetime64, and whole-number-float columns render differently under pyarrow (and the float case can change the dtype read_csv infers on round-trip), so "auto" skips pyarrow for those too, while explicit engine="pyarrow" proceeds anyway with a warning.

Rewrites pandas/tests/io/formats/test_to_csv.py to exercise all three engines, asserting the actual (possibly different) rendering per engine. Also fixes pre-existing tests elsewhere that hard-coded python-engine-only to_csv output, now that "auto" is the default.

- [x] closes #53618 (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

This replaces #64342.