### PR TITLE
BUG: where/mask mishandled a list `other` for extension dtypes (GH#63842)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -658,6 +658,7 @@ Indexing
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` where incorrect values were produced when ``other`` was a :class:`Series` with :class:`ExtensionArray` values (:issue:`64635`)
 - Bug in :meth:`DataFrame.rename` and :meth:`Series.rename` not preserving nullable extension dtype (e.g. ``Int64``, ``Float64``) when relabeling index or column labels (:issue:`65315`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
+- Bug in :meth:`DataFrame.where`, :meth:`DataFrame.mask`, :meth:`Series.where` and :meth:`Series.mask` with an extension dtype (e.g. ``str``, ``Int64``, :class:`ArrowDtype`) casting to ``object`` or raising ``TypeError`` when ``other`` was a list-like of length 1 or of the same length as the object (:issue:`63842`)
 - Bug in :meth:`DataFrame.xs` where ``drop_level=False`` was ignored for fully specified :class:`MultiIndex` keys when ``level`` was not explicitly provided (:issue:`6507`)
 - Bug in :meth:`Index.get_indexer_non_unique` raising ``ZeroDivisionError`` instead of returning an all-missing result when called on an empty index with a non-empty target (:issue:`54746`)
 - Bug in :meth:`Index.get_level_values` mishandling boolean, NA-like (``np.nan``, ``pd.NA``, ``pd.NaT``) and integer index names (:issue:`62169`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -658,6 +658,7 @@ Indexing
 - Bug in :meth:`DataFrame.mask` with ``inplace=True`` where incorrect values were produced when ``other`` was a :class:`Series` with :class:`ExtensionArray` values (:issue:`64635`)
 - Bug in :meth:`DataFrame.rename` and :meth:`Series.rename` not preserving nullable extension dtype (e.g. ``Int64``, ``Float64``) when relabeling index or column labels (:issue:`65315`)
 - Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` raising ``TypeError`` when ``cond`` is a :class:`Series` and ``axis=1`` (:issue:`58190`)
+- Bug in :meth:`DataFrame.where` and :meth:`DataFrame.mask` with a datetimelike dtype (e.g. ``datetime64[ns, tz]``, ``period[D]``) silently filling every masked position with the first entry of a list-like ``other`` (:issue:`63842`)
 - Bug in :meth:`DataFrame.where`, :meth:`DataFrame.mask`, :meth:`Series.where` and :meth:`Series.mask` with an extension dtype (e.g. ``str``, ``Int64``, :class:`ArrowDtype`) casting to ``object`` or raising ``TypeError`` when ``other`` was a list-like of length 1 or of the same length as the object (:issue:`63842`)
 - Bug in :meth:`DataFrame.xs` where ``drop_level=False`` was ignored for fully specified :class:`MultiIndex` keys when ``level`` was not explicitly provided (:issue:`6507`)
 - Bug in :meth:`Index.get_indexer_non_unique` raising ``ZeroDivisionError`` instead of returning an all-missing result when called on an empty index with a non-empty target (:issue:`54746`)

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -9,6 +9,7 @@ An interface for extending pandas with custom arrays.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 import operator
 from typing import (
     TYPE_CHECKING,
@@ -87,7 +88,6 @@ if TYPE_CHECKING:
     from collections.abc import (
         Callable,
         Iterator,
-        Sequence,
     )
 
     from pandas._libs.missing import NAType
@@ -2703,20 +2703,11 @@ class ExtensionArray:
         ----------
         mask : np.ndarray[bool]
         value : scalar or listlike
-            If listlike, must be arraylike with same length as self.
-
-        Returns
-        -------
-        None
-
-        Notes
-        -----
-        Unlike np.putmask, we do not repeat listlike values with mismatched length.
-        'value' should either be a scalar or an arraylike with the same length
-        as self.
+            If listlike, must hold one entry per position ``mask`` selects, or
+            have the same length as self, or have length 1.
         """
         if is_list_like(value):
-            val = value[mask]
+            val = self._align_putmask_value(value, mask)
         else:
             val = value
 
@@ -2730,6 +2721,8 @@ class ExtensionArray:
         ----------
         mask : np.ndarray[bool]
         value : scalar or listlike
+            If listlike, must have the same length as self, or length 1, in
+            which case it is broadcast.
 
         Returns
         -------
@@ -2738,12 +2731,54 @@ class ExtensionArray:
         result = self.copy()
 
         if is_list_like(value):
-            val = value[~mask]
+            val = self._align_mask_value(value)[~mask]
         else:
             val = value
 
         result[~mask] = val
         return result
+
+    def _align_mask_value(self, value):
+        """
+        Convert a list-like ``value`` passed to ``_where`` into an array with
+        the same length as self.
+
+        A length-1 ``value`` is broadcast, matching the semantics numpy dtypes
+        get from ``np.where`` (GH#63842).
+        """
+        if not isinstance(value, (np.ndarray, ExtensionArray)):
+            if not isinstance(value, Sequence):
+                # e.g. dict or set: list-like, but with no element order to
+                #  line up against the mask.  Pass it through unchanged so the
+                #  indexing below handles it exactly as it did before.
+                return value
+            value = construct_1d_object_array_from_listlike(value)
+
+        if len(value) == 1 and len(self) != 1:
+            value = value.repeat(len(self))
+        elif len(value) != len(self):
+            raise ValueError(
+                f"Length of value ({len(value)}) does not match length of "
+                f"the array ({len(self)})"
+            )
+        return value
+
+    def _align_putmask_value(self, value, mask: npt.NDArray[np.bool_]):
+        """
+        Select the entries of a list-like ``value`` that ``mask`` will write.
+
+        ``putmask`` takes one more shape than ``where`` does: as in
+        ``putmask_without_repeat``, a ``value`` holding one entry per selected
+        position is used as-is, the way ``np.place`` does (GH#63842).
+        """
+        if isinstance(value, Sequence):
+            value = construct_1d_object_array_from_listlike(value)
+
+        if isinstance(value, (np.ndarray, ExtensionArray)) and len(value) == mask.sum():
+            return value
+        # anything else -- a dict or set included -- is left to
+        #  _align_mask_value, which passes it through untouched
+        return self._align_mask_value(value)[mask]
 
     @property
     def _is_monotonic_increasing(self) -> bool:

--- a/pandas/core/arrays/base.py
+++ b/pandas/core/arrays/base.py
@@ -9,7 +9,6 @@ An interface for extending pandas with custom arrays.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 import operator
 from typing import (
     TYPE_CHECKING,
@@ -88,6 +87,7 @@ if TYPE_CHECKING:
     from collections.abc import (
         Callable,
         Iterator,
+        Sequence,
     )
 
     from pandas._libs.missing import NAType
@@ -2703,11 +2703,20 @@ class ExtensionArray:
         ----------
         mask : np.ndarray[bool]
         value : scalar or listlike
-            If listlike, must hold one entry per position ``mask`` selects, or
-            have the same length as self, or have length 1.
+            If listlike, must be arraylike with same length as self.
+
+        Returns
+        -------
+        None
+
+        Notes
+        -----
+        Unlike np.putmask, we do not repeat listlike values with mismatched length.
+        'value' should either be a scalar or an arraylike with the same length
+        as self.
         """
         if is_list_like(value):
-            val = self._align_putmask_value(value, mask)
+            val = value[mask]
         else:
             val = value
 
@@ -2721,8 +2730,6 @@ class ExtensionArray:
         ----------
         mask : np.ndarray[bool]
         value : scalar or listlike
-            If listlike, must have the same length as self, or length 1, in
-            which case it is broadcast.
 
         Returns
         -------
@@ -2731,54 +2738,12 @@ class ExtensionArray:
         result = self.copy()
 
         if is_list_like(value):
-            val = self._align_mask_value(value)[~mask]
+            val = value[~mask]
         else:
             val = value
 
         result[~mask] = val
         return result
-
-    def _align_mask_value(self, value):
-        """
-        Convert a list-like ``value`` passed to ``_where`` into an array with
-        the same length as self.
-
-        A length-1 ``value`` is broadcast, matching the semantics numpy dtypes
-        get from ``np.where`` (GH#63842).
-        """
-        if not isinstance(value, (np.ndarray, ExtensionArray)):
-            if not isinstance(value, Sequence):
-                # e.g. dict or set: list-like, but with no element order to
-                #  line up against the mask.  Pass it through unchanged so the
-                #  indexing below handles it exactly as it did before.
-                return value
-            value = construct_1d_object_array_from_listlike(value)
-
-        if len(value) == 1 and len(self) != 1:
-            value = value.repeat(len(self))
-        elif len(value) != len(self):
-            raise ValueError(
-                f"Length of value ({len(value)}) does not match length of "
-                f"the array ({len(self)})"
-            )
-        return value
-
-    def _align_putmask_value(self, value, mask: npt.NDArray[np.bool_]):
-        """
-        Select the entries of a list-like ``value`` that ``mask`` will write.
-
-        ``putmask`` takes one more shape than ``where`` does: as in
-        ``putmask_without_repeat``, a ``value`` holding one entry per selected
-        position is used as-is, the way ``np.place`` does (GH#63842).
-        """
-        if isinstance(value, Sequence):
-            value = construct_1d_object_array_from_listlike(value)
-
-        if isinstance(value, (np.ndarray, ExtensionArray)) and len(value) == mask.sum():
-            return value
-        # anything else -- a dict or set included -- is left to
-        #  _align_mask_value, which passes it through untouched
-        return self._align_mask_value(value)[mask]
 
     @property
     def _is_monotonic_increasing(self) -> bool:

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 import inspect
 import re
 from typing import (
@@ -118,7 +119,6 @@ if TYPE_CHECKING:
         Callable,
         Generator,
         Iterable,
-        Sequence,
     )
 
     from pandas._typing import (
@@ -1807,6 +1807,65 @@ class EABackedBlock(Block):
             return self
 
     @final
+    def _align_listlike_arg(
+        self, arg, target: ArrayLike, mask: npt.NDArray[np.bool_] | None = None
+    ):
+        """
+        Line a list-like ``other``/``new`` up against ``target``.
+
+        ``EA._where``/``EA._putmask`` need an arraylike they can index with the
+        mask, so a raw list -- which supports neither boolean indexing nor
+        broadcasting -- would otherwise fall through to an object upcast
+        (GH#63842).  A length-1 argument is broadcast, matching what numpy
+        dtypes get from ``np.where``.  When ``mask`` is given we are on the
+        putmask path, which takes one more shape -- one entry per selected
+        position -- and dispatches that case itself.
+        """
+        if (
+            isinstance(arg, (np.ndarray, ExtensionArray))
+            or not is_list_like(arg)
+            or not isinstance(arg, Sequence)
+            or isinstance(arg, tuple)
+        ):
+            # An ndarray/EA already lines up or broadcasts.  Otherwise only an
+            #  ordered sequence can be lined up against the mask; a dict or set
+            #  is left for the EA to reject, which upcasts to object and holds
+            #  it as a scalar, as numpy dtypes do.  A tuple is excluded because
+            #  it is a valid scalar, and is held as one for numpy dtypes too
+            #  (GH#37681).
+            return arg
+
+        # NB: not _from_sequence(dtype=self.dtype), which would coerce where we
+        #  want to raise -- str turns 9 into "9" and Categorical turns an
+        #  unknown category into NaN.  Casting is the setitem call's job, and
+        #  its raising is what triggers the caller's upcast to object.
+        arg = com.asarray_tuplesafe(arg)
+
+        nrows = self.shape[-1]
+        if mask is not None and len(arg) == mask.sum() != nrows:
+            # One entry per selected position; putmask dispatches this itself.
+            return arg
+
+        if target.ndim == 2:
+            # TODO(EA2D): unnecessary with 2D EAs
+            if len(arg) == nrows:
+                # Column-like, not row-like: the same reshape (and the same
+                #  raise for a multi-column block) as in Block.where.
+                return arg.reshape(target.shape)
+            # Any other length is left to np.where's broadcasting, as it is
+            #  for numpy dtypes.
+            return arg
+
+        if len(arg) == 1 and nrows != 1:
+            arg = arg.repeat(nrows)
+        elif len(arg) != nrows:
+            raise ValueError(
+                f"Length of value ({len(arg)}) does not match length of "
+                f"the array ({nrows})"
+            )
+        return arg
+
+    @final
     def where(self, other, cond) -> list[Block]:
         arr = self.values.T
 
@@ -1825,6 +1884,8 @@ class EABackedBlock(Block):
             # GH#44181, GH#45135
             # Avoid a) raising for Interval/PeriodDtype and b) unnecessary object upcast
             return [self.copy(deep=False)]
+
+        other = self._align_listlike_arg(other, arr)
 
         try:
             res_values = arr._where(cond, other).T
@@ -1909,9 +1970,22 @@ class EABackedBlock(Block):
             if isinstance(new, (np.ndarray, ExtensionArray)) and new.ndim == 2:
                 new = new.T
 
+        new = self._align_listlike_arg(new, values, mask)
+
         try:
-            # Caller is responsible for ensuring matching lengths
-            values._putmask(mask, new)
+            if (
+                (self.ndim == 1 or self.shape[0] == 1)
+                and isinstance(new, (np.ndarray, ExtensionArray))
+                and new.ndim == 1
+                and len(new) == mask.sum() != self.shape[-1]
+            ):
+                # One entry per selected position rather than one per row.
+                #  This is the EA analogue of the np.place call that
+                #  putmask_without_repeat makes for numpy dtypes; EA._putmask
+                #  itself takes only a full-length value.
+                values[mask] = new
+            else:
+                values._putmask(mask, new)
         except OutOfBoundsDatetime:
             raise
         except (TypeError, ValueError):

--- a/pandas/tests/extension/base/methods.py
+++ b/pandas/tests/extension/base/methods.py
@@ -750,6 +750,63 @@ class BaseMethodsTests:
         ser.mask(~cond, other, inplace=True)
         tm.assert_equal(ser, expected)
 
+    def _listlike_other_setup(self, data, as_frame):
+        assert data[0] != data[1]
+        cls = type(data)
+        first, second = data[:2]
+
+        orig = pd.Series(
+            cls._from_sequence([first, first, second, second], dtype=data.dtype)
+        )
+        cond = np.array([True, False, True, False])
+        if as_frame:
+            orig = orig.to_frame(name="a")
+            cond = pd.DataFrame({"a": cond})
+
+        def expected(values):
+            res = pd.Series(cls._from_sequence(values, dtype=data.dtype))
+            return res.to_frame(name="a") if as_frame else res
+
+        return orig, cond, expected, first, second
+
+    def test_where_series_listlike_other(self, data, as_frame):
+        # GH#63842 a list-like 'other' is lined up against the mask without
+        #  casting to object
+        orig, cond, expected, first, second = self._listlike_other_setup(data, as_frame)
+
+        result = orig.where(cond, [first, second, first, second])
+        tm.assert_equal(result, expected([first, second, second, second]))
+
+        # a length-1 'other' is broadcast, as it is for numpy dtypes
+        result = orig.where(cond, [first])
+        tm.assert_equal(result, expected([first, first, second, first]))
+
+    def test_where_series_listlike_other_wrong_length(self, data):
+        # GH#63842 a length that is neither 1 nor len(self) cannot be lined up
+        cls = type(data)
+        first, second = data[:2]
+        ser = pd.Series(
+            cls._from_sequence([first, first, second, second], dtype=data.dtype)
+        )
+        cond = np.array([True, False, True, False])
+
+        msg = r"Length of value \(3\) does not match length of the array \(4\)"
+        with pytest.raises(ValueError, match=msg):
+            ser.where(cond, [first, second, first])
+
+    def test_mask_listlike_other_inplace(self, data, as_frame):
+        # GH#63842 putmask takes one more shape than where does: a value
+        #  holding one entry per selected position
+        orig, cond, expected, first, second = self._listlike_other_setup(data, as_frame)
+
+        obj = orig.copy()
+        obj.mask(~cond, [first], inplace=True)
+        tm.assert_equal(obj, expected([first, first, second, first]))
+
+        obj = orig.copy()
+        obj.mask(~cond, [second, first], inplace=True)
+        tm.assert_equal(obj, expected([first, second, second, first]))
+
     @pytest.mark.parametrize("repeats", [0, 1, 2, [1, 2, 3]])
     def test_repeat(self, data, repeats, as_series, use_numpy):
         arr = type(data)._from_sequence(data[:3], dtype=data.dtype)

--- a/pandas/tests/extension/json/test_json.py
+++ b/pandas/tests/extension/json/test_json.py
@@ -194,6 +194,14 @@ class TestJSONArray(base.ExtensionTests):
     def test_combine_first(self, data):
         super().test_combine_first(data)
 
+    @pytest.mark.xfail(reason="JSONArray.__setitem__ mishandles a boolean mask")
+    def test_where_series_listlike_other(self, data, as_frame):
+        super().test_where_series_listlike_other(data, as_frame)
+
+    @pytest.mark.xfail(reason="JSONArray.__setitem__ mishandles a boolean mask")
+    def test_mask_listlike_other_inplace(self, data, as_frame):
+        super().test_mask_listlike_other_inplace(data, as_frame)
+
     @pytest.mark.xfail(reason="broadcasting error")
     def test_where_series(self, data, na_value):
         # Fails with

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -283,6 +283,10 @@ class TestSparseArray(base.ExtensionTests):
     def test_fillna_length_mismatch(self, data_missing):
         super().test_fillna_length_mismatch(data_missing)
 
+    @pytest.mark.xfail(reason="SparseArray does not support item assignment")
+    def test_mask_listlike_other_inplace(self, data, as_frame):
+        super().test_mask_listlike_other_inplace(data, as_frame)
+
     def test_where_series(self, data, na_value):
         assert data[0] != data[1]
         cls = type(data)

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -849,6 +849,149 @@ def test_where_string_dtype(frame_or_series):
     tm.assert_equal(result, expected)
 
 
+@pytest.mark.parametrize("box", [list, tuple])
+def test_where_listlike_other_keeps_ea_dtype(
+    frame_or_series, any_numeric_ea_and_arrow_dtype, box
+):
+    # GH#63842 a list-like 'other' should not cast to object or raise
+    dtype = any_numeric_ea_and_arrow_dtype
+    obj = frame_or_series(pd.array([1, 2, 3, 4], dtype=dtype))
+    cond = pd.Series([True, False, True, False])
+    if frame_or_series is pd.DataFrame:
+        cond = cond.to_frame()
+
+    result = obj.where(cond, box([9, 8, 7, 6]))
+    expected = frame_or_series(pd.array([1, 8, 3, 6], dtype=dtype))
+    tm.assert_equal(result, expected)
+
+    # a length-1 'other' is broadcast, as it is for numpy dtypes
+    result = obj.where(cond, box([9]))
+    expected = frame_or_series(pd.array([1, 9, 3, 9], dtype=dtype))
+    tm.assert_equal(result, expected)
+
+    obj.mask(~cond, box([9]), inplace=True)
+    tm.assert_equal(obj, expected)
+
+
+def test_where_listlike_other_wrong_length_raises(any_numeric_ea_and_arrow_dtype):
+    # GH#63842 a length that is neither 1 nor len(self) cannot be lined up
+    ser = pd.Series(pd.array([1, 2, 3, 4], dtype=any_numeric_ea_and_arrow_dtype))
+    msg = r"Length of value \(2\) does not match length of the array \(4\)"
+    with pytest.raises(ValueError, match=msg):
+        ser.where(pd.Series([True, False, True, False]), [9, 8])
+
+
+@pytest.mark.parametrize("box", [list, tuple])
+def test_where_listlike_other_keeps_string_dtype(
+    frame_or_series, any_string_dtype, box
+):
+    # GH#63842
+    obj = frame_or_series(pd.array(["a", "bc", "cde", "fghi"], dtype=any_string_dtype))
+    cond = pd.Series([True, False, True, False])
+    if frame_or_series is pd.DataFrame:
+        cond = cond.to_frame()
+
+    result = obj.where(cond, box(["w", "x", "y", "z"]))
+    expected = frame_or_series(pd.array(["a", "x", "cde", "z"], dtype=any_string_dtype))
+    tm.assert_equal(result, expected)
+
+    # a length-1 'other' is broadcast, as it is for numpy dtypes
+    result = obj.where(cond, box(["cudf"]))
+    expected = frame_or_series(
+        pd.array(["a", "cudf", "cde", "cudf"], dtype=any_string_dtype)
+    )
+    tm.assert_equal(result, expected)
+
+    result = obj.mask(~cond, box(["cudf"]))
+    tm.assert_equal(result, expected)
+
+
+def test_where_listlike_other_keeps_interval_dtype(frame_or_series):
+    # GH#63842
+    values = list(pd.IntervalIndex.from_breaks([0, 1, 2, 3, 4]))
+    other = list(pd.IntervalIndex.from_breaks([9, 10, 11, 12, 13]))
+    obj = frame_or_series(pd.array(values))
+    cond = pd.Series([True, False, True, False])
+    if frame_or_series is pd.DataFrame:
+        cond = cond.to_frame()
+
+    result = obj.where(cond, other)
+    expected = frame_or_series(pd.array([values[0], other[1], values[2], other[3]]))
+    tm.assert_equal(result, expected)
+
+
+@pytest.mark.parametrize("box", [list, np.array])
+def test_putmask_listlike_value_per_selected_position(
+    any_numeric_ea_and_arrow_dtype, box
+):
+    # GH#63842 putmask takes one value per selected position, as it does for
+    #  numpy dtypes, rather than one per row
+    dtype = any_numeric_ea_and_arrow_dtype
+    cond = pd.Series([False, True, False, True])
+    expected = pd.Series(pd.array([1, 9, 3, 8], dtype=dtype))
+
+    ser = pd.Series(pd.array([1, 2, 3, 4], dtype=dtype))
+    ser.mask(cond, box([9, 8]), inplace=True)
+    tm.assert_series_equal(ser, expected)
+
+    ser = pd.Series(pd.array([1, 2, 3, 4], dtype=dtype))
+    ser.where(~cond, box([9, 8]), inplace=True)
+    tm.assert_series_equal(ser, expected)
+
+    # matching the numpy-dtype result
+    ref = pd.Series([1, 2, 3, 4])
+    ref.mask(cond, box([9, 8]), inplace=True)
+    tm.assert_series_equal(ser.astype("int64"), ref)
+
+
+def test_setitem_boolean_frame_listlike_value_keeps_ea_dtype(
+    any_numeric_ea_and_arrow_dtype,
+):
+    # GH#63842 an ndarray 'value' is rejected upstream for every dtype, so the
+    #  list form is the one that reaches putmask here
+    dtype = any_numeric_ea_and_arrow_dtype
+    key = pd.DataFrame({"A": [False, True, False, True]})
+
+    df = pd.DataFrame({"A": pd.array([1, 2, 3, 4], dtype=dtype)})
+    df[key] = [9, 8]
+    tm.assert_frame_equal(df, pd.DataFrame({"A": pd.array([1, 9, 3, 8], dtype=dtype)}))
+
+    ref = pd.DataFrame({"A": [1, 2, 3, 4]})
+    ref[key] = [9, 8]
+    tm.assert_frame_equal(df.astype("int64"), ref)
+
+
+def test_putmask_listlike_value_per_selected_position_string(any_string_dtype):
+    # GH#63842
+    cond = pd.Series([False, True, False, True])
+    ser = pd.Series(pd.array(["a", "b", "c", "d"], dtype=any_string_dtype))
+    ser.mask(cond, ["w", "x"], inplace=True)
+    expected = pd.Series(pd.array(["a", "w", "c", "x"], dtype=any_string_dtype))
+    tm.assert_series_equal(ser, expected)
+
+
+def test_index_where_listlike_other_keeps_ea_dtype(any_numeric_ea_and_arrow_dtype):
+    # GH#63842 Index.where and Index.putmask reach the same code path
+    dtype = any_numeric_ea_and_arrow_dtype
+    idx = pd.Index(pd.array([1, 2, 3, 4], dtype=dtype))
+    cond = np.array([True, False, True, False])
+
+    result = idx.where(cond, [9, 8, 7, 6])
+    tm.assert_index_equal(result, pd.Index(pd.array([1, 8, 3, 6], dtype=dtype)))
+
+    result = idx.putmask(~cond, [9, 8, 7, 6])
+    tm.assert_index_equal(result, pd.Index(pd.array([1, 8, 3, 6], dtype=dtype)))
+
+
+def test_where_mapping_other_treated_as_scalar(any_string_dtype):
+    # GH#63842 a dict is list-like, but it has no element order to line up
+    #  against the mask, so it stays a scalar as it does for numpy dtypes
+    ser = pd.Series(["a", "b", "c"], dtype=any_string_dtype)
+    result = ser.where(pd.Series([True, False, True]), {"zz": 1})
+    expected = pd.Series(["a", {"zz": 1}, "c"], dtype=object)
+    tm.assert_series_equal(result, expected)
+
+
 def test_where_bool_comparison():
     # GH 10336
     df_mask = pd.DataFrame(

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -849,9 +849,8 @@ def test_where_string_dtype(frame_or_series):
     tm.assert_equal(result, expected)
 
 
-@pytest.mark.parametrize("box", [list, tuple])
 def test_where_listlike_other_keeps_ea_dtype(
-    frame_or_series, any_numeric_ea_and_arrow_dtype, box
+    frame_or_series, any_numeric_ea_and_arrow_dtype
 ):
     # GH#63842 a list-like 'other' should not cast to object or raise
     dtype = any_numeric_ea_and_arrow_dtype
@@ -860,16 +859,16 @@ def test_where_listlike_other_keeps_ea_dtype(
     if frame_or_series is pd.DataFrame:
         cond = cond.to_frame()
 
-    result = obj.where(cond, box([9, 8, 7, 6]))
+    result = obj.where(cond, [9, 8, 7, 6])
     expected = frame_or_series(pd.array([1, 8, 3, 6], dtype=dtype))
     tm.assert_equal(result, expected)
 
     # a length-1 'other' is broadcast, as it is for numpy dtypes
-    result = obj.where(cond, box([9]))
+    result = obj.where(cond, [9])
     expected = frame_or_series(pd.array([1, 9, 3, 9], dtype=dtype))
     tm.assert_equal(result, expected)
 
-    obj.mask(~cond, box([9]), inplace=True)
+    obj.mask(~cond, [9], inplace=True)
     tm.assert_equal(obj, expected)
 
 
@@ -881,34 +880,35 @@ def test_where_listlike_other_wrong_length_raises(any_numeric_ea_and_arrow_dtype
         ser.where(pd.Series([True, False, True, False]), [9, 8])
 
 
-@pytest.mark.parametrize("box", [list, tuple])
-def test_where_listlike_other_keeps_string_dtype(
-    frame_or_series, any_string_dtype, box
-):
+def test_where_listlike_other_keeps_string_dtype(frame_or_series, any_string_dtype):
     # GH#63842
-    if box is tuple and any_string_dtype == object:
-        # GH#37681 a tuple is a valid object-dtype scalar, so for object dtype
-        #  it is filled in as a scalar; see test_where_tuple_scalar_object_dtype
-        pytest.skip("tuple is treated as a scalar for object dtype")
-
     obj = frame_or_series(pd.array(["a", "bc", "cde", "fghi"], dtype=any_string_dtype))
     cond = pd.Series([True, False, True, False])
     if frame_or_series is pd.DataFrame:
         cond = cond.to_frame()
 
-    result = obj.where(cond, box(["w", "x", "y", "z"]))
+    result = obj.where(cond, ["w", "x", "y", "z"])
     expected = frame_or_series(pd.array(["a", "x", "cde", "z"], dtype=any_string_dtype))
     tm.assert_equal(result, expected)
 
     # a length-1 'other' is broadcast, as it is for numpy dtypes
-    result = obj.where(cond, box(["cudf"]))
+    result = obj.where(cond, ["cudf"])
     expected = frame_or_series(
         pd.array(["a", "cudf", "cde", "cudf"], dtype=any_string_dtype)
     )
     tm.assert_equal(result, expected)
 
-    result = obj.mask(~cond, box(["cudf"]))
+    result = obj.mask(~cond, ["cudf"])
     tm.assert_equal(result, expected)
+
+
+def test_where_tuple_other_treated_as_scalar(any_string_dtype):
+    # GH#37681 a tuple is a valid scalar, so -- as for numpy dtypes -- it is
+    #  filled in whole rather than lined up against the mask
+    ser = pd.Series(["a", "b", "c"], dtype=any_string_dtype)
+    result = ser.where(pd.Series([True, False, True]), ("x", "y", "z"))
+    expected = pd.Series(["a", ("x", "y", "z"), "c"], dtype=object)
+    tm.assert_series_equal(result, expected)
 
 
 def test_where_listlike_other_keeps_interval_dtype(frame_or_series):
@@ -986,6 +986,22 @@ def test_index_where_listlike_other_keeps_ea_dtype(any_numeric_ea_and_arrow_dtyp
 
     result = idx.putmask(~cond, [9, 8, 7, 6])
     tm.assert_index_equal(result, pd.Index(pd.array([1, 8, 3, 6], dtype=dtype)))
+
+
+@pytest.mark.parametrize(
+    "dtype", ["datetime64[ns]", "datetime64[ns, UTC]", "period[D]"]
+)
+def test_where_listlike_other_2d_block_column_like(dtype):
+    # GH#63842 datetimelike blocks are 2D, so a list 'other' used to reach
+    #  np.where unaligned and broadcast row-like, silently filling every
+    #  masked position with other[0]
+    values = pd.array(pd.date_range("2016-01-01", periods=4), dtype=dtype)
+    other = list(values[[1, 0, 1, 0]])
+    df = pd.DataFrame({"a": values})
+
+    result = df.where(pd.DataFrame({"a": [True, False, True, False]}), other)
+    expected = pd.DataFrame({"a": values[[0, 0, 2, 0]]})
+    tm.assert_frame_equal(result, expected)
 
 
 def test_where_mapping_other_treated_as_scalar(any_string_dtype):

--- a/pandas/tests/frame/indexing/test_where.py
+++ b/pandas/tests/frame/indexing/test_where.py
@@ -886,6 +886,11 @@ def test_where_listlike_other_keeps_string_dtype(
     frame_or_series, any_string_dtype, box
 ):
     # GH#63842
+    if box is tuple and any_string_dtype == object:
+        # GH#37681 a tuple is a valid object-dtype scalar, so for object dtype
+        #  it is filled in as a scalar; see test_where_tuple_scalar_object_dtype
+        pytest.skip("tuple is treated as a scalar for object dtype")
+
     obj = frame_or_series(pd.array(["a", "bc", "cde", "fghi"], dtype=any_string_dtype))
     cond = pd.Series([True, False, True, False])
     if frame_or_series is pd.DataFrame:


### PR DESCRIPTION
closes #63842

`ExtensionArray._where` and `._putmask` index `value[~mask]` directly, which only works if `value` is already an ndarray/ExtensionArray of exactly `len(self)`. Nothing upstream converts a plain list, so a list `other` silently fell back to `object` for `str`/`string[pyarrow]`/`interval` and raised `TypeError: only integer scalar arrays can be converted to a scalar index` for `Int64`/`Float64`/`boolean`/`ArrowDtype` — the reported bug is only the string half of that. `Index.where`, `Index.putmask` and boolean-mask setitem are fixed with it, since they route through the same two methods.

The conversion is done in a new `EABackedBlock._align_listlike_arg`, not in `ExtensionArray`. `_where`/`_putmask` keep their existing contract ("arraylike with the same length as self"), so an EA author still reads the same short method, and `EABackedBlock.where`/`.putmask` are their only callers outside the EAs themselves. Handling it at the block level also reaches `NDArrayBackedExtensionArray` and `SparseArray`, which override `_where` so a fix on the base class never applied to them, and the 2-D datetimelike blocks, where a list reached `np.where` unaligned and silently filled **every** masked position with `other[0]`.

A 2-D block now gets one alignment order: one entry per selected position (putmask only — the analogue of the `np.place` call `putmask_without_repeat` makes for numpy dtypes), then one value per column, then one value per row filling every column. A length that fits none of them raises `ValueError`. The order matters because a consolidated `datetime64[ns]`/`timedelta64[ns]` block holds every column of the frame while `Int64`/`ArrowDtype`/`Categorical`/`datetime64[ns, tz]`/`period` get a block each: before this they gave different answers for the same input, and now they agree.

Non-`Sequence` list-likes — `dict`, `set`, `MultiIndex` — are passed through untouched, so the EA holds them as a scalar (the object-backed dtypes) or rejects them (masked, Arrow, `Categorical`), exactly as before. A tuple is likewise left alone: object dtype holds one as a scalar (GH-37681), and `Index.fillna` admits one.

Note on the conversion: it goes through `com.asarray_tuplesafe` rather than `_from_sequence(dtype=self.dtype)`. `_from_sequence` coerces where we need it to raise — `str` turns `9` into `"9"` and `Categorical` turns an unknown category into `NaN` — and it is the setitem call raising that triggers the block's upcast to `object`.

Base extension tests cover the list shapes, xfailed for `SparseArray` (no item assignment) and `JSONArray` (its `__setitem__` mishandles a boolean mask, which is also the cause of the pre-existing `test_where_series` xfail there).

Not reconciled here: 1-D EA dtypes get one block per column, so they cannot see the frame's column count, and a multi-column EA frame still reads a row-length list per column (`df[key] = [10, 20, 30]`) where the numpy and object spellings raise. That needs the rule moved into `NDFrame._where`, which changes behavior for every dtype and belongs in its own PR. The whatsnew entries are scoped to what actually changed.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the root cause, wrote the fix and tests, and ran repeated rounds of adversarial review over the diff.
