### PR TITLE
BUG: named agg result depended on the output name matching the column name (GH#63743)

### DIFF
--- a/pandas/core/apply.py
+++ b/pandas/core/apply.py
@@ -1886,7 +1886,7 @@ class ResamplerWindowApply(GroupByApply):
 
 
 def reconstruct_func(
-    func: AggFuncType | None, **kwargs
+    func: AggFuncType | None, allow_skip_normalization: bool = False, /, **kwargs
 ) -> tuple[bool, AggFuncType, tuple[str, ...] | None, npt.NDArray[np.intp] | None]:
     """
     This is the internal function to reconstruct func given if there is relabeling
@@ -1902,10 +1902,22 @@ def reconstruct_func(
     names, and the reconstructed order of columns.
     If relabeling is False, the columns and order will be None.
 
+    Named aggregation is the one exception: when ``allow_skip_normalization`` is
+    True, every output name equals its source column name, and every aggfunc
+    reduces to a scalar, relabeling is reported as False (and columns/order as
+    None) even though named aggregation was used, because the caller can consume
+    the un-normalized func directly.
+
     Parameters
     ----------
     func: agg function (e.g. 'min' or Callable) or list of agg functions
         (e.g. ['min', np.max]) or dictionary (e.g. {'A': ['min', np.max]}).
+    allow_skip_normalization: bool, default False
+        Whether the caller can handle the un-normalized ``{column: aggfunc}`` form
+        that named aggregation reduces to when every output name equals its source
+        column name and every aggfunc is a scalar reduction. Callers that rely on
+        ``columns``/``order`` being returned whenever named aggregation was used
+        must leave this False.
     **kwargs: dict, kwargs used in is_multi_agg_with_relabel and
         normalize_keyword_aggregation function for relabelling
 
@@ -1924,6 +1936,9 @@ def reconstruct_func(
     >>> reconstruct_func("min")
     (False, 'min', None, None)
     """
+    # deferred: pandas.core.groupby.generic imports from this module at import
+    #  time, so a top-level import here would be circular
+    from pandas.core.groupby.base import reduction_kernels
     from pandas.core.groupby.generic import NamedAgg
 
     relabeling = func is None and (
@@ -1946,7 +1961,7 @@ def reconstruct_func(
             raise TypeError("Must provide 'func' or tuples of '(column, aggfunc).")
 
     if relabeling:
-        normalization_needed = False
+        normalization_needed = not allow_skip_normalization
         # error: Incompatible types in assignment (expression has type
         # "MutableMapping[Hashable, list[Callable[..., Any] | str]]", variable has type
         # "Callable[..., Any] | str | list[Callable[..., Any] | str] |
@@ -1964,7 +1979,17 @@ def reconstruct_func(
             else:
                 column, aggfunc = val
 
-            if column != key:
+            # The un-normalized {column: aggfunc} form only matches the normalized
+            #  one when the aggfunc reduces each group to a single scalar. A
+            #  list-like aggfunc, or a string naming a non-reduction groupby method
+            #  (e.g. "describe"/"ohlc", which give a frame per group), would widen
+            #  the result past the one output column per keyword named aggregation
+            #  promises.
+            if (
+                column != key
+                or is_list_like(aggfunc)
+                or (isinstance(aggfunc, str) and aggfunc not in reduction_kernels)
+            ):
                 normalization_needed = True
             converted_kwargs[key] = column, aggfunc
 

--- a/pandas/core/groupby/generic.py
+++ b/pandas/core/groupby/generic.py
@@ -2264,7 +2264,18 @@ class DataFrameGroupBy(GroupBy[DataFrame]):
         1   1.0
         2   3.0
         """
-        relabeling, func, columns, order = reconstruct_func(func, **kwargs)
+        # This method can consume the un-normalized {column: aggfunc} form, but only
+        #  when the columns are unique: dict aggregation fans a single key out to
+        #  every matching column, while named aggregation must produce exactly one
+        #  output per keyword.
+        #  `func is None` is a precondition for relabeling at all, and short-circuits
+        #  materializing _obj_with_exclusions on the far more common plain-agg path.
+        allow_skip_normalization = (
+            func is None and self._obj_with_exclusions.columns.is_unique
+        )
+        relabeling, func, columns, order = reconstruct_func(
+            func, allow_skip_normalization, **kwargs
+        )
         func = maybe_mangle_lambdas(func)
 
         if maybe_use_numba(engine):

--- a/pandas/tests/apply/test_frame_apply_relabeling.py
+++ b/pandas/tests/apply/test_frame_apply_relabeling.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import pandas as pd
 import pandas._testing as tm
@@ -103,3 +104,56 @@ def test_reconstruct_func():
     result = pd.core.apply.reconstruct_func("min")
     expected = (False, "min", None, None)
     tm.assert_equal(result, expected)
+
+
+def test_reconstruct_func_allow_skip_normalization():
+    # GH#63743 the normalization fast path is opt-in: only callers that pass
+    #  allow_skip_normalization can receive the un-normalized {column: aggfunc}
+    #  form, and only when every output name equals its source column name
+    kwargs = {"B": ("B", "sum")}
+
+    result = pd.core.apply.reconstruct_func(None, True, **kwargs)
+    assert result == (False, {"B": "sum"}, None, None)
+
+    # default (every caller other than DataFrameGroupBy.aggregate) normalizes
+    relabeling, func, columns, order = pd.core.apply.reconstruct_func(None, **kwargs)
+    assert relabeling
+    assert func == {"B": ["sum"]}
+    assert columns == ("B",)
+    tm.assert_numpy_array_equal(order, np.array([0], dtype=np.intp))
+
+    # a renamed output still normalizes even when the fast path is allowed
+    relabeling, _, columns, _ = pd.core.apply.reconstruct_func(
+        None, True, x=("B", "sum")
+    )
+    assert relabeling
+    assert columns == ("x",)
+
+
+def test_agg_relabel_output_name_matches_column():
+    # GH#63743 named aggregation returns a DataFrame indexed by the output
+    #  names even when those names match the source column names
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
+
+    result = df.agg(A=("A", "min"))
+    expected = pd.DataFrame({"A": [1]}, index=pd.Index(["A"]))
+    tm.assert_frame_equal(result, expected)
+
+    result = df.agg(A=("A", "min"), B=("B", "max"))
+    expected = pd.DataFrame(
+        {"A": [1.0, np.nan], "B": [np.nan, 6.0]}, index=pd.Index(["A", "B"])
+    )
+    tm.assert_frame_equal(result, expected)
+
+
+def test_agg_relabel_output_name_matches_column_axis_1():
+    # GH#63743 named aggregation with axis=1 raises regardless of whether the
+    #  output name matches the column name
+    df = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]}, index=["A", "B", "C"])
+    msg = "Named aggregation is not supported when axis=1."
+
+    with pytest.raises(NotImplementedError, match=msg):
+        df.agg(A=("A", "min"), axis=1)
+
+    with pytest.raises(NotImplementedError, match=msg):
+        df.agg(x=("A", "min"), axis=1)

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -2089,6 +2089,56 @@ def test_agg_relabel_with_name_match_and_namedagg():
     tm.assert_frame_equal(result, expected)
 
 
+def test_agg_relabel_with_name_match_listlike_aggfunc():
+    # GH#63743 a list-like aggfunc takes the same path whether or not the output
+    #  name matches the column name
+    df = DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
+
+    with pytest.raises(TypeError, match="unhashable"):
+        df.groupby("A").agg(B=("B", ["sum", "max"]))
+
+    with pytest.raises(TypeError, match="unhashable"):
+        df.groupby("A").agg(x=("B", ["sum", "max"]))
+
+    # a tuple aggfunc is read as a single (name, func) pair, not two aggfuncs
+    result = df.groupby("A").agg(B=("B", ("sum", "max")))
+    expected = df.groupby("A").agg(x=("B", ("sum", "max")))
+    expected.columns = ["B"]
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("aggfunc", ["describe", "ohlc"])
+def test_agg_relabel_with_name_match_non_reduction(aggfunc):
+    # GH#63743 a string aggfunc that is not a reduction gives a frame per group,
+    #  so it must still produce one output column per keyword when the output
+    #  name matches the column name
+    df = DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
+
+    result = df.groupby("A").agg(B=("B", aggfunc))
+    expected = df.groupby("A").agg(z=("B", aggfunc))
+    expected.columns = ["B"]
+    tm.assert_frame_equal(result, expected)
+
+    result = df.groupby("A").agg(B=pd.NamedAgg("B", aggfunc))
+    tm.assert_frame_equal(result, expected)
+
+
+def test_agg_relabel_with_name_match_duplicate_columns():
+    # GH#63743 named aggregation gives one output column per keyword even when
+    #  the source label is duplicated and the output name matches it
+    df = DataFrame(
+        [[0, 1, 2], [0, 3, 4], [1, 5, 6], [1, 7, 8]], columns=["A", "B", "B"]
+    )
+
+    result = df.groupby("A").agg(B=("B", "sum"))
+    expected = df.groupby("A").agg(x=("B", "sum"))
+    expected.columns = ["B"]
+    tm.assert_frame_equal(result, expected)
+
+    result = df.groupby("A").agg(B=pd.NamedAgg("B", "sum"))
+    tm.assert_frame_equal(result, expected)
+
+
 def test_multiple_partial_functions_same_name():
     # GH#28570
     quant50 = partial(np.percentile, q=50)

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -2092,7 +2092,7 @@ def test_agg_relabel_with_name_match_and_namedagg():
 def test_agg_relabel_with_name_match_listlike_aggfunc():
     # GH#63743 a list-like aggfunc takes the same path whether or not the output
     #  name matches the column name
-    df = DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
+    df = pd.DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
 
     with pytest.raises(TypeError, match="unhashable"):
         df.groupby("A").agg(B=("B", ["sum", "max"]))
@@ -2112,7 +2112,7 @@ def test_agg_relabel_with_name_match_non_reduction(aggfunc):
     # GH#63743 a string aggfunc that is not a reduction gives a frame per group,
     #  so it must still produce one output column per keyword when the output
     #  name matches the column name
-    df = DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
+    df = pd.DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
 
     result = df.groupby("A").agg(B=("B", aggfunc))
     expected = df.groupby("A").agg(z=("B", aggfunc))
@@ -2126,7 +2126,7 @@ def test_agg_relabel_with_name_match_non_reduction(aggfunc):
 def test_agg_relabel_with_name_match_duplicate_columns():
     # GH#63743 named aggregation gives one output column per keyword even when
     #  the source label is duplicated and the output name matches it
-    df = DataFrame(
+    df = pd.DataFrame(
         [[0, 1, 2], [0, 3, 4], [1, 5, 6], [1, 7, 8]], columns=["A", "B", "B"]
     )
 


### PR DESCRIPTION
GH-63743 added a fast path to `reconstruct_func` that skips normalization when every named-aggregation output name equals its source column name. That function is shared by four callers (`frame_apply`, `reconstruct_and_relabel_result`, `window/rolling.py`, and `DataFrameGroupBy.aggregate`), so the fast path leaked out of `groupby.agg` and made results depend on whether the output name happened to match the column name.

```python
df = pd.DataFrame({"A": [1, 2, 3], "B": [4.0, 5.0, 6.0]})

df.agg(A=("A", "max"))   # Series  <- wrong
df.agg(x=("A", "max"))   # DataFrame

df.agg(A=("A", "min"), axis=1)   # silently aggregated row "A"
df.agg(x=("A", "min"), axis=1)   # NotImplementedError

d = pd.DataFrame({"A": [0, 0, 1, 1], "B": [1, 2, 3, 4]})
d.groupby("A").agg(B=("B", "ohlc")).shape   # (2, 4)  <- 4 columns for 1 keyword
d.groupby("A").agg(x=("B", "ohlc")).shape   # (2, 1)
```

`"describe"` widened to eight columns the same way, `"expanding"` changed the return type from `DataFrame` to `Series`, and on a frame with duplicate column labels `agg(B=("B", "sum"))` produced one output column per matching column instead of one per keyword.

This makes the fast path opt-in. `reconstruct_func` takes a positional-only `allow_skip_normalization` flag — positional-only so that a column literally named `allow_skip_normalization` cannot collide with `**kwargs` — and only `DataFrameGroupBy.aggregate` passes `True`, and only when its columns are unique. The fast path additionally requires a non-list-like aggfunc that, if a string, names a scalar reduction (gated on `pandas.core.groupby.base.reduction_kernels` rather than a hand-maintained blocklist, since `describe`, `ohlc` and `expanding` all had to be excluded).

GH-63743's performance win is preserved: on its own benchmark the named form still skips normalization (0.56 ms vs 0.43 ms for the equivalent unnamed dict form, against 1.36 ms when normalized).

No whatsnew note: the regression is not in any released version — no tag contains 9591444e34c.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and ran a differential sweep of 44 aggfuncs across the matched-name, renamed and `NamedAgg` spellings; I reviewed the result.