### PR TITLE
BUG: IntervalIndex.is_overlapping counted empty intervals as overlapping (GH#26893)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -644,6 +644,7 @@ Interval
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors allowing unsupported ``object`` dtype on the right endpoint, causing ``dtype.subtype`` to disagree with ``right.dtype`` (:issue:`66518`)
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors unnecessarily upcasting sub-64-bit numeric dtypes (e.g. ``float32``, ``int32``) to 64-bit (:issue:`45412`)
 - Bug in :func:`cut` and other operations building an :class:`IntervalIndex` engine raising ``TypeError`` on 32-bit platforms when there were more than 100 intervals (:issue:`44075`, :issue:`23440`)
+- Bug in :attr:`IntervalIndex.is_overlapping` returning ``True`` for an index containing an empty interval nested inside another interval, e.g. ``IntervalIndex.from_tuples([(0, 3), (1, 1)], closed="left")``; such an index is now also usable with :meth:`IntervalIndex.get_indexer` and as ``bins`` in :func:`cut` (:issue:`68068`)
 - Bug in :meth:`Interval.overlaps`, :meth:`IntervalArray.overlaps`, and :meth:`IntervalIndex.overlaps` reporting an overlap with an empty interval such as ``Interval(0, 0, closed="left")``, which contains no points; empty intervals now never overlap (:issue:`26893`)
 
 Indexing

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -644,7 +644,7 @@ Interval
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors allowing unsupported ``object`` dtype on the right endpoint, causing ``dtype.subtype`` to disagree with ``right.dtype`` (:issue:`66518`)
 - Bug in :class:`IntervalArray` and :class:`IntervalIndex` constructors unnecessarily upcasting sub-64-bit numeric dtypes (e.g. ``float32``, ``int32``) to 64-bit (:issue:`45412`)
 - Bug in :func:`cut` and other operations building an :class:`IntervalIndex` engine raising ``TypeError`` on 32-bit platforms when there were more than 100 intervals (:issue:`44075`, :issue:`23440`)
-- Bug in :attr:`IntervalIndex.is_overlapping` returning ``True`` for an index containing an empty interval nested inside another interval, e.g. ``IntervalIndex.from_tuples([(0, 3), (1, 1)], closed="left")``; such an index is now also usable with :meth:`IntervalIndex.get_indexer` and as ``bins`` in :func:`cut` (:issue:`68068`)
+- Bug in :attr:`IntervalIndex.is_overlapping` returning ``True`` for an index containing an empty interval nested inside another interval, e.g. ``IntervalIndex.from_tuples([(0, 3), (1, 1)], closed="left")``; such an index is now also usable with :meth:`IntervalIndex.get_indexer` and as ``bins`` in :func:`cut` (:issue:`68069`)
 - Bug in :meth:`Interval.overlaps`, :meth:`IntervalArray.overlaps`, and :meth:`IntervalIndex.overlaps` reporting an overlap with an empty interval such as ``Interval(0, 0, closed="left")``, which contains no points; empty intervals now never overlap (:issue:`26893`)
 
 Indexing

--- a/pandas/_libs/intervaltree.pxi.in
+++ b/pandas/_libs/intervaltree.pxi.in
@@ -105,10 +105,16 @@ cdef class IntervalTree(IntervalMixin):
         # <= when both sides closed since endpoints can overlap
         op = le if self.closed == 'both' else lt
 
+        sorter = self.left_sorter
+        if self.closed != 'both':
+            # GH#26893 empty intervals contain no points, so they overlap
+            # nothing; dropping them preserves the sweep's sort order
+            sorter = sorter[self.left[sorter] != self.right[sorter]]
+
         # overlap if start of current interval < end of previous interval
         # (current and previous in terms of sorted order by left/start side)
-        current = self.left[self.left_sorter[1:]]
-        previous = self.right[self.left_sorter[:-1]]
+        current = self.left[sorter[1:]]
+        previous = self.right[sorter[:-1]]
         self._is_overlapping = bool(op(current, previous).any())
 
         return self._is_overlapping

--- a/pandas/core/indexes/interval.py
+++ b/pandas/core/indexes/interval.py
@@ -604,6 +604,7 @@ class IntervalIndex(ExtensionIndex):
 
         Two intervals overlap if they share a common point, including closed
         endpoints. Intervals that only have an open endpoint in common do not
+        overlap, and empty intervals contain no points at all, so they never
         overlap.
 
         Returns
@@ -640,6 +641,15 @@ class IntervalIndex(ExtensionIndex):
         >>> index = pd.interval_range(0, 3, closed="left")
         >>> index
         IntervalIndex([[0, 1), [1, 2), [2, 3)],
+              dtype='interval[int64, left]')
+        >>> index.is_overlapping
+        False
+
+        Empty intervals never overlap, even when nested inside another interval:
+
+        >>> index = pd.IntervalIndex.from_tuples([(0, 3), (1, 1)], closed="left")
+        >>> index
+        IntervalIndex([[0, 3), [1, 1)],
               dtype='interval[int64, left]')
         >>> index.is_overlapping
         False
@@ -865,9 +875,11 @@ class IntervalIndex(ExtensionIndex):
         elif not (is_object_dtype(target.dtype) or is_string_dtype(target.dtype)):
             # homogeneous scalar index
             # we should always have self._should_partial_index(target) here
-            if self.is_monotonic_increasing:
+            if self.is_monotonic_increasing and self.right.is_monotonic_increasing:
                 # GH#47614 - use searchsorted for O(n*log(m)) instead of
-                # IntervalTree which scales poorly for large target arrays
+                # IntervalTree which scales poorly for large target arrays.
+                # right is checked too: an empty interval can nest inside
+                # another without overlapping it (GH#26893)
                 indexer = self._get_indexer_monotonic(target)
             else:
                 target = self._maybe_convert_i8(target)

--- a/pandas/tests/indexes/interval/test_indexing.py
+++ b/pandas/tests/indexes/interval/test_indexing.py
@@ -589,6 +589,28 @@ def test_get_indexer_scalar_monotonic_timedelta():
     tm.assert_numpy_array_equal(result, expected)
 
 
+@pytest.mark.parametrize("closed", ["left", "right", "neither"])
+def test_get_indexer_nested_empty_interval(closed):
+    # GH#26893 an empty interval nested inside another one is not an overlap,
+    #  so the index is usable with get_indexer; the empty one matches nothing
+    index = pd.IntervalIndex.from_tuples([(0, 3), (1, 1)], closed=closed)
+    assert index.is_overlapping is False
+
+    result = index.get_indexer([0, 1, 2, 3])
+    expected = np.array(
+        {
+            "left": [0, 0, 0, -1],
+            "right": [-1, 0, 0, 0],
+            "neither": [-1, 0, 0, -1],
+        }[closed],
+        dtype="intp",
+    )
+    tm.assert_numpy_array_equal(result, expected)
+
+    # the empty interval is still found by an exact Interval lookup
+    assert index.get_loc(pd.Interval(1, 1, closed=closed)) == 1
+
+
 class TestSliceLocs:
     def test_slice_locs_with_interval(self):
         # increasing monotonically

--- a/pandas/tests/indexes/interval/test_interval_tree.py
+++ b/pandas/tests/indexes/interval/test_interval_tree.py
@@ -189,3 +189,24 @@ class TestIntervalTree:
 
         result = tree.root.pivot
         assert result == expected
+
+
+@pytest.mark.parametrize("closed", ["left", "right", "neither"])
+@pytest.mark.parametrize("order", [list(x) for x in permutations(range(3))])
+def test_is_overlapping_empty_interval(closed, order):
+    # GH#26893 an empty interval contains no points, so nesting one inside
+    #  another interval is not an overlap
+    left = np.array([0, 1, 5], dtype="int64")
+    right = np.array([3, 1, 6], dtype="int64")
+    tree = IntervalTree(left[order], right[order], closed=closed)
+    assert tree.is_overlapping is False
+
+
+@pytest.mark.parametrize("closed", ["left", "right", "neither"])
+def test_is_overlapping_empty_interval_hides_overlap(closed):
+    # GH#26893 dropping the empty interval must not hide the overlap between
+    #  the two intervals it sits between
+    left = np.array([0, 1, 2], dtype="int64")
+    right = np.array([3, 1, 4], dtype="int64")
+    tree = IntervalTree(left, right, closed=closed)
+    assert tree.is_overlapping is True


### PR DESCRIPTION
Follow-up to GH-67945, which fixed `Interval.overlaps` / `IntervalArray.overlaps` for empty intervals (GH-26893). `IntervalIndex.is_overlapping` goes through a different code path — an adjacent-pair sweep in `IntervalTree.is_overlapping` — and kept reporting an overlap for an empty interval nested inside another one:

```python
ii = pd.IntervalIndex.from_tuples([(0, 3), (1, 1)], closed="left")
ii.is_overlapping                       # True, but [1, 1) contains no points
ii.overlaps(pd.Interval(1, 1, "left"))  # array([False, False])
```

Fixed by dropping empty intervals from `left_sorter` before the sweep.

That also flips `IntervalIndex._index_as_unique` to `True` for such an index, which newly exposes the GH-47614 searchsorted fast path in `_get_indexer`. That path searchsorts on `self.right` and relies on sorted lefts implying sorted rights — true only when nothing is nested, and an empty interval is exactly what nests without overlapping. So the fast path is now additionally gated on `self.right.is_monotonic_increasing`; without that guard, `ii.get_indexer([0, 1, 2, 3])` would silently return `[0, -1, -1, -1]` instead of `[0, 0, 0, -1]`. The gate is a no-op for every index reachable before this PR.

Two user-visible consequences beyond the property itself: such an index now works with `get_indexer` (`.loc`, `reindex`) instead of raising `InvalidIndexError`, and is accepted as `bins` in `cut` instead of raising `"Overlapping IntervalIndex is not accepted."`.

Verified with a 4000-case randomized differential of `is_overlapping` against brute-force pairwise `Interval.overlaps`, and of `get_indexer` against `_get_indexer_pointwise` — no mismatches.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the patch and tests and ran the differential; reviewed by me before opening.