### PR TITLE
DOC: fix misplaced copy deprecation notice in Series.set_axis

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -5684,14 +5684,6 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         """
         Assign desired index to given axis.
 
-        .. deprecated:: 3.0.0
-            This keyword is ignored and will be removed in pandas 4.0. Since
-            pandas 3.0, this method always returns a new object using a lazy
-            copy mechanism that defers copies until necessary
-            (Copy-on-Write). See the `user guide on Copy-on-Write
-            <https://pandas.pydata.org/docs/dev/user_guide/copy_on_write.html>`__
-            for more details.
-
         Indexes for row labels can be changed by assigning a list-like or Index.
 
         Parameters
@@ -5704,6 +5696,15 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         copy : bool, default False
             This keyword is now ignored; changing its value will have no
             impact on the method.
+
+            .. deprecated:: 3.0.0
+
+                This keyword is ignored and will be removed in pandas 4.0. Since
+                pandas 3.0, this method always returns a new object using a lazy
+                copy mechanism that defers copies until necessary
+                (Copy-on-Write). See the `user guide on Copy-on-Write
+                <https://pandas.pydata.org/docs/dev/user_guide/copy_on_write.html>`__
+                for more details.
 
         Returns
         -------


### PR DESCRIPTION
- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (n/a — no new arguments/methods)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature. (n/a — docstring-only formatting fix, no behavior change; following precedent of e.g. #64118)
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

## Description

Small documentation-only fix. No behavior change.

The `.. deprecated:: 3.0.0` notice for the `copy` keyword in `[Series.set_axis](https://pandas.pydata.org/docs/reference/api/pandas.Series.set_axis.html)` was placed at the top of the docstring body, before the `Parameters` section, rather than nested under the `copy` parameter it describes. This corrects it to match the convention used elsewhere in pandas, e.g. `[NDFrame.set_axis](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.set_axis.html)` in `generic.py`.

AI use: Claude Sonnet 5 (Claude Code) was used to locate the misplaced docstring block, compare it against the correctly-formatted convention in `generic.py`'s `set_axis`, apply the fix, and verify it with `ruff check`/`ruff format --diff`. I reviewed the resulting diff line by line before pushing.
