### PR TITLE
TST: fix NameError in test_setitem MultiIndex assign tests

### DIFF
--- a/pandas/tests/indexing/multiindex/test_setitem.py
+++ b/pandas/tests/indexing/multiindex/test_setitem.py
@@ -668,8 +668,8 @@ def test_setitem_new_column_multiindex_full_tuple_no_warning():
 def test_assign_multiindex_columns_warns():
     # GH#17024 - keyword arguments cannot be tuples, so the warning points at
     #  df[full_tuple] = ... rather than at an impossible tuple keyword
-    mi = MultiIndex.from_tuples([("a", "b")], names=["x", "y"])
-    df = DataFrame([[1]], columns=mi)
+    mi = pd.MultiIndex.from_tuples([("a", "b")], names=["x", "y"])
+    df = pd.DataFrame([[1]], columns=mi)
     msg = re.escape("DataFrame.assign cannot take a tuple key; use df[('new', '')]")
     with tm.assert_produces_warning(Pandas4Warning, match=msg):
         result = df.assign(new=[2])
@@ -678,8 +678,8 @@ def test_assign_multiindex_columns_warns():
 
 def test_assign_multiindex_columns_existing_key_no_warning():
     # GH#17024 - a key that matches existing columns is not an expansion
-    mi = MultiIndex.from_tuples([("a", "b"), ("a", "c")], names=["x", "y"])
-    df = DataFrame([[1, 2]], columns=mi)
+    mi = pd.MultiIndex.from_tuples([("a", "b"), ("a", "c")], names=["x", "y"])
+    df = pd.DataFrame([[1, 2]], columns=mi)
     with tm.assert_produces_warning(None):
         result = df.assign(a=[3])
     assert result.columns.tolist() == [("a", "b"), ("a", "c")]


### PR DESCRIPTION
The two tests added in GH-67013 use bare `MultiIndex`/`DataFrame`, but
`pandas/tests/indexing/multiindex/test_setitem.py` only imports `pandas as pd`.
Every Unit Tests job on main is red with
`NameError: name 'MultiIndex' is not defined`. Switched them to the `pd.`
prefix the rest of the file uses.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the CI failure from the job logs and made the one-file fix.