### PR TITLE
BUG: to_numeric with errors=coerce gave a float nan instead of a null for ArrowDtype

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -614,6 +614,7 @@ Conversion
 - Fixed bug in :class:`DataFrame` constructor where mutating the result could corrupt the source :class:`Series` or :class:`Index` when built with ``dtype="str"`` and ``infer_string=False`` (:issue:`63936`)
 - Fixed bug in :func:`to_numeric` where a string containing an embedded NUL byte was converted using only the bytes before the NUL, so e.g. ``"1.5\x00xyz"`` silently became ``1.5``; such values now raise, or become ``NaN`` with ``errors="coerce"`` (:issue:`66524`)
 - Fixed bug in :func:`to_numeric` where values preceding the first complex number in ``object``-dtype data were replaced with uninitialized memory, so e.g. ``to_numeric(Series(["1.5", 2j]))`` returned ``0j`` in place of ``1.5+0j`` (:issue:`35051`)
+- Fixed bug in :func:`to_numeric` with ``errors="coerce"`` where a value that failed to parse became ``NaN`` instead of a missing value for :class:`ArrowDtype` input, so :meth:`Series.isna` did not detect it and :meth:`Series.ffill` did not fill it (:issue:`67949`)
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``TypeError`` when ``to_replace`` was ``Ellipsis`` (``...``) (:issue:`50373`)
 - Fixed bug in :meth:`DataFrame.to_dict` with ``orient="index"`` did not respect the ``into`` argument in nested mappings (:issue:`65778`)

--- a/pandas/core/tools/numeric.py
+++ b/pandas/core/tools/numeric.py
@@ -256,6 +256,7 @@ def to_numeric(
             set(),
             coerce_numeric=coerce_numeric,
             convert_to_masked_nullable=dtype_backend is not lib.no_default
+            or isinstance(values_dtype, ArrowDtype)
             or (
                 isinstance(values_dtype, StringDtype)
                 and values_dtype.na_value is libmissing.NA
@@ -307,6 +308,12 @@ def to_numeric(
         if mask is None or (new_mask is not None and new_mask.shape == mask.shape):
             # GH 52588
             mask = new_mask
+        elif new_mask is not None:
+            # GH 67949 mask covers every position and new_mask only the ones that
+            # survived dropna above, so drop the parse failures into the slots that
+            # were not already null instead of losing them
+            mask = mask.copy()
+            mask[~mask] = new_mask
         else:
             mask = mask.copy()
         assert isinstance(mask, np.ndarray)

--- a/pandas/tests/tools/test_to_numeric.py
+++ b/pandas/tests/tools/test_to_numeric.py
@@ -737,6 +737,28 @@ def test_to_numeric_from_nullable_string_coerce(nullable_string_dtype):
 
 
 @pytest.mark.parametrize(
+    "values, expected",
+    [
+        (["1", "NaN"], [1, None]),
+        (["1", None, "x"], [1, None, None]),
+        (["x", None, "5"], [None, None, 5]),
+        (["1", "2"], [1, 2]),
+    ],
+)
+def test_to_numeric_arrow_string_coerce(values, expected):
+    # GH#67949 coerce has to give a real null, not a float nan, and a value that
+    # was already null has to stay null alongside one that failed to parse.
+    # note this needs ArrowDtype, not StringDtype. dtype="string[pyarrow]" gives
+    # StringDtype, which already behaved correctly, so a test built that way passes
+    # with or without the fix
+    pa = pytest.importorskip("pyarrow")
+    ser = pd.Series(values, dtype=pd.ArrowDtype(pa.string()))
+    result = pd.to_numeric(ser, errors="coerce")
+    assert result.isna().tolist() == [v is None for v in expected]
+    assert result.dropna().tolist() == [v for v in expected if v is not None]
+
+
+@pytest.mark.parametrize(
     "data, input_dtype, downcast, expected_dtype",
     (
         ([1, 1], "Int64", "integer", "Int8"),


### PR DESCRIPTION
Closes #67949

Two things were wrong, and the second only shows up once the first is fixed.

The flag that decides whether `maybe_convert_numeric` hands back a mask lists `StringDtype` and not `ArrowDtype`, so for an arrow column a value that failed to parse ended up as a plain float nan. `isna` did not see it and `ffill` did not fill it. That is what the issue reports, and it is why it worked for `StringDtype`.

Adding arrow to that condition on its own is not a fix though. `mask` covers every position and `new_mask` only the ones that survived the `dropna` above, so when a column has a null and a bad value the two are never combined:

```
mask=(3,)  new_mask=(2,)  values=(1,)
```

`data[~mask] = values` then has one value for two open slots and numpy broadcasts it, so `["1", None, "x"]` came back as `[1, <NA>, 1]`. The bad value became a copy of the good one. So the masks are merged instead, by dropping the parse failures into the slots that were not already null.

The test covers both, and one thing worth flagging for whoever reviews it: `dtype="string[pyarrow]"` gives `StringDtype`, not `ArrowDtype`, and `StringDtype` already behaved correctly. A test written that way passes with or without the change, so it builds `pd.ArrowDtype(pa.string())` explicitly.

`pandas/tests/tools` and `pandas/tests/dtypes` pass, 7196 tests. With the change removed, three of the four new cases fail.
