### PR TITLE
TST: fix undefined names in tests after pandas-namespace conversion

### DIFF
--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1443,15 +1443,15 @@ def test_unstack_sort_false_nan(levels2, expected_columns):
 )
 def test_unstack_sort_false_nan_series(levels2):
     # GH#66672
-    index = MultiIndex.from_product([["r"], levels2], names=["x", "z"])
-    ser = Series([1.0, 2.0, 3.0], index=index)
+    index = pd.MultiIndex.from_product([["r"], levels2], names=["x", "z"])
+    ser = pd.Series([1.0, 2.0, 3.0], index=index)
 
     result = ser.unstack(level="z", sort=False)
 
-    expected = DataFrame(
+    expected = pd.DataFrame(
         [[1.0, 2.0, 3.0]],
-        index=Index(["r"], name="x"),
-        columns=Index(levels2, name="z"),
+        index=pd.Index(["r"], name="x"),
+        columns=pd.Index(levels2, name="z"),
     )
     tm.assert_frame_equal(result, expected)
 

--- a/pandas/tests/io/formats/test_ipython_compat.py
+++ b/pandas/tests/io/formats/test_ipython_compat.py
@@ -26,7 +26,7 @@ class TestTableSchemaRepr:
         # the latex repr goes through Styler, which needs jinja2
         pytest.importorskip("jinja2")
         ipython = ip.instance(config=ip.config)
-        df = DataFrame({"A": [1, 2]})
+        df = pd.DataFrame({"A": [1, 2]})
 
         with cf.option_context(
             "display.html.table_schema", True, "styler.render.repr", "latex"


### PR DESCRIPTION
Two tests referenced bare pandas names that are not imported in their modules, so they fail at call time with `NameError`:

- `test_unstack_sort_false_nan_series` (added in GH-66719) uses `MultiIndex`, `Series`, `DataFrame` and `Index`. The `pd.`-namespace conversion (GH-67276) landed alongside it, so the two merged into a broken state.
- `test_publishes_latex` uses a bare `DataFrame`. This was latent until GH-67294 made the ipython-gated tests actually run in CI.

`ruff check --select F821 pandas/` is clean repo-wide after this.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the undefined names and applied the `pd.` qualification.