### PR TITLE
BUG: Export pandas.api.internals submodule

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -936,6 +936,7 @@ Other
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
 - Bug in ``register_option`` where registering an option whose name was a prefix of an existing option (e.g. ``"a.b"`` when ``"a.b.c"`` was already registered) silently overwrote the existing option's namespace instead of raising (:issue:`29242`)
 - Bug in the ``display.max_colwidth`` option where values smaller than ``4`` were silently ignored, leaving the repr untruncated and its column headers misaligned (:issue:`16097`)
+- Bug in :mod:`pandas.api` where the ``internals`` submodule was not reachable as ``pandas.api.internals`` from a bare ``import pandas``, making the API test order-dependent (:issue:`67993`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/api/__init__.py
+++ b/pandas/api/__init__.py
@@ -5,6 +5,7 @@ from pandas.api import (
     extensions,
     indexers,
     interchange,
+    internals,
     types,
     typing,
 )
@@ -14,6 +15,7 @@ __all__ = [
     "extensions",
     "indexers",
     "interchange",
+    "internals",
     "types",
     "typing",
 ]


### PR DESCRIPTION
- [x] closes #67993
- [x] Tests added and passed
- [x] All code checks passed.
- [x] Added type annotations to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines.

Check exactly one of the following, per the automated contributions policy:

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting.

## Summary

`pandas/api/__init__.py` imported six public submodules but not `internals`, even
though `pandas/tests/api/test_api.py` lists `"internals"` in `allowed_api_dirs`.
A submodule only appears in its parent's `dir()` once imported, so
`pd.api.internals` was reachable only after an explicit `import
pandas.api.internals`, and running `pandas/tests/api/test_api.py` on its own
failed because `dir(pandas.api)` omitted `internals` depending on import order.

This PR imports `internals` (and adds it to `__all__`), matching the other six
public submodules, so `pd.api.internals` is reachable from a bare
`import pandas` and the API test is order-independent.

## Verification

- `pytest pandas/tests/api/test_api.py -q` → 21 passed, 1 xfailed
- `ruff check pandas/api/__init__.py` → All checks passed
- `ruff format --check pandas/api/__init__.py` → already formatted

## Automated contribution disclosure

- Tool: Pi coding agent (https://github.com/earendil-works/pi-coding-agent)
- Model: deepseek-v4-pro (via company-newapi)
- Reasoning-effort setting: off

The agent proposed the two-line change (the `internals` entry in the import
block and in `__all__`). I reviewed it, confirmed it against the root cause in
#67993, and verified it by running the API test in isolation before and after
the change.
