### PR TITLE
BUG: group bars correctly in list-valued subplots

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -832,10 +832,10 @@ Period
 
 Plotting
 ^^^^^^^^
-- Bug in :meth:`DataFrame.plot` with ``kind="bar"`` or ``kind="barh"`` and grouped ``subplots`` incorrectly overlaying columns when ``stacked=False`` (:issue:`67727`)
 - Bug in :meth:`DataFrame.plot.bar` and :meth:`DataFrame.plot.barh` raising ``AttributeError`` for a regularly-spaced :class:`DatetimeIndex` whose ``freq`` attribute is unset (:issue:`66771`)
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
 - Bug in :meth:`DataFrame.plot` and :meth:`Series.plot` with ``secondary_y`` hiding the primary y-axis when the data already on the axes was drawn as a collection rather than as lines, e.g. by :meth:`DataFrame.plot.scatter` (:issue:`66789`)
+- Bug in :meth:`DataFrame.plot` with ``kind="bar"`` or ``kind="barh"`` and grouped ``subplots`` incorrectly overlaying columns when ``stacked=False`` (:issue:`67727`)
 - Bug in :meth:`Series.plot`, :meth:`DataFrame.plot`, :meth:`DataFrame.plot.scatter`, :meth:`Series.hist`, :meth:`DataFrame.hist`, :func:`plotting.lag_plot` and :func:`plotting.parallel_coordinates` with timezone-aware data labelling the axis in UTC instead of in the data's own timezone (:issue:`64613`)
 -
 

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -832,6 +832,7 @@ Period
 
 Plotting
 ^^^^^^^^
+- Bug in :meth:`DataFrame.plot` with ``kind="bar"`` or ``kind="barh"`` and grouped ``subplots`` incorrectly overlaying columns when ``stacked=False`` (:issue:`67727`)
 - Bug in :meth:`DataFrame.plot.bar` and :meth:`DataFrame.plot.barh` raising ``AttributeError`` for a regularly-spaced :class:`DatetimeIndex` whose ``freq`` attribute is unset (:issue:`66771`)
 - Bug in :meth:`DataFrame.plot.hexbin` ignoring ``rcParams["image.cmap"]`` and always defaulting to ``"BuGn"`` when no colormap was specified (:issue:`31871`)
 - Bug in :meth:`DataFrame.plot` and :meth:`Series.plot` with ``secondary_y`` hiding the primary y-axis when the data already on the axes was drawn as a collection rather than as lines, e.g. by :meth:`DataFrame.plot.scatter` (:issue:`66789`)

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -2060,12 +2060,23 @@ class BarPlot(MPLPlot):
                 _stacked_subplots_offsets[offset_index] = (pos_new, neg_new)
 
             elif self.subplots:
