### PR TITLE
BUG: is_list_like was False for an Enum class so it could not be used as columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -932,6 +932,7 @@ Styler
 Other
 ^^^^^
 
+- Bug in :class:`DataFrame` constructor where passing an :class:`~enum.Enum` subclass as ``index`` or ``columns`` raised ``TypeError`` even though it is iterable; :func:`api.types.is_list_like` now reports a class as list-like when its metaclass defines ``__iter__`` (:issue:`54386`)
 - Bug in :class:`DataFrame` constructor where passing the same :class:`Index` object as both ``index`` and ``columns`` shared a single object between the two axes, so mutating metadata such as ``names`` on one would also change the other (:issue:`42934`)
 - Bug in :func:`eval` and :meth:`DataFrame.eval` where passing a :class:`Series` or :class:`DataFrame` as ``expr`` silently parsed its (possibly truncated) repr instead of raising, producing a confusing error (:issue:`16289`)
 - Bug in :func:`option_context` where deprecation warnings pointed to ``contextlib.__enter__`` instead of user code (:issue:`63235`)

--- a/pandas/_libs/lib.pyx
+++ b/pandas/_libs/lib.pyx
@@ -1523,7 +1523,11 @@ cdef bint c_is_list_like(object obj, bint allow_sets) except -1:
     # then the generic implementation
     return (
         # equiv: `isinstance(obj, abc.Iterable)`
-        getattr(obj, "__iter__", None) is not None and not isinstance(obj, type)
+        getattr(obj, "__iter__", None) is not None
+        # a class only iterates if its metaclass says so. `list.__iter__` exists but
+        # `iter(list)` fails, while an Enum subclass is iterable through EnumType
+        and not (isinstance(obj, type)
+                 and getattr(type(obj), "__iter__", None) is None)
         # we do not count strings/unicode/bytes as list-like
         # exclude Generic types that have __iter__
         and not isinstance(obj, (str, bytes, _GenericAlias, GenericAlias))

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -15,6 +15,7 @@ from datetime import (
     timedelta,
 )
 from decimal import Decimal
+from enum import Enum
 from fractions import Fraction
 from io import StringIO
 import itertools
@@ -246,6 +247,28 @@ def test_is_list_like_native_container_types():
     assert not inference.is_list_like(list[str])
     assert not inference.is_list_like(tuple[int])
     assert not inference.is_list_like(tuple[str])
+
+
+def test_is_list_like_enum_class():
+    # GH 54386
+    # an Enum subclass iterates through its metaclass, so the class itself is
+    # list-like even though it is a class. the members are not
+    class Color(Enum):
+        RED = 1
+        GREEN = 2
+
+    assert list(Color) == [Color.RED, Color.GREEN]
+    assert inference.is_list_like(Color)
+    assert not inference.is_list_like(Color.RED)
+
+    # a class whose metaclass has no __iter__ stays scalar. list.__iter__ exists
+    # but iter(list) raises, so this is the case the class check was there for
+    class Plain:
+        pass
+
+    assert not inference.is_list_like(Plain)
+    assert not inference.is_list_like(list)
+    assert not inference.is_list_like(dict)
 
 
 def test_is_sequence():

--- a/pandas/tests/frame/test_constructors.py
+++ b/pandas/tests/frame/test_constructors.py
@@ -16,6 +16,7 @@ from datetime import (
     datetime,
     timedelta,
 )
+from enum import Enum
 import functools
 import re
 import zoneinfo
@@ -2998,6 +2999,17 @@ class TestDataFrameConstructors:
         df = pd.DataFrame(dummy)
         expected = pd.DataFrame(np.eye(3))
         tm.assert_frame_equal(df, expected)
+
+    def test_constructor_columns_enum(self):
+        # GH 54386
+        # an Enum subclass is iterable, so it should be usable as columns
+        class Color(Enum):
+            RED = 1
+            GREEN = 2
+
+        result = pd.DataFrame(columns=Color)
+        expected = pd.DataFrame(columns=[Color.RED, Color.GREEN])
+        tm.assert_frame_equal(result, expected)
 
 
 class TestDataFrameConstructorIndexInference:


### PR DESCRIPTION
closes #54386

an enum subclass is iterable , `list(Color)` gives you the members , but `is_list_like` said
false for it so `DataFrame(columns=Color)` raised .

the class check in `c_is_list_like` is there for a good reason , `list.__iter__` exists while
`iter(list)` raises . but that only holds when the metaclass has no `__iter__` of its own . an
enum has one through `EnumType` , which is why `iter(Color)` works . so it asks the metaclass
now instead of turning down every class .

worth flagging , the shorter version of this does not work . checking `type(obj)` looks right
but `getattr` on a type still walks the metaclass , so `Color.RED` comes back list like , and
a member is a scalar not a collection . there is a test pinning that .

i compared the old check , the new one and what `iter()` really does over 45 objects . four
answers change and all four were wrong before , enum classes and anything else with an
iterable metaclass . nothing else moves .

89905 tests pass across dtypes , frame , series , indexes , reshape , groupby , apply ,
indexing , tools and base . both new tests fail with the change taken out .


---

disclosure , as the automated contributions policy asks for . tool is claude code , model
claude opus 5 . i used it to work through the cause , to write the patch and the tests , and
to help word this description . i went over the result myself and every number quoted above
comes from a run on my own machine . sorry it was not in here when i opened it , i had not
read the policy at that point .
