### PR TITLE
BUG Preserve outer-group ordering in MultiIndex .loc selections

### DIFF
--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -4509,8 +4509,8 @@ class MultiIndex(Index):
                 # flip order for negative step
                 new_order = np.arange(n - 1, -1, -1)[indexer]
             elif isinstance(k, slice) and k.start is None and k.stop is None:
-                # slice(None) should not determine order GH#31330
-                new_order = np.ones((n,), dtype=np.intp)[indexer]
+                # Preserve outer-group ordering for later list-like keys.
+                new_order = self.codes[i][indexer]
             else:
                 # For all other case, use the same order as the level
                 new_order = np.arange(n)[indexer]


### PR DESCRIPTION
## Summary

This PR fixes the inconsistent `MultiIndex` outer-group ordering described in #63187.

The bug is in `MultiIndex._reorder_indexer()` in `multi.py`. When a selection combines `slice(None)` on the outer level with a list of labels on the inner level, the previous behavior could lose the original outer-group ordering and flatten the selected labels across groups.

The fix preserves the original outer-group ordering while retaining the optimized lexsorted path.

## Validation

I will be honest about the current test results:

* The focused regression tests for the reported issue pass: **4 passed**.
* The full `pandas/tests/indexes/multi/test_indexing.py` test suite has **195 passed and 1 failed**.

The failing test is:

`test_get_locs_list_like_na_in_object_container`

This test currently expects the ordering `[0, 2, 1]`, while the fix produces `[0, 1, 2]`.

This failure is related to the changed ordering behavior introduced by the fix and is **not being treated as unrelated**. The reported ordering bug is fixed, but the remaining failure indicates that the implementation still needs refinement to preserve the existing ordering contract for the `pd.NA` case.

I am opening this PR transparently so the behavior and remaining regression can be reviewed.