-                w = self.bar_width / 2
+                if isinstance(self.subplots, list):
+                    sub_plot = self.subplots[self._col_idx_to_axis_idx(i)]
+                    j = sub_plot.index(i)
+                    w = self.bar_width / len(sub_plot)
+                else:
+                    j = 0
+                    w = self.bar_width
+
+                if self._align == "edge":
+                    x = self.ax_pos + self.bar_width / 2 + j * w
+                else:
+                    x = self.ax_pos + (j + 0.5) * w
                 rect = self._plot(
                     ax,
-                    self.ax_pos + w,
+                    x,
                     y,
-                    self.bar_width,
+                    w,
                     start=start,
                     label=label,
                     log=self.log,

--- a/pandas/plotting/_matplotlib/core.py
+++ b/pandas/plotting/_matplotlib/core.py
@@ -2061,22 +2061,22 @@ class BarPlot(MPLPlot):
 
             elif self.subplots:
                 if isinstance(self.subplots, list):
-                    sub_plot = self.subplots[self._col_idx_to_axis_idx(i)]
-                    j = sub_plot.index(i)
-                    w = self.bar_width / len(sub_plot)
+                    subplot_columns = self.subplots[self._col_idx_to_axis_idx(i)]
+                    series_idx = subplot_columns.index(i)
+                    width = self.bar_width / len(subplot_columns)
                 else:
-                    j = 0
-                    w = self.bar_width
+                    series_idx = 0
+                    width = self.bar_width
 
                 if self._align == "edge":
-                    x = self.ax_pos + self.bar_width / 2 + j * w
+                    bar_position = self.ax_pos + self.bar_width / 2 + series_idx * width
                 else:
-                    x = self.ax_pos + (j + 0.5) * w
+                    bar_position = self.ax_pos + (series_idx + 0.5) * width
                 rect = self._plot(
                     ax,
-                    x,
+                    bar_position,
                     y,
-                    w,
+                    width,
                     start=start,
                     label=label,
                     log=self.log,

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -2513,6 +2513,50 @@ class TestDataFramePlots:
             if kind == "line":
                 assert len(ax.lines) == len(labels)
 
+    @pytest.mark.parametrize("kind", ["bar", "barh"])
+    @pytest.mark.parametrize("align", ["center", "edge"])
+    @pytest.mark.parametrize("width, position", [(0.5, 0.5), (0.9, 0.2)])
+    def test_group_subplot_bar_geometry(self, kind, align, width, position):
+        # GH 67727
+        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+        axes = df.plot(
+            kind=kind,
+            stacked=False,
+            subplots=[("a",), ("c", "b")],
+            sharex=True,
+            align=align,
+            width=width,
+            position=position,
+            legend=False,
+        )
+
+        assert len(axes) == 2
+        for axis_idx, ax in enumerate(axes):
+            if kind == "bar":
+                actual = {
+                    patch.get_height(): (patch.get_x(), patch.get_width())
+                    for patch in ax.patches
+                }
+            else:
+                actual = {
+                    patch.get_width(): (patch.get_y(), patch.get_height())
+                    for patch in ax.patches
+                }
+            base = -width * position
+            if axis_idx == 0:
+                expected = {1: (base + (width / 2 if align == "edge" else 0), width)}
+            else:
+                group_width = width / 2
+                group_offset = width / 2 if align == "edge" else 0
+                expected = {
+                    2: (base + group_offset + group_width, group_width),
+                    3: (base + group_offset, group_width),
+                }
+
+            for value, (expected_coordinate, expected_size) in expected.items():
+                tm.assert_almost_equal(actual[value][0], expected_coordinate)
+                tm.assert_almost_equal(actual[value][1], expected_size)
+
     def test_group_subplot_series_notimplemented(self):
         ser = pd.Series(range(1))
         msg = "An iterable subplots for a Series"

--- a/pandas/tests/plotting/frame/test_frame.py
+++ b/pandas/tests/plotting/frame/test_frame.py
@@ -2513,50 +2513,6 @@ class TestDataFramePlots:
             if kind == "line":
                 assert len(ax.lines) == len(labels)
 
-    @pytest.mark.parametrize("kind", ["bar", "barh"])
-    @pytest.mark.parametrize("align", ["center", "edge"])
-    @pytest.mark.parametrize("width, position", [(0.5, 0.5), (0.9, 0.2)])
-    def test_group_subplot_bar_geometry(self, kind, align, width, position):
-        # GH 67727
-        df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
-        axes = df.plot(
-            kind=kind,
-            stacked=False,
-            subplots=[("a",), ("c", "b")],
-            sharex=True,
-            align=align,
-            width=width,
-            position=position,
-            legend=False,
-        )
-
-        assert len(axes) == 2
-        for axis_idx, ax in enumerate(axes):
-            if kind == "bar":
-                actual = {
-                    patch.get_height(): (patch.get_x(), patch.get_width())
-                    for patch in ax.patches
-                }
-            else:
-                actual = {
-                    patch.get_width(): (patch.get_y(), patch.get_height())
-                    for patch in ax.patches
-                }
-            base = -width * position
-            if axis_idx == 0:
-                expected = {1: (base + (width / 2 if align == "edge" else 0), width)}
-            else:
-                group_width = width / 2
-                group_offset = width / 2 if align == "edge" else 0
-                expected = {
-                    2: (base + group_offset + group_width, group_width),
-                    3: (base + group_offset, group_width),
-                }
-
-            for value, (expected_coordinate, expected_size) in expected.items():
-                tm.assert_almost_equal(actual[value][0], expected_coordinate)
-                tm.assert_almost_equal(actual[value][1], expected_size)
-
     def test_group_subplot_series_notimplemented(self):
         ser = pd.Series(range(1))
         msg = "An iterable subplots for a Series"

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -872,6 +872,35 @@ def test_bar_subplots_stacking_bool(df_bar_data, df_bar_df):
         )
 
 
+@pytest.mark.parametrize("kind", ["bar", "barh"])
+@pytest.mark.parametrize("align", ["center", "edge"])
+@pytest.mark.parametrize("width, position", [(0.5, 0.5), (0.9, 0.2)])
+def test_grouped_subplots_bar_geometry(kind, align, width, position):
+    # GH 67727
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [2, 4, 6], "c": [3, 6, 9]})
+    groups = [("a",), ("c", "b")]
+    kwargs = {
+        "kind": kind,
+        "stacked": False,
+        "align": align,
+        "width": width,
+        "position": position,
+        "legend": False,
+    }
+    axes = df.plot(subplots=groups, **kwargs)
+    _, expected_axes = plt.subplots(len(groups))
+    for ax, expected_ax, columns in zip(axes, expected_axes, groups, strict=True):
+        df[list(columns)].plot(ax=expected_ax, **kwargs)
+        result = sorted(tuple(patch.get_bbox().extents) for patch in ax.patches)
+        expected = sorted(
+            tuple(patch.get_bbox().extents) for patch in expected_ax.patches
+        )
+        tm.assert_almost_equal(result, expected)
+
+    plt.close(axes[0].figure)
+    plt.close(expected_axes[0].figure)
+
+
 def test_plot_bar_label_count_default():
     df = pd.DataFrame(
         [(30, 10, 10, 10), (20, 20, 20, 20), (10, 30, 30, 10)], columns=list("ABCD")

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -888,7 +888,7 @@ def test_grouped_subplots_bar_geometry(kind, align, width, position):
         "legend": False,
     }
     axes = df.plot(subplots=groups, **kwargs)
