### PR TITLE
BUG: parse_iso_8601_datetime read an indeterminate pointer on a negative length

### DIFF
--- a/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
+++ b/pandas/_libs/src/vendored/numpy/datetime/np_datetime_strings.c
@@ -113,12 +113,16 @@ int parse_iso_8601_datetime(const char *str, int len, int want_exc,
                             int *out_tzoffset, const char *format,
                             int format_len,
                             FormatRequirement format_requirement) {
-  if (len < 0 || format_len < 0)
-    goto parse_error;
   int year_leap = 0;
   int i, numdigits;
-  const char *substr;
+  const char *substr = str;
   int sublen;
+
+  // Must come *after* substr is initialized: parse_error reports the failing
+  // position as `substr - str`, and jumping into substr's scope would skip its
+  // initializer, leaving that subtraction reading an indeterminate pointer.
+  if (len < 0 || format_len < 0)
+    goto parse_error;
   NPY_DATETIMEUNIT bestunit = NPY_FR_GENERIC;
   DatetimePartParseResult comparison;
 


### PR DESCRIPTION
Found by the clang static analyzer over the hand-written C in `_libs`.

The negative-length guard sits above the declaration of `substr`, so its `goto parse_error` jumps into `substr`'s scope and skips the initializer. `parse_error` then reports the failing position as `substr - str`, reading an indeterminate pointer.

The guard cannot simply gain an initializer in place -- the jump would still skip it -- so it has to move below the declaration. Hence the slightly odd-looking hunk, which the comment explains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjbJu6Y1uzUCMVVdzRKxBL
