### PR TITLE
BUG: Sparse[datetime64] Series repr printed the raw i8 value

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -920,7 +920,7 @@ Sparse
 - Bug in :meth:`SparseArray.sum` with ``skipna=False`` returning ``NA`` for a non-null ``fill_value`` and ignoring missing values under a null ``fill_value`` (:issue:`65478`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
 - Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a differently-indexed :class:`Series` raising an uninformative error instead of aligning and returning the expected result (:issue:`32119`)
-- Bug in the repr of a datetime64 or timedelta64 :class:`SparseDtype`-backed :class:`Series`, and in casting such an array to ``object`` dtype, showing raw integers such as ``1577836800000000000`` instead of :class:`Timestamp`/:class:`Timedelta` values (:issue:`68053`)
+- Bug in the repr of a datetime64 or timedelta64 :class:`SparseDtype`-backed :class:`Series`, and in casting such an array to ``object`` dtype, showing raw integers such as ``1577836800000000000`` instead of :class:`Timestamp`/:class:`Timedelta` values (:issue:`68073`)
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -920,6 +920,7 @@ Sparse
 - Bug in :meth:`SparseArray.sum` with ``skipna=False`` returning ``NA`` for a non-null ``fill_value`` and ignoring missing values under a null ``fill_value`` (:issue:`65478`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
 - Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a differently-indexed :class:`Series` raising an uninformative error instead of aligning and returning the expected result (:issue:`32119`)
+- Bug in the repr of a datetime64 or timedelta64 :class:`SparseDtype`-backed :class:`Series`, and in casting such an array to ``object`` dtype, showing raw integers such as ``1577836800000000000`` instead of :class:`Timestamp`/:class:`Timedelta` values (:issue:`68053`)
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -573,6 +573,20 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
     def __array__(
         self, dtype: NpDtype | None = None, copy: bool | None = None
     ) -> np.ndarray:
+        if (
+            dtype is not None
+            and np.dtype(dtype) == object
+            and self.sp_values.dtype.kind in "mM"
+        ):
+            # numpy renders datetime64/timedelta64 as ints when casting to
+            # object; box them ourselves, see test_array_object_datetimelike
+            if copy is False:
+                raise ValueError(
+                    "Unable to avoid copy while creating an array as requested."
+                )
+            dense = ensure_wrapped_if_datetimelike(np.asarray(self))
+            return np.asarray(dense, dtype=object)
+
         if self.sp_index.ngaps == 0:
             # Compat for na dtype and int values.
             if copy is True:

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -546,6 +546,30 @@ def test_zero_sparse_column():
     tm.assert_frame_equal(result, expected)
 
 
+def test_series_repr_datetime64():
+    # GH#68053 printed the raw i8 value
+    arr = SparseArray(np.array(["2020-01-01", "NaT"], dtype="M8[ns]"))
+    expected = "0    2020-01-01 00:00:00\n1                    NaT"
+    assert pd.Series(arr).to_string() == expected
+
+
+@pytest.mark.parametrize("kind", ["M8", "m8"])
+@pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+def test_array_object_datetimelike(kind, unit):
+    # GH#68053 numpy renders datetime64/timedelta64 as ints when casting to
+    # object, so we have to box these ourselves
+    values = np.array([1, 2, 3], dtype="i8").astype(f"{kind}[{unit}]")
+    values[1] = "NaT"
+    expected = pd.array(values).astype(object)
+
+    arr = SparseArray(values)
+    tm.assert_numpy_array_equal(np.asarray(arr, dtype=object), expected)
+
+    # no gaps, so __array__ takes the sp_values shortcut
+    no_gaps = SparseArray(values[::2])
+    tm.assert_numpy_array_equal(np.asarray(no_gaps, dtype=object), expected[::2])
+
+
 def test_array_interface(arr_data, arr):
     # https://github.com/pandas-dev/pandas/pull/60046
     result = np.asarray(arr)

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -547,7 +547,7 @@ def test_zero_sparse_column():
 
 
 def test_series_repr_datetime64():
-    # GH#68053 printed the raw i8 value
+    # GH#68073 printed the raw i8 value
     arr = SparseArray(np.array(["2020-01-01", "NaT"], dtype="M8[ns]"))
     expected = "0    2020-01-01 00:00:00\n1                    NaT"
     assert pd.Series(arr).to_string() == expected
@@ -556,7 +556,7 @@ def test_series_repr_datetime64():
 @pytest.mark.parametrize("kind", ["M8", "m8"])
 @pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
 def test_array_object_datetimelike(kind, unit):
-    # GH#68053 numpy renders datetime64/timedelta64 as ints when casting to
+    # GH#68073 numpy renders datetime64/timedelta64 as ints when casting to
     # object, so we have to box these ourselves
     values = np.array([1, 2, 3], dtype="i8").astype(f"{kind}[{unit}]")
     values[1] = "NaT"


### PR DESCRIPTION
A `Series` backed by a datetime64 or timedelta64 `SparseArray` printed raw integers:

```python
pd.Series(SparseArray(np.array(["2020-01-01"], dtype="M8[ns]"))).to_string()
# 0    1577836800000000000
```

`SparseArray.__array__` ignored a requested `object` dtype, so numpy performed the cast itself, and numpy renders `datetime64[ns]` as int64 when going to object (coarser units fit in `datetime.datetime`, which is why only `ns` looked broken). The repr reaches that cast through `_ExtensionArrayFormatter`, and `np.asarray(arr, dtype=object)` / `Series.to_numpy(dtype=object)` returned the same integers.

`__array__` now boxes a datetimelike subtype itself via `ensure_wrapped_if_datetimelike`. That also fixes the gapped case, where the fill went through `np.full(..., dtype=object)` and a `datetime64("2020-01-01")` fill came back as a `datetime.date` and `NaT` as `None`.

One deliberate behavior change beyond the bug: for non-`ns` units the object cast now yields `Timestamp`/`Timedelta` rather than `datetime.datetime`/`datetime.timedelta`, matching `DatetimeArray`, `Series` and `Index`.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the numpy object-cast root cause, wrote the fix and the tests, and ran the sparse, extension and io.formats suites.