### PR TITLE
TST: remove redundant length-zero string test (GH#40624)

### DIFF
--- a/pandas/tests/arithmetic/test_string.py
+++ b/pandas/tests/arithmetic/test_string.py
@@ -545,20 +545,10 @@ def test_add_length_zero_keeps_dtype(any_string_dtype):
 
 def test_add_length_zero_mixed_storage(any_string_dtype, any_string_dtype2):
     # GH#40624 the length-zero result should keep the dtype the full-length
-    #  operation resolves to rather than raising
+    #  operation resolves to rather than raising.  The object-dtype
+    #  combinations cover the operand boxing to the pyarrow null type.
     left = pd.Series(["a", "b"], dtype=any_string_dtype)
     right = pd.Series(["c", "d"], dtype=any_string_dtype2)
 
     result = left.iloc[:0] + right.iloc[:0]
     tm.assert_series_equal(result, (left + right).iloc[:0])
-
-
-@td.skip_if_no("pyarrow")
-def test_add_length_zero_object_ndarray():
-    # GH#40624 a length-zero object-dtype ndarray boxes to the pyarrow null
-    #  type, which has no binary_join kernel
-    # dtype is specified explicitly so the test exercises the pyarrow-backed
-    #  path regardless of the future.infer_string setting
-    arr = pd.array(["a", "b"], dtype=pd.StringDtype("pyarrow"))
-    result = arr[:0] + np.array([], dtype=object)
-    tm.assert_extension_array_equal(result, arr[:0])


### PR DESCRIPTION
Follow-up to GH-67291, addressing @jorisvandenbossche's review comment: `test_add_length_zero_object_ndarray` is already covered by the test above it.

Confirmed by reverting just the `arrow/array.py` null-cast hunk from GH-67291 — `test_add_length_zero_mixed_storage` fails in five parametrizations on its own:

```
FAILED test_add_length_zero_mixed_storage[string=object-string=string[pyarrow]]
FAILED test_add_length_zero_mixed_storage[string=object-string=str[pyarrow]]
FAILED test_add_length_zero_mixed_storage[string=string[python]-string=str[pyarrow]]
FAILED test_add_length_zero_mixed_storage[string=string[pyarrow]-string=object]
FAILED test_add_length_zero_mixed_storage[string=str[pyarrow]-string=object]
```

`any_string_dtype` includes `np.dtype("object")`, so those combinations box a length-zero operand to the pyarrow null type — the same branch. The Series operand unwraps to the same object ndarray before `_evaluate_op_method` sees it, so the raw-ndarray framing wasn't a distinct path. `_check_length_zero` in `pandas/tests/extension/base/ops.py` catches the same regression independently (`test_string.py::TestStringArray::test_arith_series_with_array[__add__-string=string[python]]`).

Added a line to the remaining test's comment so the object-dtype parametrizations aren't dropped without noticing what they cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5w4PX5MUSMkbKFpJhoZ34