### PR TITLE
BUG: DataFrame reductions forced the result into the SparseDtype column's own dtype (GH#55123)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -892,6 +892,7 @@ Reshaping
 
 Sparse
 ^^^^^^
+- Bug in :meth:`DataFrame.count`, :meth:`DataFrame.sum`, :meth:`DataFrame.mean`, :meth:`DataFrame.min`, and :meth:`DataFrame.max` on :class:`SparseDtype` columns forcing the result into the column's own dtype: ``count`` returned ``1`` for every sparse column, the sum of a narrow integer column silently wrapped around, the mean of an integer column was truncated to an integer, and a missing result (e.g. from ``min_count`` or an empty column) came back as a fill value or raised (:issue:`55123`)
 - Bug in :meth:`Series.mean` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`Series.reindex` and alignment raising when extending a boolean :class:`SparseDtype`-backed :class:`Series`; missing entries now upcast to ``object`` to match the dense behavior (:issue:`32119`)
 - Bug in :meth:`Series.sum`, :meth:`Series.min`, and :meth:`Series.max` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1616,7 +1616,21 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             result = getattr(arr, name)(**kwargs)
 
         if keepdims:
-            return type(self)([result], dtype=self.dtype)
+            dtype = self.dtype
+            if dtype.subtype.kind in "biufc":
+                # The reduction is not always closed over self.dtype, e.g. the
+                # mean of an integer column, the sum of a narrow one, or the
+                # NaN that min_count inserts; casting the result back to
+                # self.dtype would silently truncate it.
+                subtype = np.result_type(dtype.subtype, result)
+                if subtype != dtype.subtype:
+                    fill_value = self.fill_value
+                    if notna(fill_value):
+                        # keep the fill value so that reducing a frame of
+                        # sparse columns does not mix fill values
+                        fill_value = subtype.type(fill_value).item()
+                    dtype = SparseDtype(subtype, fill_value)
+            return type(self)([result], dtype=dtype)
         else:
             return result
 

--- a/pandas/tests/arrays/sparse/test_reductions.py
+++ b/pandas/tests/arrays/sparse/test_reductions.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 import pandas as pd
+import pandas._testing as tm
 from pandas.core.arrays.sparse import SparseArray
 
 
@@ -339,3 +340,77 @@ class TestArgmaxArgmin:
         arr = SparseArray([])
         with pytest.raises(ValueError, match=msg):
             getattr(arr, method)()
+
+
+@pytest.mark.parametrize("values, expected", [([1, 2, 4], 7 / 3), ([1, 2, 3], 2.0)])
+def test_frame_mean_int_column_not_truncated(values, expected):
+    # GH#55123 the DataFrame path cast the reduction back to the column's
+    #  dtype, truncating the mean of an integer column
+    df = pd.DataFrame({"a": SparseArray(np.array(values), fill_value=0)})
+    result = df.mean()
+    expected = pd.Series([expected], index=["a"], dtype=pd.SparseDtype("float64", 0.0))
+    tm.assert_series_equal(result, expected)
+
+
+def test_frame_sum_bool_column_not_cast_back():
+    # GH#55123 summing a bool column gave True instead of the count
+    df = pd.DataFrame({"a": SparseArray([True, False, False], fill_value=False)})
+    result = df.sum()
+    expected = pd.Series([1], index=["a"], dtype=pd.SparseDtype("int64", 0))
+    tm.assert_series_equal(result, expected)
+
+
+def test_frame_sum_narrow_int_column_does_not_overflow():
+    # GH#55123 casting the sum back to a narrow subtype wrapped around
+    df = pd.DataFrame({"a": SparseArray(np.array([100, 100, 100], dtype="int8"))})
+    result = df.sum()
+    expected = pd.Series([300], index=["a"], dtype=pd.SparseDtype("int64", 0))
+    tm.assert_series_equal(result, expected)
+
+
+def test_frame_count_sparse_columns():
+    # GH#55123 count went through the same cast and collapsed every sparse
+    #  column to 1
+    df = pd.DataFrame(
+        {"a": SparseArray([1.0, 2.0, 3.0]), "b": SparseArray([1.0, np.nan, 3.0])}
+    )
+    result = df.count()
+    expected = pd.Series([3, 2], index=["a", "b"], dtype="int64")
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("method", ["min", "max"])
+@pytest.mark.parametrize("subtype", ["int64", "bool"])
+def test_frame_min_max_empty_column(method, subtype):
+    # GH#55123 reducing an empty column gives NaN, which these subtypes cannot
+    #  hold; casting back gave True for bool and raised for int64
+    df = pd.DataFrame({"a": SparseArray(np.array([], dtype=subtype))})
+    result = getattr(df, method)()
+    expected = pd.Series([np.nan], index=["a"], dtype=pd.SparseDtype("float64", 0.0))
+    tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "arr, subtype",
+    [
+        (SparseArray([True, False, False], fill_value=False), "float64"),
+        (SparseArray(np.array([1, 2, 4]), fill_value=0), "float64"),
+        # a float32 subtype already holds the missing value, so it is retained
+        (SparseArray(np.array([1, 2, 4], dtype="float32"), fill_value=0), "float32"),
+    ],
+)
+def test_frame_sum_min_count_not_cast_to_column_dtype(arr, subtype):
+    # GH#55123 the missing value produced by min_count was swallowed by the
+    #  cast back to the column's dtype
+    df = pd.DataFrame({"a": arr})
+    result = df.sum(min_count=4)
+    expected = pd.Series([np.nan], index=["a"], dtype=pd.SparseDtype(subtype, 0.0))
+    tm.assert_series_equal(result, expected)
+
+
+def test_frame_reduction_keeps_datetime64_dtype():
+    # the widening must not kick in for a datetime64 subtype
+    arr = SparseArray(np.array(["2020-01-01", "2020-01-03"], dtype="M8[ns]"))
+    result = pd.DataFrame({"a": arr}).max()
+    expected = pd.Series([pd.Timestamp("2020-01-03")], index=["a"], dtype=arr.dtype)
+    tm.assert_series_equal(result, expected)