-    _, expected_axes = plt.subplots(len(groups))
+    _, expected_axes = plt.subplots(len(groups), sharex=True)
     for ax, expected_ax, columns in zip(axes, expected_axes, groups, strict=True):
         df[list(columns)].plot(ax=expected_ax, **kwargs)
         result = sorted(tuple(patch.get_bbox().extents) for patch in ax.patches)

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -889,8 +889,10 @@ def test_grouped_subplots_bar_geometry(kind, align, width, position):
     }
     axes = df.plot(subplots=groups, **kwargs)
     _, expected_axes = plt.subplots(len(groups), sharex=True)
-    for ax, expected_ax, columns in zip(axes, expected_axes, groups, strict=True):
+    for expected_ax, columns in zip(expected_axes, groups, strict=True):
         df[list(columns)].plot(ax=expected_ax, **kwargs)
+
+    for ax, expected_ax in zip(axes, expected_axes, strict=True):
         result = sorted(tuple(patch.get_bbox().extents) for patch in ax.patches)
         expected = sorted(
             tuple(patch.get_bbox().extents) for patch in expected_ax.patches

--- a/pandas/tests/plotting/test_misc.py
+++ b/pandas/tests/plotting/test_misc.py
@@ -896,9 +896,8 @@ def test_grouped_subplots_bar_geometry(kind, align, width, position):
             tuple(patch.get_bbox().extents) for patch in expected_ax.patches
         )
         tm.assert_almost_equal(result, expected)
-
-    plt.close(axes[0].figure)
-    plt.close(expected_axes[0].figure)
+        tm.assert_almost_equal(ax.get_xlim(), expected_ax.get_xlim())
+        tm.assert_almost_equal(ax.get_ylim(), expected_ax.get_ylim())
 
 
 def test_plot_bar_label_count_default():


### PR DESCRIPTION
- [x] closes #67727

- [x] tests added / passed

- [x] whatsnew entry added

Grouped bar plots with list-valued `subplots` previously used the full bar width and the same offset for every series assigned to an axis. This caused multiple series in the same subplot group to overlap when `stacked=False`.

This updates the subplot bar positioning logic to divide the available width between the series in each group and use the series position within that group when calculating offsets.

The existing behavior is preserved for singleton groups, `subplots=True`, regular grouped bar plots, and horizontal bar plots.

Validation:

- regression test: 8 failed before the fix, 8 passed after

- relevant plotting tests: 98 passed

- additional subplot/bar subsets: 20 passed / 8 skipped, 35 passed, 56 passed

- stacked subplot subset: 14 passed

- manual geometry checks for bar/barh, center/edge alignment, different positions and column ordering

- applicable pre-commit hooks passed

- git diff --check passed

AI assistance disclosure:

I used an AI coding assistant to help investigate the issue, implement the change, and develop tests. I reviewed and verified the resulting code and test behavior myself.
