### PR TITLE
BLD: consider platform-specific pixi targets in test dependency validation

### DIFF
--- a/scripts/tests/test_validate_test_dependencies.py
+++ b/scripts/tests/test_validate_test_dependencies.py
@@ -1,5 +1,6 @@
 import pytest
 
+import scripts.validate_test_dependencies as vm
 from scripts.validate_test_dependencies import (
     ALLOWED_UNDECLARED,
     declared_packages,
@@ -22,30 +23,40 @@ PIXI = {
         "numpy-nightly": ["test-base", "nightly"],
         "docs": {"features": ["documentation"]},
     },
+    "target": {
+        "win": {"dependencies": {"tzdata": ">=2023.3"}},
+    },
 }
 
 
 def test_declared_packages_unions_the_given_environments() -> None:
-    result = declared_packages(PIXI, ["py313", "downstream"])
-    assert result == {"python-dateutil", "pytest", "scipy", "dask"}
+    everywhere, _ = declared_packages(PIXI, ["py313", "downstream"])
+    assert everywhere == {"python-dateutil", "pytest", "scipy", "dask"}
 
 
 def test_declared_packages_excludes_other_environments() -> None:
     # sphinx is only installed in an environment that does not run pytest
-    assert "sphinx" not in declared_packages(PIXI, ["py313", "downstream"])
+    everywhere, _ = declared_packages(PIXI, ["py313", "downstream"])
+    assert "sphinx" not in everywhere
 
 
 def test_declared_packages_includes_pypi_dependencies() -> None:
-    assert "numpy" in declared_packages(PIXI, ["numpy-nightly"])
+    everywhere, _ = declared_packages(PIXI, ["numpy-nightly"])
+    assert "numpy" in everywhere
 
 
 def test_declared_packages_accepts_a_bare_feature_list() -> None:
     # pixi allows both `env = [...]` and `env = { features = [...] }`
-    assert declared_packages(PIXI, ["numpy-nightly"]) == {
-        "python-dateutil",
-        "pytest",
-        "numpy",
-    }
+    everywhere, _ = declared_packages(PIXI, ["numpy-nightly"])
+    assert everywhere == {"python-dateutil", "pytest", "numpy"}
+
+
+def test_declared_packages_reports_platform_specific_targets() -> None:
+    # [target.win.dependencies] installs tzdata only on Windows, so it is not
+    # part of `everywhere` but is reported with the platform it runs on.
+    everywhere, platform_only = declared_packages(PIXI, ["py313"])
+    assert "tzdata" not in everywhere
+    assert platform_only == {"tzdata": {"win"}}
 
 
 def test_environments_running_tests_reads_the_workflow_matrix() -> None:
@@ -62,3 +73,45 @@ def test_repository_test_dependencies_are_declared(capsys) -> None:
 @pytest.mark.parametrize("module", sorted(ALLOWED_UNDECLARED))
 def test_allowed_undeclared_entries_have_a_reason(module) -> None:
     assert ALLOWED_UNDECLARED[module].strip()
