### PR TITLE
TST: qualify MultiIndex/Series/DataFrame in test_unstack_sort_false_nan_series

### DIFF
--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1443,15 +1443,15 @@ def test_unstack_sort_false_nan(levels2, expected_columns):
 )
 def test_unstack_sort_false_nan_series(levels2):
     # GH#66672
-    index = MultiIndex.from_product([["r"], levels2], names=["x", "z"])
-    ser = Series([1.0, 2.0, 3.0], index=index)
+    index = pd.MultiIndex.from_product([["r"], levels2], names=["x", "z"])
+    ser = pd.Series([1.0, 2.0, 3.0], index=index)
 
     result = ser.unstack(level="z", sort=False)
 
-    expected = DataFrame(
+    expected = pd.DataFrame(
         [[1.0, 2.0, 3.0]],
-        index=Index(["r"], name="x"),
-        columns=Index(levels2, name="z"),
+        index=pd.Index(["r"], name="x"),
+        columns=pd.Index(levels2, name="z"),
     )
     tm.assert_frame_equal(result, expected)
 


### PR DESCRIPTION
`test_unstack_sort_false_nan_series` was skipped by the namespace conversion in #67276 — it still uses bare `MultiIndex`/`Series`/`DataFrame`/`Index`, but that PR removed the `from pandas import ...` line, so it now raises `NameError: name 'MultiIndex' is not defined` and `main` is red on it across all platforms. Qualify the four names with `pd.` to match the rest of the file.

- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] If I used AI to develop this pull request, I prompted it to follow `AGENTS.md`.
