### PR TITLE
CLN: Remove ChainIndexing asv benchmark

### DIFF
--- a/asv_bench/benchmarks/indexing.py
+++ b/asv_bench/benchmarks/indexing.py
@@ -19,7 +19,6 @@ from pandas import (
     Series,
     concat,
     date_range,
-    option_context,
     period_range,
 )
 
@@ -602,23 +601,6 @@ class SeriesSetitem:
 
     def time_setitem_slice_array_infer(self, dtype):
         self.s[:] = self.arr_obj
-
-
-class ChainIndexing:
-    params = [None, "warn"]
-    param_names = ["mode"]
-
-    def setup(self, mode):
-        self.N = 1000000
-        self.df = DataFrame({"A": np.arange(self.N), "B": "foo"})
-
-    def time_chained_indexing(self, mode):
-        df = self.df
-        N = self.N
-        with warnings.catch_warnings(record=True):
-            with option_context("mode.chained_assignment", mode):
-                df2 = df[df.A > N // 2]
-                df2["C"] = 1.0
 
 
 class Block:


### PR DESCRIPTION
- [x] closes #67989
- [x] Tests added and passed
- [x] All code checks passed.
- [x] Added type annotations to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines.

Check exactly one of the following, per the automated contributions policy:

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting.

## Summary

The `ChainIndexing` benchmark in `asv_bench/benchmarks/indexing.py` was written
to measure the `SettingWithCopy` bookkeeping, via a `[None, "warn"]` A/B over
`mode.chained_assignment` and a `catch_warnings` around the body.
`SettingWithCopyWarning` was removed in GH-56614, so those became no-ops.

What remains measures only the boolean mask (95% of the time), which is already
covered by `DataFrameIndexing.time_boolean_rows`, plus a column assignment
covered by `InsertColumns.time_assign_with_setitem`. It does not touch the
machinery it is named after (binding `df2` short-circuits the refcount test in
`DataFrame.__setitem__`), and making it genuinely chained yields no measurable
signal. There is no residual question this benchmark answers, so it is removed.

No whatsnew entry: this is a benchmark-only removal with no user-visible
behavior change.

## Verification

- `ruff check asv_bench/benchmarks/indexing.py` → All checks passed
- `ruff format --check asv_bench/benchmarks/indexing.py` → already formatted
- `ast.parse` syntax check on the file → OK

## Automated contribution disclosure

- Tool: Pi coding agent (https://github.com/earendil-works/pi-coding-agent)
- Model: deepseek-v4-pro (via company-newapi)
- Reasoning-effort setting: off

The agent proposed deleting the `ChainIndexing` class and removing the then
unused `option_context` import. I reviewed it against the analysis in #67989
(including the timing and call-count measurements quoted there) and confirmed
no remaining references to the class or the import in the file.
