### PR TITLE
DOC: clarify that rollforward/rollback are no-ops on valid offset dates (GH#42813)

### DIFF
--- a/doc/source/user_guide/timeseries.rst
+++ b/doc/source/user_guide/timeseries.rst
@@ -1066,6 +1066,22 @@ business offsets operate on the weekdays.
    # Date is brought to the closest offset date first and then the hour is added
    ts + offset
 
+Both methods roll *conditionally*: a date that is already a valid offset date is
+returned unchanged, so :meth:`rollforward` and :meth:`rollback` give the same
+answer there. Use :meth:`is_on_offset` to check whether a date is already valid,
+and add or subtract the offset to move unconditionally.
+
+.. ipython:: python
+
+   # The last business day of July 2021, so already a valid BMonthEnd date
+   ts = pd.Timestamp("2021-07-30")
+   offset = pd.offsets.BMonthEnd()
+   offset.is_on_offset(ts)
+   offset.rollback(ts)
+   offset.rollforward(ts)
+   # Subtract the offset to always move to the previous business month end
+   ts - offset
+
 These operations preserve time (hour, minute, etc) information by default.
 To reset time to midnight, use :meth:`normalize` before or after applying
 the operation (depending on whether you want the time information included


### PR DESCRIPTION
closes #42813

The timeseries user guide describes `rollforward`/`rollback` as "methods for moving a date forward or backward respectively to a valid offset date", without mentioning that the roll is *conditional* — a date already on the offset is returned unchanged, so the two methods agree there. That omission is what the issue reports as a bug: `BMonthEnd().rollback(...)` and `.rollforward(...)` returning the same value for the last business day of a month is the documented behavior, not a defect.

The method docstrings already say so explicitly (since GH-63731), so this adds the same clarification to the user guide, where a reader is most likely to form the wrong expectation. Includes a runnable example on the reporter's own case and points at subtracting the offset for an unconditional move.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which investigated the issue, confirmed the behavior matches the documented contract, and wrote the doc change.