### PR TITLE
BUG: fix IndexError when usecols selects a column not at position 0

### DIFF
--- a/pandas/io/parsers/c_parser_wrapper.py
+++ b/pandas/io/parsers/c_parser_wrapper.py
@@ -437,6 +437,12 @@ def _concatenate_chunks(
     names = list(chunks[0].keys())
     warning_columns = []
 
+    # GH-67375: ``name`` is the raw column *position* in the table (e.g. 50),
+    # but ``column_names`` has already been filtered by ``usecols`` and so
+    # cannot be indexed by that position directly. ``column_names`` is kept in
+    # ascending position order, so it aligns 1:1 with the sorted chunk keys.
+    names_to_columns = dict(zip(sorted(names), column_names))
+
     result: dict = {}
     for name in names:
         arrs = [chunk.pop(name) for chunk in chunks]
@@ -464,7 +470,7 @@ def _concatenate_chunks(
         else:
             result[name] = concat_compat(arrs)
             if len(non_cat_dtypes) > 1 and result[name].dtype == np.dtype(object):
-                warning_columns.append(column_names[name])
+                warning_columns.append(names_to_columns[name])
 
     if warning_columns and warn_mixed:
         warning_names = ", ".join(

--- a/pandas/tests/io/parser/test_concatenate_chunks.py
+++ b/pandas/tests/io/parser/test_concatenate_chunks.py
@@ -36,3 +36,20 @@ def test_concatenate_chunks_pyarrow_strings():
         [np.array([1.5, 2.5], dtype=object), np.array(["a", "b"])]
     )
     tm.assert_numpy_array_equal(result[0], expected)
+
+
+def test_concatenate_chunks_usecols_mixed_dtype_nonzero_pos():
+    # GH#67375 - usecols selecting a column not at position 0. Chunk keys are
+    # raw column *positions*; column_names has already been filtered by usecols
+    # so it must be mapped position->name, not indexed by position.
+    chunks = [
+        {50: np.array([1.5, 2.5])},
+        {50: np.array(["a", "b"])},  # second chunk infers object -> mixed types
+    ]
+    with tm.assert_produces_warning(
+        DtypeWarning, match=r"Columns \(0: Overall_Judgment\) have mixed types"
+    ):
+        result = _concatenate_chunks(chunks, ["Overall_Judgment"])
+    tm.assert_numpy_array_equal(
+        result[50], np.array([1.5, 2.5, "a", "b"], dtype=object)
+    )


### PR DESCRIPTION
Closes GH#67375.

## What
`read_csv(usecols=...)` with `low_memory=True` raised `IndexError` when a
`usecols`-selected column was at a position other than 0 and different chunks
inferred mixed dtypes for that column.

## Root cause
In `_concatenate_chunks`, chunk keys are raw column *positions* (e.g. 50), but
`column_names` is already filtered by `usecols`, so `column_names[name]`
indexed by the raw position and went out of range. It only worked when the
column happened to be at position 0.

## Fix
Build a position->name mapping from the sorted chunk keys (which align with
the ascending-position order of `column_names`) and look up by position
instead of positional index.

## Test
Adds `test_concatenate_chunks_usecols_mixed_dtype_nonzero_pos` in
`test_concatenate_chunks.py`. It fails before the fix (IndexError) and passes
after.

## AI assistance
I used an AI assistant to reproduce the bug, locate the cause, and draft the
fix and test; I reviewed all changed lines and verified the behaviour locally.