### PR TITLE
[fix] DataFrame.unstack(sort=False) mislabels columns when the unstac…

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -898,6 +898,7 @@ Reshaping
 - Bug in :meth:`DataFrame.select_dtypes` where the string form of an Arrow dtype such as ``"int64[pyarrow]"`` selected no columns and ``"float64[pyarrow]"`` selected numpy float columns; an Arrow dtype string now selects only columns of that exact dtype (:issue:`59888`)
 - Bug in :meth:`DataFrame.stack` raising a bare ``AssertionError`` or an ``IndexError`` when ``level`` contained duplicate entries, including duplicates produced by resolving level names or negative level numbers; it now raises an informative ``ValueError`` (:issue:`66588`)
 - Bug in :meth:`DataFrame.unstack` and :meth:`Series.unstack` with ``sort=False`` placing values under the wrong row labels, or collapsing distinct index combinations into a single row (:issue:`62816`)
+- Bug in :meth:`DataFrame.unstack` with ``sort=False`` mislabeling columns when the unstacked level had entries that were entirely unused; the underlying values were placed correctly, only the column labels were wrong (:issue:`66673`)
 - Bug in :meth:`Index.union` where the result could be unsorted when both inputs were monotonic increasing but disjoint, when ``sort`` was not ``False`` (:issue:`54646`)
 - Bug in :meth:`Series.unstack` with ``sort=False`` always placing a ``NaN`` column first without reordering the corresponding values (:issue:`66672`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -156,7 +156,13 @@ class _Unstacker:
                 self.unique_nan_index = np.flatnonzero(nan_mask)[0]
 
             self.removed_level = self.removed_level.take(unique_codes)
-            self.removed_level_full = self.removed_level_full.take(unique_codes)
+            # unique_codes indexes into self.removed_level (already reduced to
+            # used entries by index.remove_unused_levels() above), not into
+            # self.removed_level_full, which may still contain entries removed
+            # from self.removed_level (GH#66673); re-derive positions by label.
+            self.removed_level_full = self.removed_level_full.take(
+                self.removed_level_full.get_indexer(self.removed_level)
+            )
 
         if config["mode"]["performance_warnings"]:
             # Bug fix GH 20601

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1469,6 +1469,35 @@ def test_unstack_sort_false_unsorted_with_gaps():
     tm.assert_frame_equal(result, expected)
 
 
+def test_unstack_sort_false_unused_level_in_columns():
+    # GH#66673 removed_level_full was indexed using codes computed against
+    # the level already trimmed of unused entries, so whenever the unstacked
+    # level had an entry unused entirely, the resulting DataFrame column
+    # labels (but not the underlying values) came out wrong. Series.unstack,
+    # which never touches removed_level_full, was unaffected.
+    mi = pd.MultiIndex(
+        levels=[["a", "b"], ["x", "y", "z"]],
+        codes=[[0, 0, 1, 1], [2, 0, 2, 0]],
+        names=["r", "c"],
+    )
+    df = pd.DataFrame({"v": [1.0, 2.0, 3.0, 4.0]}, index=mi)
+
+    result = df.unstack(sort=False)
+    expected = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0]],
+        index=pd.Index(["a", "b"], name="r"),
+        columns=pd.MultiIndex.from_tuples([("v", "z"), ("v", "x")], names=[None, "c"]),
+    )
+    tm.assert_frame_equal(result, expected)
+
+    expected_series = pd.DataFrame(
+        [[1.0, 2.0], [3.0, 4.0]],
+        index=pd.Index(["a", "b"], name="r"),
+        columns=pd.Index(["z", "x"], name="c"),
+    )
+    tm.assert_frame_equal(df["v"].unstack(sort=False), expected_series)
+
+
 @pytest.mark.parametrize("frame", [False, True])
 @pytest.mark.parametrize("dtype", ["int64", "Int64", "int64[pyarrow]"])
 def test_unstack_sort_false_multiple_remaining_levels(frame, dtype):


### PR DESCRIPTION


- [x] closes #66673  (Replace xxxx with the GitHub issue number)
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow AGENTS.md, I have reviewed and understood every change. I used Claude Sonnet 5 (High) for root ccause investigation. I arrived at a fix and used claude to rewrite the code to the repo standards. I tested the test cases myself
