### PR TITLE
[fix] 66203 : use loop instead of numpy scaffolding

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -310,6 +310,7 @@ Performance improvements
 - Performance improvement in :class:`.DataFrameGroupBy` aggregations (``sum``, ``mean``, ``min``, ``max``, ``prod``) when the grouping keys are already sorted (:issue:`65103`)
 - Performance improvement in :class:`.DataFrameGroupBy` and :class:`.SeriesGroupBy` reductions for :class:`ArrowDtype` decimal columns (``sum``, ``prod``, ``min``, ``max``, ``mean``, ``var``) and for Arrow-backed string columns (``min``, ``max``), i.e. :class:`ArrowDtype` and :class:`StringDtype` with ``storage="pyarrow"``, by dispatching to PyArrow's native ``group_by`` instead of a slower fallback (:issue:`63416`)
 - Performance improvement in :class:`.DataFrameGroupBy` and :class:`.SeriesGroupBy` with ``sort=True``, as well as :func:`factorize` and :func:`merge` with ``sort=True``, when the keys are integers with many unique values (:issue:`66129`)
+- Performance improvement in :meth:`DataFrame.apply` with ``raw=True`` and the default ``engine="python"`` by avoiding :func:`numpy.apply_along_axis`'s generic N-dimensional overhead (:issue:`66203`)
 - Performance improvement in casting integer and boolean dtypes to ``string[pyarrow]`` by using PyArrow's native cast instead of element-wise conversion (:issue:`56505`)
 - Performance improvement in :meth:`DataFrame.__getitem__` when selecting a
   single column by label on a :class:`DataFrame` with duplicate column names.

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1218,31 +1218,27 @@ class FrameApply(NDFrameApply):
             result = nb_looper(self.values, self.axis, *args)
             # If we made the result 2-D, squeeze it back to 1-D
             result = np.squeeze(result)
+        # values is always 2-D, so avoid np.apply_along_axis: its
+        # generic N-D machinery (dynamic coordinate tuples,
+        # slice-by-slice writes, and inferring the output dtype from
+        # only the first call) adds substantial Python-level overhead
+        # here, and that first-call dtype probe can even silently
+        # truncate later, longer string results (GH#35940,
+        # https://github.com/numpy/numpy/issues/8352). Applying the
+        # function ourselves and letting np.array infer the result's
+        # shape/dtype from *all* the results at once sidesteps both.
+        elif self.axis == 0:
+            # np.apply_along_axis with axis=0 stacks per-slice results
+            # along axis 0 of the output; iterating self.values.T
+            # naturally stacks them along axis 1 instead, so transpose
+            # back to match.
+            result = np.array(
+                [self.func(col, *self.args, **self.kwargs) for col in self.values.T]
+            ).T
         else:
-            # values is always 2-D, so avoid np.apply_along_axis: its
-            # generic N-D machinery (dynamic coordinate tuples,
-            # slice-by-slice writes, and inferring the output dtype from
-            # only the first call) adds substantial Python-level overhead
-            # here, and that first-call dtype probe can even silently
-            # truncate later, longer string results (GH#35940,
-            # https://github.com/numpy/numpy/issues/8352). Applying the
-            # function ourselves and letting np.array infer the result's
-            # shape/dtype from *all* the results at once sidesteps both.
-            if self.axis == 0:
-                # np.apply_along_axis with axis=0 stacks per-slice results
-                # along axis 0 of the output; iterating self.values.T
-                # naturally stacks them along axis 1 instead, so transpose
-                # back to match.
-                result = np.array(
-                    [
-                        self.func(col, *self.args, **self.kwargs)
-                        for col in self.values.T
-                    ]
-                ).T
-            else:
-                result = np.array(
-                    [self.func(row, *self.args, **self.kwargs) for row in self.values]
-                )
+            result = np.array(
+                [self.func(row, *self.args, **self.kwargs) for row in self.values]
+            )
 
         # TODO: mixed type case
         if result.ndim == 2:

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1200,21 +1200,6 @@ class FrameApply(NDFrameApply):
     def apply_raw(self, engine="python", engine_kwargs=None):
         """apply to the values as a numpy array"""
 
