### PR TITLE
CLN: remove no longer used `allow_object` return path in objects_to_datetime64

### DIFF
--- a/pandas/_libs/tslib.pyi
+++ b/pandas/_libs/tslib.pyi
@@ -21,10 +21,7 @@ def array_to_datetime(
     creso: int = ...,
     unit_for_numerics: str | None = ...,
     warned_quarter: bool = ...,
-) -> tuple[np.ndarray, tzinfo | None]: ...
-
-# returned ndarray may be object dtype or datetime64[ns]
-
+) -> tuple[npt.NDArray[np.datetime64], tzinfo | None]: ...
 def array_to_datetime_with_tz(
     values: npt.NDArray[np.object_],
     tz: tzinfo,
@@ -32,4 +29,4 @@ def array_to_datetime_with_tz(
     yearfirst: bool,
     creso: int,
     warned_quarter: bool = ...,
-) -> npt.NDArray[np.int64]: ...
+) -> npt.NDArray[np.datetime64]: ...

--- a/pandas/_libs/tslib.pyx
+++ b/pandas/_libs/tslib.pyx
@@ -374,10 +374,7 @@ cpdef array_to_datetime(
     bint warned_quarter=False,
 ):
     """
-    Converts a 1D array of date-like values to a numpy array of either:
-        1) datetime64[ns] data
-        2) datetime.datetime objects, if OutOfBoundsDatetime or TypeError
-           is encountered
+    Converts a 1D array of date-like values to a numpy array of datetime64 data.
 
     Also returns a fixed-offset tzinfo object if an array of strings with the same
     timezone offset is passed and utc=True is not passed. Otherwise, None
@@ -408,7 +405,7 @@ cpdef array_to_datetime(
     Returns
     -------
     np.ndarray
-        May be datetime64[creso_unit] or object dtype
+        datetime64[creso_unit] dtype
     tzinfo or None
     """
     cdef:
@@ -583,9 +580,9 @@ cpdef array_to_datetime(
             if is_coerce:
                 iresult[i] = NPY_NAT
                 continue
-            elif is_raise:
+            else:
+                # is_raise
                 raise
-            return values, None
 
     tz_out = state.check_for_mixed_inputs(tz_out, utc)
 

--- a/pandas/_libs/tslibs/strptime.pyi
+++ b/pandas/_libs/tslibs/strptime.pyi
@@ -1,3 +1,5 @@
+from datetime import tzinfo
+
 import numpy as np
 
 from pandas._typing import npt
@@ -9,6 +11,4 @@ def array_strptime(
     errors: str = ...,
     utc: bool = ...,
     creso: int = ...,  # NPY_DATETIMEUNIT
-) -> tuple[np.ndarray, np.ndarray]: ...
-
-# first ndarray is M8[ns], second is object ndarray of tzinfo | None
+) -> tuple[npt.NDArray[np.datetime64], tzinfo | None]: ...

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -644,9 +644,9 @@ def array_strptime(
             if is_coerce:
                 iresult[i] = NPY_NAT
                 continue
-            elif is_raise:
+            else:
+                # is_raise
                 raise
-            return values, None
 
     tz_out = state.check_for_mixed_inputs(tz_out, utc)
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2814,7 +2814,6 @@ def objects_to_datetime64(
     result : ndarray
         np.datetime64[out_unit] if returned values represent wall times or UTC
         timestamps.
-        object if mixed timezones
     inferred_tz : tzinfo or None
         If not None, then the datetime64 values in `result` denote UTC timestamps.
 
@@ -2843,16 +2842,8 @@ def objects_to_datetime64(
         return result, tz_parsed
     elif result.dtype.kind == "M":
         return result, tz_parsed
-    elif result.dtype == object:
-        # GH#23675 when called via `pd.to_datetime`, returning an object-dtype
-        #  array is allowed.  When called via `pd.DatetimeIndex`, we can
-        #  only accept datetime64 dtype, so raise TypeError if object-dtype
-        #  is returned, as that indicates the values can be recognized as
-        #  datetimes but they have conflicting timezones/awareness
-        raise TypeError("DatetimeIndex has mixed timezones")
     else:  # pragma: no cover
-        # GH#23675 this TypeError should never be hit, whereas the TypeError
-        #  in the object-dtype branch above is reachable.
+        # this TypeError should never be hit
         raise TypeError(result)
 
 

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -2686,7 +2686,6 @@ def _sequence_to_dt64(
                 data,
                 dayfirst=dayfirst,
                 yearfirst=yearfirst,
-                allow_object=False,
                 out_unit=out_unit,
             )
             copy = False
@@ -2794,7 +2793,6 @@ def objects_to_datetime64(
     yearfirst,
     utc: bool = False,
     errors: DateTimeErrorChoices = "raise",
-    allow_object: bool = False,
     out_unit: str | None = None,
 ) -> tuple[np.ndarray, tzinfo | None]:
     """
@@ -2808,9 +2806,6 @@ def objects_to_datetime64(
     utc : bool, default False
         Whether to convert/localize timestamps to UTC.
     errors : {'raise', 'coerce'}
-    allow_object : bool
-        Whether to return an object-dtype ndarray instead of raising if the
-        data contains more than one timezone.
     out_unit : str or None, default None
         None indicates we should do resolution inference.
 
@@ -2854,8 +2849,6 @@ def objects_to_datetime64(
         #  only accept datetime64 dtype, so raise TypeError if object-dtype
         #  is returned, as that indicates the values can be recognized as
         #  datetimes but they have conflicting timezones/awareness
-        if allow_object:
-            return result, tz_parsed
         raise TypeError("DatetimeIndex has mixed timezones")
     else:  # pragma: no cover
         # GH#23675 this TypeError should never be hit, whereas the TypeError

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -477,7 +477,6 @@ def _convert_listlike_datetimes(
         yearfirst=yearfirst,
         utc=utc,
         errors=errors,
-        allow_object=True,
     )
 
     if tz_parsed is not None:


### PR DESCRIPTION
Noticed this while working on the `to_datetime` unit PRs. I think this is a left-over from the time that `pd.to_datetime()` could return object dtype (either original input with `errors="ignore"` or `datetime.datetime` objects for things we couldn't represent)

(codecov also confirmed for the python side that this code was not covered)