### PR TITLE
BLD: pass --shared=pandas._libs._cyutility to window extensions

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -237,6 +237,7 @@ Other API changes
 Build
 ^^^^^
 - C++20 is required to build from source (:issue:`66735`)
+- The ``pandas._libs.window`` extensions now pass ``--shared=pandas._libs._cyutility`` to Cython, sharing the utility code instead of embedding a copy in each extension and reducing wheel size (:issue:`67995`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.deprecations:

--- a/pandas/_libs/window/meson.build
+++ b/pandas/_libs/window/meson.build
@@ -2,7 +2,7 @@ cy_args = ['-X always_allow_keywords=true']
 # Use shared utility code to reduce wheel sizes
 # copied from https://github.com/scikit-learn/scikit-learn/pull/31151/files
 if cy.version().version_compare('>=3.1.0')
-    cython_args += ['--shared=pandas._libs._cyutility']
+    cy_args += ['--shared=pandas._libs._cyutility']
 endif
 
 py.extension_module(


### PR DESCRIPTION
- [x] closes #67995

`pandas/_libs/window/meson.build` appends `--shared=pandas._libs._cyutility` to `cython_args`, but both `py.extension_module` calls pass `cython_args: cy_args`, so the flag never reaches the `aggregations` or `indexers` extensions (and the `+=` mutates the inherited `cython_args` as a side effect). Append to `cy_args` instead so the flag is actually passed.

Wheel-size only; no correctness impact.

Verification: reconfigured the meson build and confirmed the Cython commands for both window extensions now include `--shared=pandas._libs._cyutility`, recompiled both extensions, and ran a rolling-sum/mean smoke test.

---

AI-assisted contribution disclosure: this change was prepared with the assistance of an AI coding agent (Pi coding agent, model deepseek-v4-pro, reasoning-effort setting off).