-        def wrap_function(func):
-            """
-            Wrap user supplied function to work around numpy issue.
-
-            see https://github.com/numpy/numpy/issues/8352
-            """
-
-            def wrapper(*args, **kwargs):
-                result = func(*args, **kwargs)
-                if isinstance(result, str):
-                    result = np.array(result, dtype=object)
-                return result
-
-            return wrapper
-
         if engine == "numba":
             args, kwargs = prepare_function_arguments(
                 self.func,  # type: ignore[arg-type]
@@ -1234,13 +1219,30 @@ class FrameApply(NDFrameApply):
             # If we made the result 2-D, squeeze it back to 1-D
             result = np.squeeze(result)
         else:
-            result = np.apply_along_axis(
-                wrap_function(self.func),
-                self.axis,
-                self.values,
-                *self.args,
-                **self.kwargs,
-            )
+            # values is always 2-D, so avoid np.apply_along_axis: its
+            # generic N-D machinery (dynamic coordinate tuples,
+            # slice-by-slice writes, and inferring the output dtype from
+            # only the first call) adds substantial Python-level overhead
+            # here, and that first-call dtype probe can even silently
+            # truncate later, longer string results (GH#35940,
+            # https://github.com/numpy/numpy/issues/8352). Applying the
+            # function ourselves and letting np.array infer the result's
+            # shape/dtype from *all* the results at once sidesteps both.
+            if self.axis == 0:
+                # np.apply_along_axis with axis=0 stacks per-slice results
+                # along axis 0 of the output; iterating self.values.T
+                # naturally stacks them along axis 1 instead, so transpose
+                # back to match.
+                result = np.array(
+                    [
+                        self.func(col, *self.args, **self.kwargs)
+                        for col in self.values.T
+                    ]
+                ).T
+            else:
+                result = np.array(
+                    [self.func(row, *self.args, **self.kwargs) for row in self.values]
+                )
 
         # TODO: mixed type case
         if result.ndim == 2:

--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1228,16 +1228,18 @@ class FrameApply(NDFrameApply):
         # function ourselves and letting np.array infer the result's
         # shape/dtype from *all* the results at once sidesteps both.
         elif self.axis == 0:
+            func = cast("Callable", self.func)
             # np.apply_along_axis with axis=0 stacks per-slice results
             # along axis 0 of the output; iterating self.values.T
             # naturally stacks them along axis 1 instead, so transpose
             # back to match.
             result = np.array(
-                [self.func(col, *self.args, **self.kwargs) for col in self.values.T]
+                [func(col, *self.args, **self.kwargs) for col in self.values.T]
             ).T
         else:
+            func = cast("Callable", self.func)
             result = np.array(
-                [self.func(row, *self.args, **self.kwargs) for row in self.values]
+                [func(row, *self.args, **self.kwargs) for row in self.values]
             )
 
         # TODO: mixed type case

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -390,11 +390,26 @@ def test_apply_raw_float_frame_lambda(float_frame, axis, engine):
     tm.assert_series_equal(result, expected)
 
 
-def test_apply_raw_float_frame_no_reduction(float_frame, engine):
+@pytest.mark.parametrize("axis", [0, 1])
+def test_apply_raw_float_frame_no_reduction(float_frame, axis, engine):
     # no reduction
-    result = float_frame.apply(lambda x: x * 2, engine=engine, raw=True)
+    result = float_frame.apply(lambda x: x * 2, axis=axis, engine=engine, raw=True)
     expected = float_frame * 2
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+def test_apply_raw_array_return_matches_apply_along_axis(axis, engine):
+    # GH#66203 raw=True's fast path (replacing np.apply_along_axis) must
+    #  preserve its shape convention for functions returning an array per
+    #  slice, in particular the axis=0 transpose.
+    if engine == "numba":
+        pytest.skip("numba engine raw path uses a different mechanism")
+    df = DataFrame(np.arange(12).reshape(3, 4), dtype="int64")
+    func = lambda x: x[::-1]
+    result = df.apply(func, axis=axis, engine=engine, raw=True)
+    expected = np.apply_along_axis(func, axis, df.to_numpy())
+    tm.assert_numpy_array_equal(result.to_numpy(), expected)
 
 
 @pytest.mark.parametrize("axis", [0, 1])

--- a/pandas/tests/apply/test_frame_apply.py
+++ b/pandas/tests/apply/test_frame_apply.py
@@ -405,7 +405,7 @@ def test_apply_raw_array_return_matches_apply_along_axis(axis, engine):
     #  slice, in particular the axis=0 transpose.
     if engine == "numba":
         pytest.skip("numba engine raw path uses a different mechanism")
-    df = DataFrame(np.arange(12).reshape(3, 4), dtype="int64")
+    df = pd.DataFrame(np.arange(12).reshape(3, 4), dtype="int64")
     func = lambda x: x[::-1]
     result = df.apply(func, axis=axis, engine=engine, raw=True)
     expected = np.apply_along_axis(func, axis, df.to_numpy())


### PR DESCRIPTION
- [x] closes #66203  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
