### PR TITLE
ENH: name the offending intervals when left > right (GH#66807)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -48,6 +48,7 @@ Other enhancements
 - Added reduction methods as public API on pandas-implemented extension arrays where applicable (:issue:`63512`)
 - Building from source no longer fails on a checkout with CRLF line endings, such as under WSL (:issue:`64272`)
 - Display formatting for float sequences in DataFrame cells now respects the ``display.precision`` option (:issue:`60503`).
+- Improved the error message raised when constructing an :class:`IntervalIndex` or :class:`arrays.IntervalArray` with a left side greater than the right side, which now shows the offending intervals and their positions (:issue:`66807`)
 - Improved the precision of float parsing in :func:`read_csv` (:issue:`64395`)
 - Improved the string ``repr`` of :class:`pd.core.arrays.SparseArray` (:issue:`64547`)
 - Improved type inference of comparison and arithmetic operators on :class:`Series` and :class:`DataFrame` for static type checkers (e.g. ``ser == "a"`` is now inferred as :class:`Series` instead of ``Any``) (:issue:`40762`)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -619,7 +619,19 @@ class IntervalArray(IntervalMixin, ExtensionArray):
             )
             raise ValueError(msg)
         if not (left[left_mask] <= right[left_mask]).all():
-            msg = "left side of interval must be <= right side"
+            # GH#66807 point at the offending intervals
+            invalid = left_mask.copy()
+            invalid[left_mask] = left[left_mask] > right[left_mask]
+            positions = np.flatnonzero(invalid)
+            examples = ", ".join(
+                f"{pos}: ({left[pos]}, {right[pos]})" for pos in positions[:5]
+            )
+            if len(positions) > 5:
+                examples += f", ... ({len(positions) - 5} more)"
+            msg = (
+                "left side of interval must be <= right side; offending "
+                f"intervals (position: interval): {examples}"
+            )
             raise ValueError(msg)
 
     def _shallow_copy(self, left, right) -> Self:

--- a/pandas/tests/indexes/interval/test_constructors.py
+++ b/pandas/tests/indexes/interval/test_constructors.py
@@ -1,5 +1,6 @@
 from functools import partial
 from itertools import pairwise
+import re
 
 import numpy as np
 import pytest
@@ -522,3 +523,28 @@ def test_ea_dtype(dtype):
     assert result.dtype == interval_dtype
     expected = pd.IntervalIndex.from_tuples(bins, closed="left").astype(interval_dtype)
     tm.assert_index_equal(result, expected)
+
+
+def test_left_gt_right_message():
+    # GH#66807 the message points at the offending intervals, with positions
+    #  relative to the full arrays, not to the non-NA subset
+    left = [np.nan, 5, 7, 1]
+    right = [np.nan, 2, 3, 4]
+    msg = re.escape(
+        "left side of interval must be <= right side; offending intervals "
+        "(position: interval): 1: (5.0, 2.0), 2: (7.0, 3.0)"
+    )
+    with pytest.raises(ValueError, match=msg):
+        pd.IntervalIndex.from_arrays(left, right)
+
+
+def test_left_gt_right_message_truncated():
+    # GH#66807 at most 5 offenders are shown
+    breaks = range(10, -1, -1)
+    msg = re.escape(
+        "left side of interval must be <= right side; offending intervals "
+        "(position: interval): 0: (10, 9), 1: (9, 8), 2: (8, 7), 3: (7, 6), "
+        "4: (6, 5), ... (5 more)"
+    )
+    with pytest.raises(ValueError, match=msg):
+        pd.IntervalIndex.from_breaks(breaks)


### PR DESCRIPTION
closes #66807

`IntervalArray._validate` raised a bare `left side of interval must be <= right side`, so on a long array the user has to go find the invalid intervals themselves. It now names up to five of them with their positions:

```
>>> pd.IntervalIndex.from_arrays([np.nan, 5, 7, 1], [np.nan, 2, 3, 4])
ValueError: left side of interval must be <= right side; offending intervals (position: interval): 1: (5.0, 2.0), 2: (7.0, 3.0)

>>> pd.IntervalIndex.from_breaks(range(10, -1, -1))
ValueError: left side of interval must be <= right side; offending intervals (position: interval): 0: (10, 9), 1: (9, 8), 2: (8, 7), 3: (7, 6), 4: (6, 5), ... (5 more)
```

Positions are computed against the full arrays rather than the `notna`-filtered subset, so they stay correct when the input has missing values (the first example above). Everything added is on the error path, so valid construction is unaffected.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix, tests and whatsnew entry; verified locally across numpy, masked, pyarrow-backed, datetime64/tz and timedelta64 subtypes.
