### PR TITLE
DOC: mention psycopg 3 in the SQL user guide

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5659,7 +5659,7 @@ documentation.
 
 Where an ADBC driver is not available or may be missing functionality,
 users should opt for installing SQLAlchemy alongside their database driver library.
-Examples of such drivers are `psycopg2 <https://www.psycopg.org/>`__
+Examples of such drivers are `psycopg 3 <https://www.psycopg.org/psycopg3/>`__
 for PostgreSQL or `pymysql <https://github.com/PyMySQL/PyMySQL>`__ for MySQL.
 For `SQLite <https://docs.python.org/3/library/sqlite3.html>`__ this is
 included in Python's standard library by default.
@@ -6102,8 +6102,9 @@ Specifying this will return an iterator through chunks of the query result:
    usage. Most database drivers fetch the complete result set into client
    memory before the first chunk is produced. Actually streaming the result
    requires a server-side cursor, which with SQLAlchemy is requested with the
-   ``stream_results`` execution option (supported by, e.g., the psycopg2 and
-   pymysql drivers; drivers without server-side cursor support ignore it):
+   ``stream_results`` execution option (supported by, e.g., the psycopg2,
+   psycopg 3 and pymysql drivers; drivers without server-side cursor support
+   ignore it):
 
    .. code-block:: python
 
@@ -6123,7 +6124,11 @@ connecting to.
 
    from sqlalchemy import create_engine
 
-   engine = create_engine("postgresql://scott:tiger@localhost:5432/mydatabase")
+   # PostgreSQL using the psycopg 3 driver:
+   engine = create_engine("postgresql+psycopg://scott:tiger@localhost:5432/mydatabase")
+
+   # or using the legacy psycopg2 driver:
+   engine = create_engine("postgresql+psycopg2://scott:tiger@localhost:5432/mydatabase")
 
    engine = create_engine("mysql+mysqldb://scott:tiger@localhost/foo")
 


### PR DESCRIPTION
- [x] closes #67064
- [ ] Tests added and passed if fixing a bug or adding a new feature
- [x] All code checks passed
- [ ] Added type annotations to new arguments/methods/functions
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature
- [x] I have reviewed and followed all the contribution guidelines
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described below how I used it and exactly which tool and model version.

This PR updates the SQL user guide to mention psycopg 3, scoped to the main user guide per the maintainer comment in the issue (jorisvandenbossche, 2026-09-03). No cookbook section is added.

Changes in `doc/source/user_guide/io.rst`:

- The driver example now points to psycopg 3 (`https://www.psycopg.org/psycopg3/`) instead of psycopg2. The psycopg project describes psycopg2 as fully supported for legacy applications and recommends psycopg 3 for new projects.
- The `stream_results` note lists psycopg 3 among the drivers with server-side cursor support.
- The engine connection examples show `postgresql+psycopg` and `postgresql+psycopg2` explicitly. SQLAlchemy resolves the bare `postgresql://` form to psycopg2, so writing out the dialect avoids the pitfall reported in the issue.

The dialect strings and the psycopg2 default for the bare `postgresql://` form are documented in the SQLAlchemy 2.0 dialect docs. Psycopg 3's server-side cursor support is confirmed in the dialect source (`supports_server_side_cursors` in `lib/sqlalchemy/dialects/postgresql/psycopg.py`); SQLAlchemy's prose still only names psycopg2 and asyncpg there.

**AI disclosure:** drafted with opencode (agent session, prompted to follow `AGENTS.md`) using GLM 5.3 (standard effort). The agent located the edit sites, verified the SQLAlchemy and psycopg claims against the official docs, and drafted the wording. I reviewed and understood every change before opening this PR and can answer questions about it.
