### PR TITLE
BUG: read_csv ignored an allocation failure when building the skiprows set

### DIFF
--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -768,7 +768,8 @@ cdef class TextReader:
             parser_set_skipfirstnrows(self.parser, self.skiprows)
         elif not callable(self.skiprows):
             for i in self.skiprows:
-                parser_add_skiprow(self.parser, i)
+                if parser_add_skiprow(self.parser, i) != 0:
+                    raise MemoryError()
         else:
             self.parser.skipfunc = <PyObject *>self.skiprows
 

--- a/pandas/_libs/src/parser/tokenizer.cpp
+++ b/pandas/_libs/src/parser/tokenizer.cpp
@@ -573,6 +573,9 @@ int parser_add_skiprow(parser_t *self, int64_t row) {
 
   if (self->skipset == NULL) {
     self->skipset = (void *)kh_init_int64();
+    if (self->skipset == NULL) {
+      return -1;
+    }
   }
 
   set = (kh_int64_t *)self->skipset;


### PR DESCRIPTION
Found by a static-analysis pass over the hand-written C/C++ in `_libs`.

`parser_add_skiprow` allocates the skipset with `kh_init_int64()` and uses the result without checking it, so an allocation failure is dereferenced on the next line. The `TextReader` caller also discarded the return value.

Return `-1` on the failure and raise `MemoryError` from the caller.

Not directly testable -- it only triggers under allocation failure -- so there is no test and no whatsnew entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjbJu6Y1uzUCMVVdzRKxBL
