### PR TITLE
CI: run extra UBSan checks on the hand-written C/C++ sources

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -400,6 +400,7 @@ jobs:
             -- \
             -Csetup-args="-Dbuildtype=debugoptimized" \
             -Csetup-args="-Db_sanitize=address,undefined" \
+            -Csetup-args="-Dstrict_c_sanitize=true" \
             -Csetup-args="-Db_lundef=false"
 
       - name: Get Sanitizer Path

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,6 @@
+option(
+    'strict_c_sanitize',
+    type: 'boolean',
+    value: false,
+    description: 'Enable UBSan checks beyond the default `undefined` set on the hand-written C/C++ sources. Cython-generated code is excluded because its codegen would drown the results in noise. Only meaningful together with -Db_sanitize=undefined.',
+)

--- a/pandas/_libs/meson.build
+++ b/pandas/_libs/meson.build
@@ -50,6 +50,20 @@ _khash_primitive_helper_dep = declare_dependency(
     sources: _khash_primitive_helper,
 )
 
+# Extra UBSan checks for the hand-written C/C++ sources. These cannot be turned
+# on globally: Cython's generated code trips `function` on every cdef-class
+# vtable dispatch and narrows integers freely, so the results would be pure
+# noise. The targets below contain no Cython output, so they can be held to a
+# stricter standard than the default `undefined` set.
+strict_c_args = []
+if get_option('strict_c_sanitize')
+    strict_c_args = cc.get_supported_arguments(
+        '-fsanitize=implicit-integer-truncation',
+        '-fsanitize=implicit-integer-sign-change',
+        '-fsanitize=local-bounds',
+    )
+endif
+
 m_dep = cc.find_library('m', required: false)
 fast_float = subproject('fast_float')
 fast_float_dep = fast_float.get_variable('fast_float_dep')
