### PR TITLE
CLN: fold getdigit_ascii into the shared portable.pxd

### DIFF
--- a/pandas/_libs/portable.pxd
+++ b/pandas/_libs/portable.pxd
@@ -5,3 +5,4 @@ cdef extern from "pandas/portable.h":
     int checked_add(int64_t a, int64_t b, int64_t *res) noexcept nogil
     int checked_sub(int64_t a, int64_t b, int64_t *res) noexcept nogil
     int checked_mul(int64_t a, int64_t b, int64_t *res) noexcept nogil
+    int getdigit_ascii(char c, int default) noexcept nogil

--- a/pandas/_libs/tslibs/parsing.pyx
+++ b/pandas/_libs/tslibs/parsing.pyx
@@ -40,6 +40,7 @@ from dateutil.tz import tzoffset
 
 from pandas._config import get_option
 
+from pandas._libs.portable cimport getdigit_ascii
 from pandas._libs.tslibs.ccalendar cimport MONTH_TO_CAL_NUM
 from pandas._libs.tslibs.dtypes cimport (
     attrname_to_npy_unit,
@@ -63,9 +64,6 @@ import_pandas_datetime()
 
 from pandas._libs.tslibs.strptime import array_strptime
 
-
-cdef extern from "pandas/portable.h":
-    int getdigit_ascii(char c, int default) nogil
 
 cdef extern from "pandas/parser/tokenizer.h":
     double precise_xstrtod(const char *p, char **q, char decimal, char sci,


### PR DESCRIPTION
GH-66739 replaced five per-module `cdef extern from "pandas/portable.h"` blocks with a single `pandas/_libs/portable.pxd` that the modules cimport, but left one declaration behind in `parsing.pyx`. Moving it into the shared pxd puts the header's entire Cython surface in one file.

`grep -rn 'portable.h' pandas/` now finds only `portable.pxd` and the two C-side `#include`s (`tokenizer.cpp`, `ultrajson.h`).

`getdigit_ascii` picks up the neighbours' `noexcept nogil` spelling; `cdef extern` C functions are `noexcept` by default in Cython 3, so that is not a semantic change.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which made the edit and ran the build and the tslibs/tseries/to_datetime test suites.