### PR TITLE
TST: remove inert _SIZE_CUTOFF monkeypatch from MultiIndex duplicated test

### DIFF
--- a/pandas/tests/indexes/multi/test_duplicates.py
+++ b/pandas/tests/indexes/multi/test_duplicates.py
@@ -4,10 +4,7 @@ import re
 import numpy as np
 import pytest
 
-from pandas._libs import (
-    hashtable,
-    index as libindex,
-)
+from pandas._libs import hashtable
 
 import pandas as pd
 import pandas._testing as tm
@@ -273,18 +270,16 @@ def test_duplicated(idx_dup, keep, expected):
 
 
 @pytest.mark.arm_slow
-def test_duplicated_hashtable_impl(keep, monkeypatch):
+def test_duplicated_matches_hashtable(keep):
     # GH 9125
     n, k = 6, 10
     levels = [np.arange(n), [str(i) for i in range(n)], 1000 + np.arange(n)]
     rng = np.random.default_rng(2)
     codes = [rng.choice(n, k * n) for _ in levels]
-    with monkeypatch.context() as m:
-        m.setattr(libindex, "_SIZE_CUTOFF", 50)
-        mi = pd.MultiIndex(levels=levels, codes=codes)
+    mi = pd.MultiIndex(levels=levels, codes=codes)
 
-        result = mi.duplicated(keep=keep)
-        expected = hashtable.duplicated(mi.values, keep=keep)
+    result = mi.duplicated(keep=keep)
+    expected = hashtable.duplicated(mi.values, keep=keep)
     tm.assert_numpy_array_equal(result, expected)
 
 


### PR DESCRIPTION
- [x] closes #67991
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

`test_duplicated_hashtable_impl` monkeypatched `libindex._SIZE_CUTOFF` to 50, but nothing on the path under test reads it: `MultiIndex.duplicated` is `get_group_index` + `hashtable.duplicated` over the codes and never constructs an index engine. `BaseMultiIndexCodesEngine` has no `over_size_threshold` member either, so no MultiIndex engine consults the cutoff even when one is built.

This drops the `monkeypatch.context()` block and the fixture argument, renames the test to what it actually asserts — that the codes-based `MultiIndex.duplicated` agrees with `hashtable.duplicated` over the tuple values — and removes the `libindex` import, which becomes unused.

Test-only change, so no whatsnew entry. `pandas/tests/indexes/multi/test_duplicates.py` is 53 passed locally, and `pre-commit run --files` on the changed file is clean.

Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

AI disclosure: Claude Code running `claude opus 5 (high)` made the code change and ran the verification reported above (the test file, and `pre-commit run --files` on it).
