### PR TITLE
CI: fix failures from the clang 23 and gcsfs dependency bumps

### DIFF
--- a/pandas/_libs/algos.pyx
+++ b/pandas/_libs/algos.pyx
@@ -59,7 +59,6 @@ from pandas._libs.missing cimport (
 from pandas._libs.util cimport get_nat
 
 cdef:
-    float64_t FP_ERR = 1e-13
     float64_t NaN = <float64_t>np.nan
     int64_t NPY_NAT = get_nat()
 

--- a/pandas/_libs/window/aggregations.pyx
+++ b/pandas/_libs/window/aggregations.pyx
@@ -17,7 +17,6 @@ import numpy as np
 
 cimport numpy as cnp
 from numpy cimport (
-    float32_t,
     float64_t,
     int64_t,
     ndarray,
@@ -55,12 +54,6 @@ cdef extern from "pandas/skiplist.h":
     int skiplist_min_rank(skiplist_t*, double) nogil
 
 cdef:
-    float32_t MINfloat32 = -np.inf
-    float64_t MINfloat64 = -np.inf
-
-    float32_t MAXfloat32 = np.inf
-    float64_t MAXfloat64 = np.inf
-
     float64_t NaN = <float64_t>np.nan
     float64_t EpsF64 = np.finfo(np.float64).eps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -472,6 +472,8 @@ filterwarnings = [
   "ignore:Couldn't import C tracer",
   # NumPy 2.5 DeprecationWarning in fastparquet
   "ignore:The 'generic' unit for NumPy timedelta is deprecated:DeprecationWarning:fastparquet",
+  # Raised at import time by google-auth, pulled in by gcsfs
+  "ignore:grpcio < 1.83.0 does not support Post-Quantum Cryptography:FutureWarning",
 ]
 junit_family = "xunit2"
 


### PR DESCRIPTION
Splits out the two failure modes on the `pixi.lock` bump in GH-67374 that are independent of the lock file itself, so that PR only has to carry lock-specific changes.

### clang 22 → 23: `-Wunused-but-set-global`

clang 23 extends `-Wunused-but-set-global` to file-scope variables, and the sanitizers build passes `--werror`:

```
algos.pyx.c:4067:33: error: variable '__pyx_v_6pandas_5_libs_5algos_FP_ERR'
    set but not used [-Werror,-Wunused-but-set-global]
```

`FP_ERR` is the only reference in the tree. `MINfloat32`/`MINfloat64`/`MAXfloat32`/`MAXfloat64` in `window/aggregations.pyx` are dead the same way and would be the next hit, so they go too (along with the now-unused `float32_t` cimport).

### gcsfs 2025.10.0 → 2026.7.0: import-time `FutureWarning`

New `gcsfs` imports `google.cloud.storage` → `google.auth.transport.grpc`, which warns at import time:

```
FutureWarning: grpcio < 1.83.0 does not support Post-Quantum Cryptography (PQC) ...
```

`pandas/tests/io/test_gcs.py` imports `gcsfs` at module scope via `@td.skip_if_installed("gcsfs")`, so `filterwarnings = ["error", ...]` turns this into a collection error — which is what fails all 26 jobs in the test matrix on GH-67374 (the multi-cpu run otherwise reports 239449 passed).

The added filter is inert until the lock is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQVUarHwThnBySGadq3y5C