### PR TITLE
BUG: allow timezone-aware subtypes in IntervalArray arrow conversion

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -633,6 +633,7 @@ Interval
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors allowing unsupported ``object`` dtype on the right endpoint, causing ``dtype.subtype`` to disagree with ``right.dtype`` (:issue:`66518`)
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors unnecessarily upcasting sub-64-bit numeric dtypes (e.g. ``float32``, ``int32``) to 64-bit (:issue:`45412`)
 - Bug in :func:`cut` and other operations building an :class:`IntervalIndex` engine raising ``TypeError`` on 32-bit platforms when there were more than 100 intervals (:issue:`44075`, :issue:`23440`)
+- Bug in :meth:`DataFrame.to_parquet` and conversion to pyarrow raising ``TypeError`` for :class:`IntervalDtype` with a timezone-aware subtype, and such columns not round-tripping back to the same dtype (:issue:`67753`)
 
 Indexing
 ^^^^^^^^

--- a/pandas/core/arrays/arrow/extension_types.py
+++ b/pandas/core/arrays/arrow/extension_types.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import pyarrow
 
 from pandas.core.dtypes.dtypes import (
+    DatetimeTZDtype,
     IntervalDtype,
     PeriodDtype,
 )
@@ -110,7 +111,16 @@ class ArrowIntervalType(pyarrow.ExtensionType):
         return hash((str(self), str(self.subtype), self.closed))
 
     def to_pandas_dtype(self) -> IntervalDtype:
-        return IntervalDtype(self.subtype.to_pandas_dtype(), self.closed)
+        subtype = self.subtype
+        if pyarrow.types.is_timestamp(subtype) and subtype.tz is not None:
+            # Resolve the zone through pandas rather than pyarrow, so that the
+            # tzinfo object matches the one pandas builds for the same zone name
+            # elsewhere. pyarrow may hand back a pytz zone where pandas uses
+            # zoneinfo, which compares unequal despite naming the same zone.
+            pandas_subtype: object = DatetimeTZDtype(unit=subtype.unit, tz=subtype.tz)
+        else:
+            pandas_subtype = subtype.to_pandas_dtype()
+        return IntervalDtype(pandas_subtype, self.closed)
 
 
 # register the type with a dummy instance

--- a/pandas/core/arrays/arrow/extension_types.py
+++ b/pandas/core/arrays/arrow/extension_types.py
@@ -85,7 +85,11 @@ class ArrowIntervalType(pyarrow.ExtensionType):
     @classmethod
     def __arrow_ext_deserialize__(cls, storage_type, serialized) -> ArrowIntervalType:
         metadata = json.loads(serialized.decode())
