### PR TITLE
TST: un-skip test_query_undefined_local

### DIFF
--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -878,8 +878,7 @@ class TestDataFrameQueryNumExprPandas:
         expected = df[df.a == "@c"]
         tm.assert_frame_equal(result, expected)
 
-    def test_query_undefined_local(self):
-        engine, parser = self.engine, self.parser
+    def test_query_undefined_local(self, engine, parser):
         skip_if_no_pandas_parser(parser)
 
         df = pd.DataFrame(np.random.default_rng(2).random((10, 2)), columns=list("ab"))


### PR DESCRIPTION
`test_query_undefined_local` read `self.engine`/`self.parser`, which resolve to the undecorated fixture *functions* rather than the engine/parser strings its siblings receive as fixture arguments. A `pytest_fixture` object is never `"python"`, so `skip_if_no_pandas_parser` skipped the test unconditionally — in all four of `TestDataFrameQueryNumExprPandas`, `TestDataFrameQueryNumExprPython`, `TestDataFrameQueryPythonPandas` and `TestDataFrameQueryPythonPython`:

```
$ pytest pandas/tests/frame/test_query_eval.py -rs -k undefined_local
SKIPPED [1] test_query_eval.py:33: cannot evaluate with parser=<pytest_fixture(<bound method
  TestDataFrameQueryNumExprPandas.parser of ...>)>
... same for the other three classes
4 skipped
```

Taking `engine, parser` as fixture arguments like every sibling test in these classes makes it run: 2 passed, 2 skipped, where the two skips are the legitimate `parser="python"` ones (the `@c` local-variable syntax needs the pandas parser). The assertion the test contains passes as written, so there is no product bug behind the dead test.

Grepped the file for other `self.<fixture>` reads while here; this was the only one.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the unconditional skip, wrote the fix, and ran the test file.