### PR TITLE
TST: Drop inert _SIZE_CUTOFF monkeypatch and rename duplicated test

### DIFF
--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -4,10 +4,7 @@ import re
 import numpy as np
 import pytest
 
-from pandas._libs import (
-    hashtable,
-    index as libindex,
-)
+from pandas._libs import hashtable
 
 import pandas as pd
 import pandas._testing as tm
@@ -273,18 +270,16 @@ def test_duplicated(idx_dup, keep, expected):
 
 
 @pytest.mark.arm_slow
-def test_duplicated_hashtable_impl(keep, monkeypatch):
+def test_duplicated_agrees_with_hashtable(keep):
     # GH 9125
     n, k = 6, 10
     levels = [np.arange(n), [str(i) for i in range(n)], 1000 + np.arange(n)]
     rng = np.random.default_rng(2)
     codes = [rng.choice(n, k * n) for _ in levels]
-    with monkeypatch.context() as m:
-        m.setattr(libindex, "_SIZE_CUTOFF", 50)
-        mi = pd.MultiIndex(levels=levels, codes=codes)
+    mi = pd.MultiIndex(levels=levels, codes=codes)
 
-        result = mi.duplicated(keep=keep)
-        expected = hashtable.duplicated(mi.values, keep=keep)
+    result = mi.duplicated(keep=keep)
+    expected = hashtable.duplicated(mi.values, keep=keep)
     tm.assert_numpy_array_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #67991
- [x] Tests added and passed
- [x] All code checks passed.
- [x] Added type annotations to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines.

Check exactly one of the following, per the automated contributions policy:

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting.

## Summary

`test_duplicated_hashtable_impl` wrapped its assertions in
`monkeypatch.setattr(libindex, "_SIZE_CUTOFF", 50)`, but nothing on the path
under test reads `_SIZE_CUTOFF`: `MultiIndex.duplicated` goes through
`get_group_index` + `hashtable.duplicated` on the codes and never constructs an
index engine, and no `MultiIndex` engine consults the cutoff. The monkeypatch
was inert, and the test name described a code path it never touched.

This PR drops the `monkeypatch.context()` block (along with the now-unused
`monkeypatch` fixture argument and `libindex` import) and renames the test to
`test_duplicated_agrees_with_hashtable`, which is what it actually asserts: the
codes-based `MultiIndex.duplicated` agrees with `hashtable.duplicated` over the
tuple values.

No whatsnew entry: this is a test-only cleanup with no user-visible behavior
change (the template asks for one only when fixing a bug or adding a feature).

## Verification

- `pytest pandas/tests/indexes/multi/test_duplicates.py -q` → 53 passed
- `ruff check pandas/tests/indexes/multi/test_duplicates.py` → All checks passed
- `ruff format --check pandas/tests/indexes/multi/test_duplicates.py` → already formatted

## Automated contribution disclosure

- Tool: Pi coding agent (https://github.com/earendil-works/pi-coding-agent)
- Model: deepseek-v4-pro (via company-newapi)
- Reasoning-effort setting: off

The agent proposed dropping the inert monkeypatch block and renaming the test.
I reviewed it against the root-cause analysis in #67991 and verified it by
running the test module before and after the change.
