### PR TITLE
BUG: stacked bar subplots raise IndexError when a single-column group comes first

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -824,6 +824,7 @@ Period
 Plotting
 ^^^^^^^^
 - Bug in :meth:`DataFrame.plot.bar` and :meth:`DataFrame.plot.barh` raising ``AttributeError`` for a regularly-spaced :class:`DatetimeIndex` whose ``freq`` attribute is unset (:issue:`66771`)
+- Bug in :meth:`DataFrame.plot.bar` with ``stacked=True`` raising ``IndexError`` when a ``subplots`` group of a single column was listed before a group of several columns (:issue:`67726`)
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
 - Bug in :meth:`DataFrame.plot` and :meth:`Series.plot` with ``secondary_y`` hiding the primary y-axis when the data already on the axes was drawn as a collection rather than as lines, e.g. by :meth:`DataFrame.plot.scatter` (:issue:`66789`)
 - Bug in :meth:`Series.plot`, :meth:`DataFrame.plot`, :meth:`DataFrame.plot.scatter`, :meth:`Series.hist`, :meth:`DataFrame.hist`, :func:`plotting.lag_plot` and :func:`plotting.parallel_coordinates` with timezone-aware data labelling the axis in UTC instead of in the data's own timezone (:issue:`64613`)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -2006,11 +2006,16 @@ class BarPlot(MPLPlot):
 
         if not isinstance(self.subplots, bool):
             if bool(self.subplots) and self.stacked:
-                for i, sub_plot in enumerate(self.subplots):
+                for sub_plot in self.subplots:
                     if len(sub_plot) <= 1:
                         continue
+                    # Index into `_stacked_subplots_offsets`, which only gains
+                    # an entry for groups that are actually stacked. Enumerating
+                    # `self.subplots` instead would skip a position for every
+                    # single-column group (GH#67726).
+                    offset_index = len(_stacked_subplots_offsets)
                     for plot in sub_plot:
-                        _stacked_subplots_ind[int(plot)] = i
+                        _stacked_subplots_ind[int(plot)] = offset_index
                     _stacked_subplots_offsets.append((pos_prior, neg_prior))
 
         for i, (label, y) in enumerate(self._iter_data(data=data)):

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -826,6 +826,26 @@ def test_bar_2_subplot_1_double_stacked(df_bar_data, df_bar_df, columns_used):
 
 
 @pytest.mark.parametrize(
+    "columns_used", [["A", "B", "C"], ["A", "C", "B"], ["D", "A", "C"]]
+)
+def test_bar_2_subplot_single_column_first_stacked(
+    df_bar_data, df_bar_df, columns_used
+):
+    # GH#67726 a single-column group ahead of a stacked group used to raise IndexError,
+    # because the offsets list only gains an entry for groups that are actually stacked.
+    df_bar_df_trimmed = df_bar_df[columns_used]
+    subplot_division = [(columns_used[0],), (columns_used[1], columns_used[2])]
+    ax = df_bar_df_trimmed.plot(subplots=subplot_division, kind="bar", stacked=True)
+    subplot_data_df_list = _df_bar_xyheight_from_ax_helper(
+        df_bar_data, ax, subplot_division
+    )
+    for i in range(len(subplot_data_df_list)):
+        _df_bar_subplot_checker(
+            df_bar_data, df_bar_df_trimmed, subplot_data_df_list[i], subplot_division[i]
+        )
+
+
+@pytest.mark.parametrize(
     "subplot_division",
     [
         [("A", "B"), ("C", "D")],


### PR DESCRIPTION
- [x] closes #67726
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file

Reopening the earlier PR was not possible once the bot had closed it, so this replaces it. The issue is now assigned to me.

Still reproduces on `main` as of `5c91b22f0a`:

```python
import matplotlib
matplotlib.use("Agg")
import pandas as pd

df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1, 2, 3, 4], "c": [1, 1, 1, 1]})

df.plot(kind="bar", stacked=True, subplots=[["b", "c"], ["a"]], sharex=True)  # works
df.plot(kind="bar", stacked=True, subplots=[["a"], ["b", "c"]], sharex=True)  # IndexError
```

```
IndexError: list index out of range
```

## Cause

`BarPlot._make_plot` keeps two structures for stacked subplots:

- `_stacked_subplots_ind` maps a column position to a slot in the offsets list
- `_stacked_subplots_offsets` holds the running positive/negative stack heights

The offsets list only gains an entry for groups that hold more than one column, since a single-column group has nothing to stack onto. The index stored in `_stacked_subplots_ind`, though, came from `enumerate(self.subplots)`, which keeps counting through the groups that were skipped:

```python
for i, sub_plot in enumerate(self.subplots):
    if len(sub_plot) <= 1:
        continue
    for plot in sub_plot:
        _stacked_subplots_ind[int(plot)] = i          # position in self.subplots
    _stacked_subplots_offsets.append((pos_prior, neg_prior))   # appended at a different index
```

So the two indices agree only while no single-column group has been skipped yet, which is why the failure depends on ordering:

| `subplots` | stored index | offsets slot | result |
| --- | --- | --- | --- |
| `[["b", "c"], ["a"]]` | 0 | 0 | happens to line up |
| `[["a"], ["b", "c"]]` | 1 | 0 | `IndexError` |

The later `_stacked_subplots_offsets[offset_index]` lookup then runs off the end of the list.

## Fix

Store the index into `_stacked_subplots_offsets` itself rather than the position within `self.subplots`, so the mapping holds for any group ordering:

```python
offset_index = len(_stacked_subplots_offsets)
for plot in sub_plot:
    _stacked_subplots_ind[int(plot)] = offset_index
_stacked_subplots_offsets.append((pos_prior, neg_prior))
```

## Testing

`test_bar_2_subplot_single_column_first_stacked` mirrors the existing `test_bar_2_subplot_1_double_stacked` with the single-column group moved to the front, and reuses the same `_df_bar_subplot_checker` helper, so it verifies the resulting bar heights and stacking offsets rather than only the absence of an exception.

It fails on `main` for all three parametrisations with the `IndexError` above, and passes with the fix.

```
pytest pandas/tests/plotting/test_misc.py -k single_column_first   ->  3 passed
   (with the fix reverted:                                              3 failed)
pytest pandas/tests/plotting/                                      ->  1502 passed, 11 skipped, 10 xfailed
ruff check / ruff format --check                                   ->  clean
```

I also checked #67727, filed alongside this one by the same reporter: that is a separate problem in the non-stacked grouping path and is not addressed here.

Everything in this PR was reviewed manually by me. Claude Opus 5, via Claude Code, was used to draft the change, the test and this description.
