### PR TITLE
CI: collapse the UBSan suppression list to a glob

### DIFF
--- a/ci/suppressions/ubsan.txt
+++ b/ci/suppressions/ubsan.txt
@@ -1,28 +1,18 @@
-# UBSan suppressions.
-#
 # Entries are matched as a substring of the source path UBSan reports, which is
 # the Cython-generated C file inside meson's private build directory. Meson does
 # not guarantee the layout of that directory (1.12.0 stopped mirroring the source
 # tree inside it), so these match on the file name only (GH#66805).
 #
-# What is being suppressed is `function` (call through a pointer of the wrong
-# type) in Cython-generated C. Cython implements cdef-class inheritance by
-# storing a subclass override in a vtable slot typed for the base class, e.g.
-# in index.pyx.c:
+# Suppressed is `function` (call through a pointer of the wrong type) in
+# Cython-generated C. Cython implements cdef-class inheritance by storing a
+# subclass override in a vtable slot typed for the base class, so every virtual
+# dispatch is a genuine type mismatch; CyFunction wrapper dispatch (__pyx_pw_*)
+# trips the same check. Neither is fixable in pandas source -- it would take a
+# Cython codegen change -- and a full-suite run with these suppressions removed
+# reports nothing else: 181 reports, 31 sites, all of them this.
 #
-#   __pyx_vtable_...ObjectEngine.__pyx_base._make_hash_table =
-#       (PyObject *(*)(struct __pyx_obj_...IndexEngine *, Py_ssize_t))
-#           __pyx_f_...12ObjectEngine__make_hash_table;
-#
-# so every virtual dispatch is a genuine type mismatch. Cython's CyFunction
-# wrapper dispatch (__pyx_pw_*) trips the same check. Neither is fixable in
-# pandas source -- it would take a codegen change in Cython -- and a full-suite
-# run with these suppressions removed reports nothing else: 181 reports, 31
-# sites, all of them this.
-#
-# The glob covers every generated module, so no entry has to be added when a
-# .pyx is added or renamed, and it cannot go inert if meson moves the file
-# again. Matching only the generated file names keeps the check fully active
-# for the hand-written C/C++ (tokenizer, ujson, np_datetime, khash).
+# The glob means no entry has to be added when a .pyx is added or renamed, and
+# matching only the generated file names keeps the check fully active for the
+# hand-written C/C++ (tokenizer, ujson, np_datetime, khash).
 function:*.pyx.c
 function:_cyutility.c

--- a/ci/suppressions/ubsan.txt
+++ b/ci/suppressions/ubsan.txt
@@ -1,20 +1,28 @@
+# UBSan suppressions.
+#
 # Entries are matched as a substring of the source path UBSan reports, which is
 # the Cython-generated C file inside meson's private build directory. Meson does
 # not guarantee the layout of that directory (1.12.0 stopped mirroring the source
-# tree inside it), so match on the file name only.
+# tree inside it), so these match on the file name only (GH#66805).
+#
+# What is being suppressed is `function` (call through a pointer of the wrong
+# type) in Cython-generated C. Cython implements cdef-class inheritance by
+# storing a subclass override in a vtable slot typed for the base class, e.g.
+# in index.pyx.c:
+#
+#   __pyx_vtable_...ObjectEngine.__pyx_base._make_hash_table =
+#       (PyObject *(*)(struct __pyx_obj_...IndexEngine *, Py_ssize_t))
+#           __pyx_f_...12ObjectEngine__make_hash_table;
+#
+# so every virtual dispatch is a genuine type mismatch. Cython's CyFunction
+# wrapper dispatch (__pyx_pw_*) trips the same check. Neither is fixable in
+# pandas source -- it would take a codegen change in Cython -- and a full-suite
+# run with these suppressions removed reports nothing else: 181 reports, 31
+# sites, all of them this.
+#
+# The glob covers every generated module, so no entry has to be added when a
+# .pyx is added or renamed, and it cannot go inert if meson moves the file
+# again. Matching only the generated file names keeps the check fully active
+# for the hand-written C/C++ (tokenizer, ujson, np_datetime, khash).
+function:*.pyx.c
 function:_cyutility.c
-function:/algos.pyx.c
-function:/hashtable.pyx.c
-function:/index.pyx.c
-function:/internals.pyx.c
-function:/interval.pyx.c
-function:/lib.pyx.c
-function:/missing.pyx.c
-function:/ops.pyx.c
-function:/sparse.pyx.c
-function:/np_datetime.pyx.c
-function:/offsets.pyx.c
-function:/period.pyx.c
-function:/timedeltas.pyx.c
-function:/timezones.pyx.c
-function:/vectorized.pyx.c


### PR DESCRIPTION
The list carries one entry per Cython-generated module, so it needs an edit whenever a `.pyx` is added or renamed.

Everything it suppresses is the same thing: Cython implements cdef-class inheritance by storing a subclass override in a vtable slot typed for the base class, e.g. in `index.pyx.c`:

```c
__pyx_vtable_...ObjectEngine.__pyx_base._make_hash_table =
    (PyObject *(*)(struct __pyx_obj_...IndexEngine *, Py_ssize_t))
        __pyx_f_...12ObjectEngine__make_hash_table;
```

so every virtual dispatch is a genuine `function` type mismatch; CyFunction wrapper dispatch (`__pyx_pw_*`) trips the same check. Neither is fixable in pandas source -- it would take a Cython codegen change. A full-suite run with the suppressions removed reports 181 of these across 31 sites, in exactly the 16 files that were listed, and nothing else.

So this replaces the list with `function:*.pyx.c` plus the existing `_cyutility.c`. It is strictly more permissive than the per-file entries -- it matches the file-name tail regardless of directory, which is what GH-66805 was about -- and it keeps the check fully active for the hand-written C/C++ (tokenizer, ujson, np_datetime, khash).

Verified with controls: a bogus pattern lets the reports through, the real pattern suppresses them. Local meson is 1.10.1, so I could not reproduce 1.12.0's flat private-directory layout; the glob is layout-independent by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QEeCytmj9R6Brswu4Chyu
