### PR TITLE
CI: Fix setup-pixi action description to reference pixi.toml instead of pyproject.toml

### DIFF
--- a/.github/actions/setup-pixi/action.yml
+++ b/.github/actions/setup-pixi/action.yml
@@ -2,7 +2,7 @@ name: Set up Conda environment with Pixi
 description: Create a Conda environment based on the environments section in pixi.toml
 inputs:
   environment:
-    description: Pixi environment name in pyproject.toml to use.
+    description: Pixi environment name in pixi.toml to use.
     required: true
 runs:
   using: composite


### PR DESCRIPTION
… of pyproject.toml (GH#67983)

- [x] closes #67983
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [x] I did **not** use AI to develop this pull request.
