### PR TITLE
BLD: Use shared Cython utilities for window extensions

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -56,6 +56,7 @@ Other enhancements
 - Removed Hypothesis as a test dependency (:issue:`66675`).
 - Time strings with a space before ``AM``/``PM`` (e.g. ``"3:25:00 PM"``) are now recognized; :meth:`Series.between_time` and :meth:`DataFrame.between_time` previously raised on them, and :meth:`Series.at_time` and :meth:`DataFrame.at_time` warned that they would raise in a future version. Casting such strings to a pyarrow time dtype (``time32``/``time64``) no longer silently gives a missing value (:issue:`18793`)
 - Building from source no longer fails when compiling the windowing extensions against C++ standard libraries that provide only ``std::signbit`` (:issue:`50979`, :issue:`51047`)
+- Removed duplicated Cython utility code from window extensions (:issue:`67995`)
 - Setting values with :meth:`DataFrame.at` or :meth:`Series.at` using a non-scalar indexer (e.g. a boolean mask, list, or array) now raises a clearer ``InvalidIndexError`` directing users to ``.loc`` (:issue:`51866`)
 
 .. ---------------------------------------------------------------------------

--- a/pandas/_libs/window/meson.build
+++ b/pandas/_libs/window/meson.build
@@ -2,7 +2,7 @@ cy_args = ['-X always_allow_keywords=true']
 # Use shared utility code to reduce wheel sizes
 # copied from https://github.com/scikit-learn/scikit-learn/pull/31151/files
 if cy.version().version_compare('>=3.1.0')
-    cython_args += ['--shared=pandas._libs._cyutility']
+    cy_args += ['--shared=pandas._libs._cyutility']
 endif
 
 py.extension_module(


### PR DESCRIPTION
closes [67995](https://github.com/pandas-dev/pandas/issues/67995)

fixes `pandas/_libs/window/meson.build`; `--shared=pandas._libs._cyutility` was appended to `cython_args` instead of `cy_args`. with this fix, both window extensions now link to shared Cython utility module when Cython >= 3.1.0


Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [x] I did **not** use AI to develop this pull request.
- [ ] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

