### PR TITLE
BUG: MultiIndex.factorize dropped level dtypes and names

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -700,6 +700,7 @@ Missing
 MultiIndex
 ^^^^^^^^^^
 - Bug in :class:`MultiIndex` where pickling a :class:`DataFrame` with a ``datetime64[ns]`` level raised ``NotImplementedError`` (:issue:`63078`)
+- Bug in :meth:`MultiIndex.factorize` where the ``uniques`` were rebuilt from tuples, so extension dtypes such as ``Int32`` on a level were replaced with ``float64`` and the level names were dropped; the result now matches :meth:`MultiIndex.unique` (:issue:`62337`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
 - Bug in :meth:`MultiIndex.get_loc` where looking up a tuple key containing a scalar inside an :class:`IntervalIndex` level with overlapping intervals raised ``KeyError`` or returned incorrect results (:issue:`27456`)
 - Bug in :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` raising ``IndexError`` instead of a clear ``ValueError`` when passing an empty sequence with ``level=None`` or a list-like ``level`` (:issue:`16147`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -700,8 +700,8 @@ Missing
 MultiIndex
 ^^^^^^^^^^
 - Bug in :class:`MultiIndex` where pickling a :class:`DataFrame` with a ``datetime64[ns]`` level raised ``NotImplementedError`` (:issue:`63078`)
-- Bug in :meth:`MultiIndex.factorize` where the ``uniques`` were rebuilt from tuples, so extension dtypes such as ``Int32`` on a level were replaced with ``float64`` and the level names were dropped; the result now matches :meth:`MultiIndex.unique` (:issue:`62337`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
+- Bug in :meth:`MultiIndex.factorize` where the ``uniques`` were rebuilt from tuples, so extension dtypes such as ``Int32`` on a level were replaced with ``float64`` and the level names were dropped; the result now matches :meth:`MultiIndex.unique` (:issue:`62337`)
 - Bug in :meth:`MultiIndex.get_loc` where looking up a tuple key containing a scalar inside an :class:`IntervalIndex` level with overlapping intervals raised ``KeyError`` or returned incorrect results (:issue:`27456`)
 - Bug in :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` raising ``IndexError`` instead of a clear ``ValueError`` when passing an empty sequence with ``level=None`` or a list-like ``level`` (:issue:`16147`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -1523,7 +1523,11 @@ class IndexOpsMixin(OpsMixin):
                 # GH#57517
                 uniques = self[:0]
             else:
-                uniques = self._constructor(uniques)
+                # GH#62337 rebuilding from the tuples re-infers every level, which
+                # drops extension dtypes and the names. take the rows back out of
+                # self instead, the codes already say which ones they are
+                first = np.unique(codes, return_index=True)[1]
+                uniques = self.take(first)
         else:
             from pandas import Index
 

--- a/pandas/tests/test_algos.py
+++ b/pandas/tests/test_algos.py
@@ -47,13 +47,16 @@ class TestFactorize:
         obj = index_or_series_obj_orderable
         result_codes, result_uniques = obj.factorize(sort=sort)
 
-        constructor = pd.Index
-        if isinstance(obj, pd.MultiIndex):
-            constructor = pd.MultiIndex.from_tuples
         expected_arr = obj.unique()
         if expected_arr.dtype == np.float16:
             expected_arr = expected_arr.astype(np.float32)
-        expected_uniques = constructor(expected_arr)
+        if isinstance(obj, pd.MultiIndex):
+            # GH#62337 unique() already hands back a MultiIndex with the level
+            # dtypes and the names intact, going back through the tuples throws
+            # both of those away
+            expected_uniques = expected_arr
+        else:
+            expected_uniques = pd.Index(expected_arr)
         if (
             isinstance(obj, pd.Index)
             and expected_uniques.dtype == bool
@@ -72,6 +75,20 @@ class TestFactorize:
 
         tm.assert_numpy_array_equal(result_codes, expected_codes)
         tm.assert_index_equal(result_uniques, expected_uniques, exact=True)
+
+    def test_factorize_multiindex_keeps_level_dtypes_and_names(self):
+        # GH#62337
+        ser = pd.Series([1, None, 1], dtype="Int32")
+        mi = pd.MultiIndex.from_frame(ser.to_frame(name="col"))
+
+        codes, uniques = mi.factorize()
+
+        tm.assert_numpy_array_equal(codes, np.array([0, 1, 0], dtype=np.intp))
+        # this used to come back float64 with no name, because the uniques were
+        # rebuilt from the tuples instead of taken out of the index
+        assert uniques.dtypes.tolist() == [ser.dtype]
+        assert uniques.names == ["col"]
+        tm.assert_index_equal(uniques, mi.unique())
 
     def test_series_factorize_use_na_sentinel_false(self):
         # GH#35667


### PR DESCRIPTION
closes #62337

`MultiIndex.factorize` built the uniques with `self._constructor(uniques)` , which goes back
through the tuples and works every level out again . so an `Int32` level came back as
`float64` , and the names were dropped on the way .

the codes are already right though , only the boxing was wrong . so this takes the rows back
out of the index instead , which leaves the levels alone :

```python
first = np.unique(codes, return_index=True)[1]
uniques = self.take(first)
```

the uniques are now the same thing `MultiIndex.unique` gives you , same levels , same names ,
same dtypes . before this the two disagreed with each other .

@mroeschke on #62964 you said the real problem is `algorithms.factorize` being called on
`self._values` . that is true for the work it does , it still builds tuples . i checked
whether it is also true for the answer and it is not . 400 random multi indexes with nan ,
none and nat in them never gave back a `-1` , and 4400 factorize calls comparing this against
the old path came out with the same codes and the same values every time . so the dtype loss
was only in the boxing .

a version built on `self.codes` would be quicker because it would skip the tuples . happy to
do that one instead if you would rather have it , it is a bigger change and i did not want to
guess at it .

one thing worth a look . `test_factorize` built its expected value with
`MultiIndex.from_tuples` , which is the same lossy path , so it was checking the old
behaviour against itself . it compares against `unique` now . four cases were red on that and
are green .

134504 tests pass across indexes , algos , base , groupby , reshape , frame , series ,
extension , dtypes , apply and indexing .


---

disclosure , as the automated contributions policy asks for . tool is claude code , model
claude opus 5 . i used it to work through the cause , to write the patch and the tests , and
to help word this description . i went over the result myself and every number quoted above
comes from a run on my own machine . sorry it was not in here when i opened it , i had not
read the policy at that point .