-        subtype = pyarrow.type_for_alias(metadata["subtype"])
+        # Take the subtype from the storage type rather than from the serialized
+        # metadata: `pyarrow.type_for_alias` has no alias for parametrized types such
+        # as `timestamp[us, tz=Europe/Brussels]`, so round-tripping those through the
+        # string would fail. The storage type already carries the full type. (GH#67753)
+        subtype = storage_type.field("left").type
         closed = metadata["closed"]
         return ArrowIntervalType(subtype, closed)
 

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -1588,21 +1588,35 @@ class IntervalArray(IntervalMixin, ExtensionArray):
         """
         import pyarrow
 
+        from pandas.core.arrays.arrow.array import to_pyarrow_type
         from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
 
         try:
-            subtype = pyarrow.from_numpy_dtype(self.dtype.subtype)
-        except TypeError as err:
+            subtype = to_pyarrow_type(self.dtype.subtype)
+        except (TypeError, pyarrow.ArrowNotImplementedError) as err:
             raise TypeError(
                 f"Conversion to arrow with subtype '{self.dtype.subtype}' "
                 "is not supported"
             ) from err
+        if subtype is None:
+            raise TypeError(
+                f"Conversion to arrow with subtype '{self.dtype.subtype}' "
+                "is not supported"
+            )
         interval_type = ArrowIntervalType(subtype, self.closed)
+
+        def _to_arrow(values) -> pyarrow.Array:
+            if isinstance(self.dtype.subtype, np.dtype):
+                return pyarrow.array(values, type=subtype, from_pandas=True)
+            # For an ExtensionArray subtype, handing the array straight to pyarrow
+            # makes it fall back on the deprecated `.values`, which drops the
+            # timezone. Convert the backing values and attach the parametrized
+            # arrow type instead; `_ndarray` is UTC for tz-aware data, which is
+            # exactly what casting to a tz-aware timestamp expects. (GH#67753)
+            return pyarrow.array(values._ndarray, from_pandas=True).cast(subtype)
+
         storage_array = pyarrow.StructArray.from_arrays(
-            [
-                pyarrow.array(self._left, type=subtype, from_pandas=True),
-                pyarrow.array(self._right, type=subtype, from_pandas=True),
-            ],
+            [_to_arrow(self._left), _to_arrow(self._right)],
             names=["left", "right"],
         )
         mask = self.isna()

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1475,25 +1475,37 @@ class IntervalDtype(PandasExtensionDtype):
         import pyarrow
 
         from pandas.core.arrays import IntervalArray
+        from pandas.core.arrays.arrow.array import to_pyarrow_type
 
         if isinstance(array, pyarrow.Array):
             chunks = [array]
         else:
             chunks = array.chunks
 
+        # An ExtensionDtype subtype (e.g. DatetimeTZDtype) cannot be handed to
+        # `np.asarray` as a dtype, so defer to the subtype's own arrow conversion.
+        # (GH#67753)
+        subtype_is_numpy = isinstance(self.subtype, np.dtype)
+
+        def _convert(values: pyarrow.Array):
+            if subtype_is_numpy:
+                return np.asarray(values, dtype=self.subtype)
+            return self.subtype.__from_arrow__(values)
+
         results = []
         for arr in chunks:
             if isinstance(arr, pyarrow.ExtensionArray):
                 arr = arr.storage
-            left = np.asarray(arr.field("left"), dtype=self.subtype)
-            right = np.asarray(arr.field("right"), dtype=self.subtype)
+            left = _convert(arr.field("left"))
+            right = _convert(arr.field("right"))
             iarr = IntervalArray.from_arrays(left, right, closed=self.closed)
             results.append(iarr)
 
         if not results:
+            empty = pyarrow.array([], type=to_pyarrow_type(self.subtype))
             return IntervalArray.from_arrays(
-                np.array([], dtype=self.subtype),
-                np.array([], dtype=self.subtype),
+                _convert(empty),
+                _convert(empty),
                 closed=self.closed,
             )
         return IntervalArray._concat_same_type(results)

--- a/pandas/tests/arrays/interval/test_interval_pyarrow.py
+++ b/pandas/tests/arrays/interval/test_interval_pyarrow.py
@@ -51,6 +51,29 @@ def test_arrow_array():
         pa.array(intervals, type=ArrowIntervalType(pa.float64(), "left"))
 
 
+def test_arrow_array_tz_subtype():
+    # GH#67753 an ExtensionDtype subtype such as DatetimeTZDtype used to be rejected
+    pa = pytest.importorskip("pyarrow")
+
+    from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
+
+    breaks = pd.date_range("2017", periods=4, freq="D", tz="Europe/Brussels")
+    arr = IntervalArray.from_breaks(breaks)
+
+    result = pa.array(arr)
+    assert isinstance(result.type, ArrowIntervalType)
+    assert result.type.closed == arr.closed
+    assert result.type.subtype == pa.timestamp(breaks.unit, "Europe/Brussels")
+
+    # the extension type must survive a serialize/deserialize cycle, which reads the
+    # subtype back off the storage type rather than out of the metadata string
+    restored = ArrowIntervalType.__arrow_ext_deserialize__(
+        result.type.storage_type, result.type.__arrow_ext_serialize__()
+    )
+    assert restored == result.type
+    assert restored.subtype == result.type.subtype
+
+
 def test_arrow_array_missing(using_nan_is_na):
     pa = pytest.importorskip("pyarrow")
 
@@ -82,8 +105,12 @@ def test_arrow_array_missing(using_nan_is_na):
 
 @pytest.mark.parametrize(
     "breaks",
-    [[0.0, 1.0, 2.0, 3.0], pd.date_range("2017", periods=4, freq="D")],
-    ids=["float", "datetime64[ns]"],
+    [
+        [0.0, 1.0, 2.0, 3.0],
+        pd.date_range("2017", periods=4, freq="D"),
+        pd.date_range("2017", periods=4, freq="D", tz="Europe/Brussels"),
+    ],
+    ids=["float", "datetime64[ns]", "datetime64[ns, tz]"],
 )
 def test_arrow_table_roundtrip(breaks):
     pa = pytest.importorskip("pyarrow")
@@ -115,8 +142,12 @@ def test_arrow_table_roundtrip(breaks):
 
 @pytest.mark.parametrize(
     "breaks",
-    [[0.0, 1.0, 2.0, 3.0], pd.date_range("2017", periods=4, freq="D")],
-    ids=["float", "datetime64[ns]"],
+    [
+        [0.0, 1.0, 2.0, 3.0],
+        pd.date_range("2017", periods=4, freq="D"),
+        pd.date_range("2017", periods=4, freq="D", tz="Europe/Brussels"),
+    ],
+    ids=["float", "datetime64[ns]", "datetime64[ns, tz]"],
 )
 def test_arrow_table_roundtrip_without_metadata(breaks):
     pa = pytest.importorskip("pyarrow")


### PR DESCRIPTION
- [x] closes #67753
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file

Following up on the suggestion in the issue to take the subtype from `storage_type` rather than from the serialized metadata.

There were three places that had to change before a timezone-aware interval could make the trip out to arrow and back.

**Writing.** `IntervalArray.__arrow_array__` resolved the arrow type with `pyarrow.from_numpy_dtype`, which only understands numpy dtypes, so any `ExtensionDtype` subtype was rejected outright. It now uses the existing `to_pyarrow_type` helper, which already maps `DatetimeTZDtype` to `pyarrow.timestamp(unit, tz)`. The `TypeError` message is unchanged for subtypes that genuinely cannot be converted.

**Reconstructing the extension type.** `ArrowIntervalType.__arrow_ext_deserialize__` rebuilt the subtype by feeding the serialized string to `pyarrow.type_for_alias`, which has no alias for a parametrized type, so a file written with a tz subtype failed on read with `ValueError: No type alias for timestamp[us, tz=europe/brussels]`. It now reads the subtype off `storage_type.field("left").type`.

I left `__arrow_ext_serialize__` writing the subtype string unchanged. It is no longer read, but keeping it means files written by this version still deserialize on older pandas for every subtype that already worked, so this is only additive on the metadata side.

**Reading.** `IntervalDtype.__from_arrow__` passed the subtype to `np.asarray`, which cannot interpret an `ExtensionDtype`:

```
TypeError: Cannot interpret 'datetime64[us, Europe/Brussels]' as a data type
```

It now defers to the subtype's own `__from_arrow__` when the subtype is not a numpy dtype.

One thing worth flagging, since it is the least obvious part of the diff. Handing a tz-aware `DatetimeArray` to `pyarrow.array` makes pyarrow fall back on `Series.values`, which drops the timezone and emits `Pandas4Warning`. That warning is an error under the test suite's filters, so it had to be dealt with rather than left. The backing values are converted and cast to the parametrized arrow type instead, which is valid because `_ndarray` holds UTC for tz-aware data, exactly what a cast to a tz-aware timestamp expects. I checked the values round-trip identically rather than relying on that reasoning alone. This is only on the `ExtensionDtype` branch, so the numpy path is untouched.

Testing:

`test_arrow_array_tz_subtype` is new and covers the write plus a serialize/deserialize cycle of the extension type. The two existing round-trip tests gain a `datetime64[ns, tz]` parametrisation; `test_arrow_table_roundtrip_without_metadata` is the interesting one, since stripping the schema metadata forces reconstruction through `__arrow_ext_deserialize__`, which is the path that was broken.

All three fail on main and pass with this change.

```
pytest pandas/tests/arrays/interval/test_interval_pyarrow.py     ->  12 passed
   (on main: 3 failed, 9 passed)
pytest pandas/tests/arrays/interval/ pandas/tests/extension/test_interval.py pandas/tests/dtypes/
                                                                 ->  6304 passed, 71 skipped, 11 xfailed
pytest pandas/tests/io/test_parquet.py                           ->  86 passed, 46 skipped, 1 xfailed
ruff check / ruff format --check (0.16.1)                        ->  All checks passed
```

The one error in `test_parquet.py` is `test_parquet_read_from_url`, which needs network access I do not have.

I also confirmed end to end that a tz-aware interval column now survives an actual parquet write and read with its dtype intact, and that `int64`, `float64` and naive `datetime64` intervals still round-trip unchanged.

Written with Claude Code (Claude Opus 5); I reviewed the change and ran the tests above.