+
+
+def test_validate_reports_platform_only_gate_without_failing(
+    monkeypatch, capsys, tmp_path
+) -> None:
+    # A gate on a package that is declared only for one platform (e.g. Windows)
+    # runs there, so it is reported but must not fail the hook.
+    pixi = tmp_path / "pixi.toml"
+    pixi.write_text(
+        "[dependencies]\n"
+        'python-dateutil = ">=2.9.0"\n'
+        "\n"
+        "[environments]\n"
+        "py313 = []\n"
+        "\n"
+        "[target.win.dependencies]\n"
+        'tzdata = ">=2023.3"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(vm, "PIXI_PATH", pixi)
+    monkeypatch.setattr(vm, "environments_running_tests", lambda: {"py313"})
+    monkeypatch.setattr(vm, "gated_modules", lambda: {"tzdata": {"a.py"}})
+
+    assert validate_test_dependencies() == 0
+    out = capsys.readouterr().out
+    assert "win" in out
+    assert "never run" not in out
+
+
+def test_validate_fails_when_gate_runs_nowhere(monkeypatch, capsys, tmp_path) -> None:
+    pixi = tmp_path / "pixi.toml"
+    pixi.write_text(
+        '[dependencies]\npython-dateutil = ">=2.9.0"\n\n[environments]\npy313 = []\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(vm, "PIXI_PATH", pixi)
+    monkeypatch.setattr(vm, "environments_running_tests", lambda: {"py313"})
+    monkeypatch.setattr(vm, "gated_modules", lambda: {"nonexistent": {"a.py"}})
+
+    assert validate_test_dependencies() == 1
+    out = capsys.readouterr().out
+    assert "never run" in out

--- a/scripts/validate_test_dependencies.py
+++ b/scripts/validate_test_dependencies.py
@@ -69,6 +69,12 @@ MESSAGE = (
     "tests never run:"
 )
 
+PLATFORM_ONLY_MESSAGE = (
+    "{module!r} gates tests with importorskip/skip_if_no, and {package!r} is "
+    "installed only on {platforms}; these tests are skipped on the other "
+    "platforms:"
+)
+
 
 def environments_running_tests() -> set[str]:
     """
@@ -87,9 +93,19 @@ def environments_running_tests() -> set[str]:
     return environments
 
 
-def declared_packages(pixi: dict, environments: Iterable[str]) -> set[str]:
+def declared_packages(
+    pixi: dict, environments: Iterable[str]
+) -> tuple[set[str], dict[str, set[str]]]:
     """
-    Every package installed in at least one of ``environments``.
+    Return ``(everywhere, platform_only)``.
+
+    ``everywhere`` is the set of packages installed in at least one of
+    ``environments`` regardless of platform (top-level dependencies plus each
+    environment's feature dependencies).
+
+    ``platform_only`` maps a package to the set of platforms on which it is
+    declared under a ``[target.<platform>.dependencies]`` (or
+    ``pypi-dependencies``) table.
     """
     packages = set(pixi.get("dependencies", {}))
     for environment in environments:
@@ -102,7 +118,13 @@ def declared_packages(pixi: dict, environments: Iterable[str]) -> set[str]:
             block = pixi["feature"].get(feature, {})
             packages.update(block.get("dependencies", {}))
             packages.update(block.get("pypi-dependencies", {}))
-    return packages
+
+    platform_only: dict[str, set[str]] = {}
+    for platform, target in pixi.get("target", {}).items():
+        for key in ("dependencies", "pypi-dependencies"):
+            for package in target.get(key, {}):
+                platform_only.setdefault(package, set()).add(platform)
+    return packages, platform_only
 
 
 def gated_modules() -> dict[str, set[str]]:
@@ -122,7 +144,7 @@ def gated_modules() -> dict[str, set[str]]:
 def validate_test_dependencies() -> int:
     with open(PIXI_PATH, "rb") as file_handle:
         pixi = tomllib.load(file_handle)
-    declared = declared_packages(pixi, environments_running_tests())
+    declared, platform_only = declared_packages(pixi, environments_running_tests())
 
     ret = 0
     for module, paths in sorted(gated_modules().items()):
@@ -130,6 +152,20 @@ def validate_test_dependencies() -> int:
             continue
         package = IMPORT_TO_CONDA.get(module, module)
         if package in declared:
+            continue
+        platforms = platform_only.get(package)
+        if platforms:
+            # Runs only on some platforms, so the gate is not silently dead
+            # everywhere; report it but do not fail the hook.
+            print(
+                PLATFORM_ONLY_MESSAGE.format(
+                    module=module,
+                    package=package,
+                    platforms=", ".join(sorted(platforms)),
+                )
+            )
+            for path in sorted(paths):
+                print(f"    {path}")
             continue
         print(MESSAGE.format(module=module, package=package))
         for path in sorted(paths):


### PR DESCRIPTION
- [x] closes #67985

`scripts/validate_test_dependencies.py` built its set of installed packages from the top-level `[dependencies]` table plus each environment's feature `dependencies`/`pypi-dependencies`, ignoring `[target.<platform>.dependencies]` tables. A gate on a platform-scoped dependency (e.g. `tzdata` under `[target.win.dependencies]`) was therefore reported as "not installed in any environment ... so these tests never run", which is false.

This change makes `declared_packages` return `(everywhere, platform_only)`: the set of packages installed regardless of platform, plus a mapping of packages declared only under a platform-specific target to the platforms they run on. The validator now reports platform-only gates with "installed only on <platform>" without failing the hook, and only fails when a gate runs nowhere.

Tests: updated the `declared_packages` unit tests for the new return shape, added a test covering `[target.win.dependencies]` parsing, and added two `validate_test_dependencies` tests (via monkeypatched `PIXI_PATH`/`gated_modules`) asserting that a platform-only gate reports `win` and returns 0, while a gate that runs nowhere returns 1. `ruff check`/`format` pass and the full `scripts/tests/test_validate_test_dependencies.py` suite passes (10 passed).

---

AI-assisted contribution disclosure: this change was prepared with the assistance of an AI coding agent (Pi coding agent, model deepseek-v4-pro, reasoning-effort setting off).
