### PR TITLE
TST: tuple-of-Timestamp dict keys against tuple-of-date columns (GH#36131)

### DIFF
--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -2567,6 +2567,18 @@ class TestDataFrameConstructors:
         expected = pd.DataFrame([0, 1, 2], columns=pd.Index(pd.Series([tup])))
         tm.assert_frame_equal(result, expected)
 
+    def test_datetime_date_tuple_columns_from_dict_timestamp_keys(self):
+        # GH#36131 a Timestamp key does not match a date column, so this behaves
+        #  like any other non-matching key and gives an empty frame
+        day = date(2011, 1, 1)
+        tup = day, day
+        ts = pd.Timestamp(day) + timedelta(hours=1)
+        result = pd.DataFrame(
+            {(ts, ts): pd.Series(range(3), index=range(3))}, columns=[tup]
+        )
+        expected = pd.DataFrame(columns=pd.Index(pd.Series([tup])))
+        tm.assert_frame_equal(result, expected)
+
     def test_construct_with_two_categoricalindex_series(self):
         # GH 14600
         s1 = pd.Series(


### PR DESCRIPTION
No issue to close — this finishes a test that was written while GH-36131 was still a deprecation and left half-commented ("enable the rest once enforced").

The deprecation is enforced: `Timestamp == date` now raises rather than comparing equal, so a `Timestamp`-tuple dict key no longer matches a `date`-tuple entry in `columns`, and the constructor falls back to the ordinary non-matching-key result (an empty frame with the requested column). Nothing upstream covered that.

The new test sits immediately after its GH-10863 sibling `test_datetime_date_tuple_columns_from_dict`, which pins the matching-key case producing `[0, 1, 2]` — so the pair brackets the behavior and the new one is not a tautology: if the tuples compared equal again it would fail.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which verified the behavior on main, wrote the test, and ran it.