### PR TITLE
BUG: HDFStore.select emitted the GH#50598 nested-OR warning twice per read

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -6509,14 +6509,16 @@ class Selection:
             # create the numexpr & the filter
             if self.terms is not None:
                 self.condition, self.filter = self.terms.evaluate()
-                if self.condition is not None:
-                    self._warn_if_unreliable_or()
 
     def _warn_if_unreliable_or(self) -> None:
         """
         Warn for nested-OR queries with AND-ed operands over indexed columns
         (e.g. ``(A & B) | (C & D)``) that can return incorrect results due to
         an upstream PyTables bug (GH#50598).
+
+        Called from the query methods rather than ``__init__``: one read builds
+        several ``Selection`` objects for the same ``where``, and only the one
+        that runs the condition should warn.
         """
         table = getattr(self.table, "table", None)
         if table is None:
@@ -6572,6 +6574,7 @@ class Selection:
         generate the selection
         """
         if self.condition is not None:
+            self._warn_if_unreliable_or()
             try:
                 return self.table.table.read_where(
                     self.condition.format(), start=self.start, stop=self.stop
@@ -6612,6 +6615,7 @@ class Selection:
             stop += nrows
 
         if self.condition is not None:
+            self._warn_if_unreliable_or()
             coords = self.table.table.get_where_list(
                 self.condition.format(), start=start, stop=stop, sort=True
             )

--- a/pandas/tests/io/pytables/test_select.py
+++ b/pandas/tests/io/pytables/test_select.py
@@ -1342,3 +1342,25 @@ def test_remove_nested_or_query_warns(temp_hdfstore):
     # test_select_nested_or_query_wrong_rows_single_chunk
     assert removed == 0
     assert temp_hdfstore.get_storer("df").nrows == len(df)
+
+
+@pytest.mark.parametrize(
+    "read",
+    [
+        lambda store, where: store.select("df", where=where),
+        lambda store, where: list(store.select("df", where=where, chunksize=5)),
+        lambda store, where: store.select_as_coordinates("df", where=where),
+    ],
+    ids=["select", "iterator", "select_as_coordinates"],
+)
+def test_select_nested_or_query_warns_once(temp_hdfstore, read):
+    # GH#50598 one read builds several Selection objects for the same "where",
+    # so the warning has to come from the query rather than from every parse
+    df = pd.DataFrame({"a": np.arange(10), "b": np.arange(10)})
+    temp_hdfstore.put(
+        "df", df, format="table", data_columns=["a", "b"], track_times=False
+    )
+    with tm.assert_produces_warning(UserWarning, match="GH#50598") as record:
+        read(temp_hdfstore, "(a > 100 & b > 100) | (a < 5 & b < 5)")
+
+    assert sum("GH#50598" in str(warning.message) for warning in record) == 1


### PR DESCRIPTION
The GH-50598 nested-OR warning added in GH-65789 was emitted twice for a single read.
It fired from `Selection.__init__`, but one read builds more than one `Selection` for the
same `where` — `AppendableFrameTable.read` builds one to fetch the rows and another to
carry the post-read filters, and the `read_coordinates` path (`chunksize`/iterator,
`select_as_coordinates`, `select_as_multiple`) additionally parses the condition once in
`_where_selects_columns`. `select`, `select(columns=...)`, the iterator form and
`select_as_coordinates` all warned twice; `remove` warned once.

The warning now comes from `Selection.select()` and `Selection.select_coords()` — the two
methods that actually run the condition against the table — so it lands exactly once per
read on every entry point. The extra `Selection` objects never execute the condition, so
none of them warn, and no path loses the warning it had.

No whatsnew: GH-65789 has not been released, so the duplicate never shipped and the
existing 3.1.0 entry still describes the behavior correctly.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the
duplicate construction sites, made the change, and wrote the regression test; reviewed by me.
