### PR TITLE
BUG: IntervalDtype.__from_arrow__ ignores struct validity bitmap

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -633,6 +633,7 @@ Interval
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors allowing unsupported ``object`` dtype on the right endpoint, causing ``dtype.subtype`` to disagree with ``right.dtype`` (:issue:`66518`)
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors unnecessarily upcasting sub-64-bit numeric dtypes (e.g. ``float32``, ``int32``) to 64-bit (:issue:`45412`)
 - Bug in :func:`cut` and other operations building an :class:`IntervalIndex` engine raising ``TypeError`` on 32-bit platforms when there were more than 100 intervals (:issue:`44075`, :issue:`23440`)
+- Bug in :meth:`IntervalDtype.__from_arrow__` returning incorrect (non-NA) intervals for null struct entries because the parent struct's validity bitmap was not applied to the child ``left``/``right`` arrays (:issue:`67754`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1473,6 +1473,7 @@ class IntervalDtype(PandasExtensionDtype):
         Construct IntervalArray from pyarrow Array/ChunkedArray.
         """
         import pyarrow
+        import pyarrow.compute as pc
 
         from pandas.core.arrays import IntervalArray
 
@@ -1485,8 +1486,22 @@ class IntervalDtype(PandasExtensionDtype):
         for arr in chunks:
             if isinstance(arr, pyarrow.ExtensionArray):
                 arr = arr.storage
-            left = np.asarray(arr.field("left"), dtype=self.subtype)
-            right = np.asarray(arr.field("right"), dtype=self.subtype)
+            # Struct.field() does not apply the parent struct's validity
+            # bitmap to the child arrays, so a null struct entry would
+            # otherwise read back as whatever the children happen to hold
+            # instead of NA (GH#67754). Mask the children with the
+            # struct-level validity before converting to numpy.
+            is_valid = arr.is_valid()
+            left_field = arr.field("left")
+            right_field = arr.field("right")
+            left_arr = pc.if_else(
+                is_valid, left_field, pyarrow.scalar(None, type=left_field.type)
+            )
+            right_arr = pc.if_else(
+                is_valid, right_field, pyarrow.scalar(None, type=right_field.type)
+            )
+            left = np.asarray(left_arr, dtype=self.subtype)
+            right = np.asarray(right_arr, dtype=self.subtype)
             iarr = IntervalArray.from_arrays(left, right, closed=self.closed)
             results.append(iarr)
 

--- a/pandas/tests/arrays/interval/test_interval_pyarrow.py
+++ b/pandas/tests/arrays/interval/test_interval_pyarrow.py
@@ -152,3 +152,27 @@ def test_from_arrow_from_raw_struct_array():
 
     result = dtype.__from_arrow__(pa.chunked_array([arr]))
     tm.assert_extension_array_equal(result, expected)
+
+
+def test_from_arrow_struct_array_respects_parent_validity():
+    # GH#67754 pyarrow's StructArray.field() does not merge the parent
+    # struct's validity bitmap into the child arrays, so a null struct
+    # entry must be masked explicitly or it reads back using whatever
+    # (non-NA) values happen to be stored in the children instead of NA.
+    pa = pytest.importorskip("pyarrow")
+
+    struct_type = pa.struct([("left", pa.float64()), ("right", pa.float64())])
+    arr = pa.array(
+        [{"left": 0.0, "right": 1.0}, None], type=struct_type
+    )
+    dtype = pd.IntervalDtype(np.dtype("float64"), closed="right")
+
+    result = dtype.__from_arrow__(arr)
+    expected = IntervalArray.from_arrays(
+        np.array([0.0, np.nan]), np.array([1.0, np.nan]), closed="right"
+    )
+    tm.assert_extension_array_equal(result, expected)
+    assert result.isna().tolist() == [False, True]
+
+    result = dtype.__from_arrow__(pa.chunked_array([arr]))
+    tm.assert_extension_array_equal(result, expected)


### PR DESCRIPTION
closes #67754

`IntervalDtype.__from_arrow__` ignores the parent struct validity bitmap when pulling out `left`/`right` children — null struct entries come back as `(0.0, 0.0]` instead of `NA`.

the problem is `pyarrow.StructArray.field()` doesnt propagate struct-level validity down to child arrays. fix applies the struct validity mask with `pyarrow.compute.if_else` before converting to numpy.

added a test that checks both plain and chunked arrow arrays — makes sure null struct entries show up as NA correctly. all 10 existing interval pyarrow tests still pass.