--- a/pandas/tests/arrays/sparse/test_reductions.py
+++ b/pandas/tests/arrays/sparse/test_reductions.py
@@ -356,7 +356,7 @@ def test_frame_sum_bool_column_not_cast_back():
     # GH#55123 summing a bool column gave True instead of the count
     df = pd.DataFrame({"a": SparseArray([True, False, False], fill_value=False)})
     result = df.sum()
-    expected = pd.Series([1], index=["a"], dtype=pd.SparseDtype("int64", 0))
+    expected = pd.Series([1], index=["a"], dtype=pd.SparseDtype(np.int_, 0))
     tm.assert_series_equal(result, expected)
 
 
@@ -364,7 +364,7 @@ def test_frame_sum_narrow_int_column_does_not_overflow():
     # GH#55123 casting the sum back to a narrow subtype wrapped around
     df = pd.DataFrame({"a": SparseArray(np.array([100, 100, 100], dtype="int8"))})
     result = df.sum()
-    expected = pd.Series([300], index=["a"], dtype=pd.SparseDtype("int64", 0))
+    expected = pd.Series([300], index=["a"], dtype=pd.SparseDtype(np.int_, 0))
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -99,6 +99,12 @@ class TestSparseArray(base.ExtensionTests):
     def _honors_copy_keyword(self, data) -> bool:
         return False
 
+    def _get_expected_reduction_dtype(self, arr, op_name: str, skipna: bool):
+        if op_name in ["mean", "median", "var", "std", "sem", "skew", "kurt"]:
+            # not closed over the subtype, so the result widens to float64
+            return pd.SparseDtype("float64", arr.fill_value)
+        return arr.dtype
+
     def _supports_reduction(self, obj, op_name: str) -> bool:
         if op_name in [
             "prod",


### PR DESCRIPTION
DataFrame reductions go through `SparseArray._reduce(keepdims=True)`, which rebuilt the length-1 result as `type(self)([result], dtype=self.dtype)`. Any result the column's subtype could not hold was silently coerced back into it — the `Series`/array paths (`keepdims=False`) were fine, so the frame and the Series disagreed:

```python
df = pd.DataFrame({"a": pd.arrays.SparseArray([True, False, False])})
df.sum(min_count=4)   # True, vs NaN from the Series
df.sum()              # True, vs 1

df = pd.DataFrame({"a": pd.arrays.SparseArray(np.array([1, 2, 4]))})
df.mean()             # 2, vs 2.3333...
df.sum(min_count=4)   # raises IntCastingNaNError

pd.DataFrame({"a": pd.arrays.SparseArray(np.array([100, 100, 100], dtype="int8"))}).sum()
#   44 — the int64 sum wrapped on the way back into int8, silently

pd.DataFrame({"a": pd.arrays.SparseArray(np.array([1, 2, 3]))}).count()
#   1 — count() returned 1 for every sparse column

pd.DataFrame({"a": pd.arrays.SparseArray(np.array([], dtype=bool))}).max()
#   True, from an empty column
```

The result dtype is now promoted with `np.result_type(subtype, result)`. Under NEP 50 that is exactly the rule wanted here: a numpy scalar promotes (an integer column's mean widens to float64, a narrow integer sum to int64), while a Python scalar stays weak, so the untyped fill value that `_min_max` returns and the NaN sentinel `min_count` inserts do not widen a float32 column. Non-`biufc` subtypes (datetime64, timedelta64, object) keep their dtype as before. The fill value is carried into the promoted dtype so that reducing a frame of sparse columns does not concatenate mismatched fill values.

This is the general defect behind GH-55123. That issue was closed by GH-65530 after its float64 `axis=1` reproducer stopped failing, but the underlying `_reduce` cast was untouched and every non-float subtype still hit it.

Incidentally the reproducer in GH-58582 (`df.count()` raising `ValueError: fill_value must be a valid value for the SparseDtype.subtype`) no longer raises after this change, since the fill value now arrives already cast — but the root cause there is a separate uncast `fill_value` in `SparseDtype._get_common_dtype`, which this PR does not touch.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and ran three blind review rounds over the branch.