### PR TITLE
TST: add tests for to_datetime/to_timedelta behaviour with sub-nano unit specified

### DIFF
--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -2244,6 +2244,47 @@ class TestToDatetimeUnit:
         expected = pd.to_datetime(arr.astype(np.int64), unit="ns")
         tm.assert_index_equal(result, expected)
 
+    @pytest.mark.parametrize("typ,frac", [(int, 0), (float, 0), (float, 0.1)])
+    @pytest.mark.parametrize("unit", ["ps", "fs", "as"])
+    def test_sub_nano_unit(self, typ, frac, unit):
+        value = np.datetime64(1, "ns").astype(f"M8[{unit}]").item()
+        value = typ(value)
+        if frac != 0:
+            # this fractional part gets discarded, but it still works
+            value = value + frac
+
+        result = pd.to_datetime([value], unit=unit)
+        expected = pd.DatetimeIndex([pd.Timestamp(1, unit="ns")], dtype="M8[ns]")
+        tm.assert_index_equal(result, expected)
+
+        if frac != 0:
+            # TODO typed array code path fails this case - internal error
+            with pytest.raises(ValueError, match=None):  # noqa: PT011
+                pd.to_datetime(np.array([value]), unit=unit)
+
+            with pytest.raises(ValueError, match=None):  # noqa: PT011
+                pd.to_datetime(pd.array([value, None]), unit=unit)
+
+            with pytest.raises(ValueError, match=None):  # noqa: PT011
+                pd.to_datetime(value, unit=unit)
+        else:
+            result = pd.to_datetime(np.array([value]), unit=unit)
+            tm.assert_index_equal(result, expected)
+
+            result = pd.to_datetime(pd.array([value, None]), unit=unit)
+            expected = pd.DatetimeIndex(
+                [pd.Timestamp(1, unit="ns"), pd.NaT], dtype="M8[ns]"
+            )
+            tm.assert_index_equal(result, expected)
+
+            # scalar via to_datetime
+            result = pd.to_datetime(value, unit=unit)
+            assert result == pd.Timestamp(1, unit="ns")
+
+        # scalar via Timestamp constructor
+        result = pd.Timestamp(value, unit=unit)
+        assert result == pd.Timestamp(1, unit="ns")
+
 
 class TestToDatetimeDataFrame:
     @pytest.fixture

--- a/pandas/tests/tools/test_to_timedelta.py
+++ b/pandas/tests/tools/test_to_timedelta.py
@@ -498,6 +498,25 @@ class TestTimedeltas:
         expected = pd.to_timedelta(arr.astype(np.int64), unit="ns")
         tm.assert_index_equal(result, expected)
 
+    @pytest.mark.parametrize("unit", ["ps", "fs", "as"])
+    def test_sub_nano_unit_raises(self, unit):
+
+        msg = f"invalid unit abbreviation: {unit}"
+
+        with pytest.raises(ValueError, match=msg):
+            pd.to_timedelta([1000], unit=unit)
+
+        with pytest.raises(ValueError, match=msg):
+            pd.to_timedelta(np.array([1000]), unit=unit)
+
+        # scalar via to_datetime
+        with pytest.raises(ValueError, match=msg):
+            pd.to_timedelta(1000, unit=unit)
+
+        # scalar via Timestamp constructor
+        with pytest.raises(ValueError, match=msg):
+            pd.Timedelta(1000, unit=unit)
+
 
 def test_from_numeric_arrow_dtype(any_numeric_ea_dtype):
     # GH 52425


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/65845#discussion_r3875032467 where this came up in a review

We currently _do_ accept sub-nano units in `to_datetime`, but don't have test coverage for that (as far as I could find, and the linked PR broke this without test failure). So this PR is adding some tests for that.

For `to_timedelta` we actually validate the passed `unit` up front and raise for those units. It might be nice to make that behaviour consistent in the future (in one way or the other), but for now this PR just covers existing behaviour.