### PR TITLE
BUG: to_json leaked the dtype of object-dtype numpy.datetime64 values

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -756,6 +756,7 @@ I/O
 - Fixed bug where a file opened by pandas was left open when :func:`read_csv` and other readers raised while opening it -- for example a ZIP or TAR archive holding more than one file -- so on Windows the file could not be renamed or deleted (:issue:`58131`)
 - Fixed memory leak in :func:`read_csv` (:issue:`19941`)
 - Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing :class:`Timestamp` with timezones (:issue:`54865`)
+- Fixed memory leak in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing object-dtype ``numpy.datetime64`` values (:issue:`67930`)
 - Fixed segfault in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing an object-dtype ``datetime.date`` or ``datetime.timedelta`` subclass that carries a ``_value`` attribute but no ``_creso`` attribute (:issue:`65904`)
 - Fixed segfault when instantiating the internal ``pandas._libs.parsers.TextReader`` with no arguments; it now raises ``TypeError`` (:issue:`53131`)
 - Fixed several segfaults in :meth:`DataFrame.to_json` and :meth:`Series.to_json` when serializing python objects that are very abnormal, including massive :class:`int` values, and strings that cannot be encoded as utf-8 (:issue:`66356`)

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -1830,12 +1830,12 @@ static void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
     }
     PyArray_Descr *dtype = PyArray_DescrFromScalar(obj);
     if (dtype == NULL) {
-      return;
+      goto INVALID;
     }
     if (!PyTypeNum_ISDATETIME(dtype->type_num)) {
       PyErr_Format(PyExc_ValueError, "Could not get resolution of datetime");
       Py_DECREF(dtype);
-      return;
+      goto INVALID;
     }
 
     PyArray_Descr *outcode = PyArray_DescrFromType(NPY_INT64);

--- a/pandas/_libs/src/vendored/ujson/python/objToJSON.c
+++ b/pandas/_libs/src/vendored/ujson/python/objToJSON.c
@@ -1829,8 +1829,12 @@ static void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
       return;
     }
     PyArray_Descr *dtype = PyArray_DescrFromScalar(obj);
+    if (dtype == NULL) {
+      return;
+    }
     if (!PyTypeNum_ISDATETIME(dtype->type_num)) {
       PyErr_Format(PyExc_ValueError, "Could not get resolution of datetime");
+      Py_DECREF(dtype);
       return;
     }
 
@@ -1851,6 +1855,7 @@ static void Object_beginTypeContext(JSOBJ _obj, JSONTypeContext *tc) {
       pc->longValue = PyDateTimeToEpoch(obj, base);
       tc->type = JT_LONG;
     }
+    Py_DECREF(dtype);
     return;
   } else if (PyDelta_Check(obj)) {
     // pd.Timedelta object or pd.NaT should evaluate true here

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -1283,3 +1283,23 @@ def test_to_json_bad_label_frees_values():
     del ser, values
     # a reference held by the failed encode would keep this alive
     assert ref() is None
+
+
+def test_to_json_datetime64_scalar_frees_dtype():
+    # GH#67930
+    # Object_beginTypeContext took a reference on the scalar's dtype via
+    # PyArray_DescrFromScalar and never gave it back. The builtin descrs are
+    # immortal so most scalar types hid this, but a datetime64 descr carries
+    # unit metadata and so is a freshly allocated, mortal object every call.
+    ser = pd.Series([np.datetime64("2020-01-01T00:00:00", "s")], dtype=object)
+
+    tracemalloc.start()
+    before = tracemalloc.take_snapshot()
+    for _ in range(2000):
+        ser.to_json(date_format="iso")
+    after = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+
+    grew = sum(stat.size_diff for stat in after.compare_to(before, "filename"))
+    # the leak was ~160 bytes per call, so ~320 KiB over this loop
+    assert grew < 100_000

--- a/pandas/tests/io/json/test_ujson.py
+++ b/pandas/tests/io/json/test_ujson.py
@@ -1291,15 +1291,17 @@ def test_to_json_datetime64_scalar_frees_dtype():
     # PyArray_DescrFromScalar and never gave it back. The builtin descrs are
     # immortal so most scalar types hid this, but a datetime64 descr carries
     # unit metadata and so is a freshly allocated, mortal object every call.
-    ser = pd.Series([np.datetime64("2020-01-01T00:00:00", "s")], dtype=object)
+    # The encoder is called directly so that a leak of ~160 bytes per call
+    # stands out against the allocations the loop itself makes.
+    payload = [np.datetime64("2020-01-01T00:00:00", "s")]
 
     tracemalloc.start()
     before = tracemalloc.take_snapshot()
-    for _ in range(2000):
-        ser.to_json(date_format="iso")
+    for _ in range(20_000):
+        ujson.ujson_dumps(payload, iso_dates=True)
     after = tracemalloc.take_snapshot()
     tracemalloc.stop()
 
     grew = sum(stat.size_diff for stat in after.compare_to(before, "filename"))
-    # the leak was ~160 bytes per call, so ~320 KiB over this loop
-    assert grew < 100_000
+    # a leak here would be ~3.2 MiB over this loop
+    assert grew < 1_000_000


### PR DESCRIPTION
Found by a leak-detection pass over the hand-written C in `_libs`.

`Object_beginTypeContext` takes a new reference on the scalar's dtype via `PyArray_DescrFromScalar` and never gives it back. Most scalar types hide this because their descrs are immortal singletons, but a `datetime64` descr carries unit metadata and so is a freshly allocated, mortal object on every call.

Measured on main: ~160 bytes leaked per value serialized (~330 KiB over 2000 `to_json` calls on a one-element object-dtype Series).

Also adds the missing NULL check on `PyArray_DescrFromScalar` before the `dtype->type_num` dereference just below it, and routes both error exits in that branch through the `INVALID` label like every other error exit in the function. They returned with `tc->type` unset, which `encode` reads out of an otherwise uninitialized stack struct, and they skipped the cleanup that releases the type context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjbJu6Y1uzUCMVVdzRKxBL