@@ -67,6 +81,8 @@ tokenizer_lib = static_library(
     'src/parser/tokenizer.cpp',
     include_directories: [inc_pd, simd_config_inc],
     dependencies: [fast_float_dep, py.dependency()],
+    c_args: strict_c_args,
+    cpp_args: strict_c_args,
 )
 
 tokenizer_dep = declare_dependency(
@@ -120,6 +136,7 @@ libs_sources = {
             'src/datetime/date_conversions.c',
             'src/datetime/pd_datetime.c',
         ],
+        'c_args': strict_c_args,
     },
     'pandas_parser': {
         'sources': [
@@ -127,6 +144,7 @@ libs_sources = {
             'src/parser/pd_parser.c',
         ],
         'deps': [tokenizer_dep],
+        'c_args': strict_c_args,
     },
     'parsers': {
         'sources': [
@@ -144,6 +162,7 @@ libs_sources = {
             'src/vendored/ujson/lib/ultrajsondec.c',
         ],
         'deps': [m_dep],
+        'c_args': strict_c_args,
     },
     'ops': {'sources': ['ops.pyx']},
     'ops_dispatch': {'sources': ['ops_dispatch.pyx']},
@@ -177,6 +196,7 @@ foreach ext_name, ext_dict : libs_sources
         ext_name,
         ext_dict.get('sources'),
         cython_args: cython_args,
+        c_args: ext_dict.get('c_args', []),
         include_directories: [inc_np, inc_pd],
         dependencies: ext_dict.get('deps', []),
         subdir: 'pandas/_libs',

--- a/pandas/_libs/simd/meson.build
+++ b/pandas/_libs/simd/meson.build
@@ -24,6 +24,7 @@ moments_lib = static_library(
     'moments_@0@.cpp'.format(simd_target),
     include_directories: [inc_pd],
     dependencies: [xsimd_dep],
+    cpp_args: strict_c_args,
 )
 
 moments_simd_dep = declare_dependency(

--- a/pandas/_libs/src/vendored/ujson/lib/ultrajsondec.c
+++ b/pandas/_libs/src/vendored/ujson/lib/ultrajsondec.c
@@ -135,7 +135,7 @@ JSOBJ FASTCALL_MSVC decode_numeric(struct DecoderState *ds) {
   } else if (*(offset) == '-') {
     offset++;
     intNeg = -1;
-    overflowLimit = LLONG_MIN;
+    overflowLimit = (JSUINT64)LLONG_MIN;
     if (*(offset) == 'I') {
       goto DECODE_INF;
     }
@@ -200,9 +200,9 @@ BREAK_INT_LOOP:
   if (intNeg == 1 && (intValue & 0x8000000000000000ULL) != 0)
     return ds->dec->newUnsignedLong(ds->prv, intValue);
   else if ((intValue >> 31))
-    return ds->dec->newLong(ds->prv, (JSINT64)(intValue * (JSINT64)intNeg));
+    return ds->dec->newLong(ds->prv, (JSINT64)(intValue * (JSUINT64)intNeg));
   else
-    return ds->dec->newInt(ds->prv, (JSINT32)(intValue * intNeg));
+    return ds->dec->newInt(ds->prv, (JSINT32)(intValue * (JSUINT64)intNeg));
 
 DECODE_FRACTION:
 
@@ -823,7 +823,7 @@ JSOBJ FASTCALL_MSVC decode_string(struct DecoderState *ds) {
           case '7':
           case '8':
           case '9':
-            sur[iSur] = (sur[iSur] << 4) + (JSUTF16)(*inputOffset - '0');
+            sur[iSur] = (JSUTF16)((sur[iSur] << 4) + (*inputOffset - '0'));
             break;
 
           case 'a':
@@ -832,7 +832,7 @@ JSOBJ FASTCALL_MSVC decode_string(struct DecoderState *ds) {
           case 'd':
           case 'e':
           case 'f':
-            sur[iSur] = (sur[iSur] << 4) + 10 + (JSUTF16)(*inputOffset - 'a');
+            sur[iSur] = (JSUTF16)((sur[iSur] << 4) + 10 + (*inputOffset - 'a'));
             break;
 
           case 'A':
@@ -841,7 +841,7 @@ JSOBJ FASTCALL_MSVC decode_string(struct DecoderState *ds) {
           case 'D':
           case 'E':
           case 'F':
-            sur[iSur] = (sur[iSur] << 4) + 10 + (JSUTF16)(*inputOffset - 'A');
+            sur[iSur] = (JSUTF16)((sur[iSur] << 4) + 10 + (*inputOffset - 'A'));
             break;
           }
 


### PR DESCRIPTION
`-Db_sanitize=undefined` applies to the whole project, and Cython's generated code trips `function` on every cdef-class vtable dispatch and narrows integers freely, so checks beyond the default `undefined` set cannot be turned on globally without drowning the results in noise.

This adds a `strict_c_sanitize` build option (default off) that adds `implicit-integer-truncation`, `implicit-integer-sign-change` and `local-bounds` to the targets that contain no Cython output, and turns it on in the sanitizer CI job.

Verified from `compile_commands.json` with the option on: exactly 14 sources get the flags -- `tokenizer.cpp`, `fast_float_wrappers.cpp`, `io.c`, `pd_parser.c`, `np_datetime.c`, `np_datetime_strings.c`, `date_conversions.c`, `pd_datetime.c`, the five ujson files, and `moments_neon.cpp` -- and no `.pyx.c` or `_cyutility.c` does. The build compiles and links cleanly with the option on both with and without `-Db_sanitize`.

The `ultrajsondec.c` casts ride along because they are what the new checks were reporting; without them the sanitizer job would go red the moment the flag is set.

### Notes for review

- This is a CI-liability change more than a correctness one. It is worth deciding whether `local-bounds` in particular earns its place -- it is not part of `undefined` and is optimization-dependent.
- `src/parser/io.c` is compiled twice: once into `pandas_parser` (flagged) and once into the `parsers` extension (not flagged, since adding `c_args` there would also flag the generated `parsers.pyx.c`). The flagged copy is what gets checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjbJu6Y1uzUCMVVdzRKxBL
