### PR TITLE
CI: ensure dependabot picks up .github/actions/setup-pixi/action.yml to update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - "/"
+      - "/.github/actions/setup-pixi"
     schedule:
       interval: weekly
     labels:


### PR DESCRIPTION
xref https://github.com/pandas-dev/pandas/pull/67900#issuecomment-5507701063

This is a known issue (https://github.com/dependabot/dependabot-core/issues/6704), so listing the subdirectory explicitly to ensure dependabot picks that up as well (https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#directories-or-directory--)