### PR TITLE
CLN: remove isleapyear_arr from fields.pyx

### DIFF
--- a/pandas/_libs/tslibs/fields.pyi
+++ b/pandas/_libs/tslibs/fields.pyi
@@ -37,9 +37,6 @@ def get_timedelta_days(
     tdindex: npt.NDArray[np.int64],  # const int64_t[:]
     reso: int = ...,  # NPY_DATETIMEUNIT
 ) -> npt.NDArray[np.int64]: ...
-def isleapyear_arr(
-    years: np.ndarray,
-) -> npt.NDArray[np.bool_]: ...
 def build_isocalendar_sarray(
     dtindex: npt.NDArray[np.int64],  # const int64_t[:]
     reso: int,  # NPY_DATETIMEUNIT

--- a/pandas/_libs/tslibs/fields.pyx
+++ b/pandas/_libs/tslibs/fields.pyx
@@ -695,18 +695,6 @@ def get_timedelta_days(
     return out
 
 
-cpdef isleapyear_arr(ndarray years):
-    """vectorized version of isleapyear; NaT evaluates as False"""
-    cdef:
-        ndarray[int8_t] out
-
-    out = np.zeros(len(years), dtype="int8")
-    out[np.logical_or(years % 400 == 0,
-                      np.logical_and(years % 4 == 0,
-                                     years % 100 > 0))] = 1
-    return out.view(bool)
-
-
 @cython.wraparound(False)
 @cython.boundscheck(False)
 def build_isocalendar_sarray(const int64_t[:] dtindex, NPY_DATETIMEUNIT reso):

--- a/pandas/core/arrays/period.py
+++ b/pandas/core/arrays/period.py
@@ -40,7 +40,6 @@ from pandas._libs.tslibs.dtypes import (
     FreqGroup,
     PeriodDtypeBase,
 )
-from pandas._libs.tslibs.fields import isleapyear_arr
 from pandas._libs.tslibs.offsets import (
     Tick,
     delta_to_tick,
@@ -919,7 +918,9 @@ class PeriodArray(dtl.DatelikeOps, libperiod.PeriodMixin):
         >>> idx.is_leap_year
         array([False,  True, False])
         """
-        return isleapyear_arr(np.asarray(self.year))
+        # NaT gives year == -1, which the modulo below reports as not-leap
+        year = np.asarray(self.year)
+        return (year % 400 == 0) | ((year % 4 == 0) & (year % 100 > 0))
 
     def to_timestamp(self, freq=None, how: str = "start") -> DatetimeArray:
         """

--- a/pandas/tests/indexes/period/test_scalar_compat.py
+++ b/pandas/tests/indexes/period/test_scalar_compat.py
@@ -1,5 +1,6 @@
 """Tests for PeriodIndex behaving like a vectorized Period scalar"""
 
+import numpy as np
 import pytest
 
 from pandas.errors import Pandas4Warning
@@ -50,3 +51,11 @@ class TestPeriodIndexOps:
         dti = pd.date_range("1990-01-05", freq="D", periods=1)._with_freq(None)
         expected = dti + pd.Timedelta(1, "D") - pd.Timedelta(1, "us")
         tm.assert_index_equal(result, expected)
+
+
+def test_is_leap_year():
+    # NaT's year sentinel of -1 must not come out as leap
+    pi = pd.PeriodIndex(["2000", "1900", "2024", "2023", pd.NaT], freq="Y")
+    result = pi.is_leap_year
+    expected = np.array([True, False, True, False, False])
+    tm.assert_numpy_array_equal(result, expected)


### PR DESCRIPTION
Follow-up cleanup noticed while reviewing GH-66851.

`isleapyear_arr` is pure numpy — every operation in it dispatches through Python, so the compiled version does exactly what the same lines would do in a `.py` file, at the cost of a Cython declaration and a `.pyi` stub to keep in sync.

GH-66851 is what makes this worth doing now: it rewrote `get_date_field`'s `is_leap_year` branch to compute leapness from `dts.year` in a `nogil` loop via `ccalendar.is_leapyear`, which removed the last in-module caller. There is no `fields.pxd`, so the `cpdef`'s C entry point was never reachable from another module either — with the in-module caller gone it is dead weight, not an API.

What is left is a single Python caller, `PeriodArray.is_leap_year`, so this inlines the expression there and drops the stub. `pandas._libs` is private, so nothing is owed a deprecation. (`pd.tseries.util.isleapyear` was a different, already-removed function — deprecated in 0.19, removed in 0.23 via GH-18370.)

Behaviour is unchanged: the new expression is value- and dtype-identical to the old one, including the NaT case. `PeriodArray.year` yields `-1` for NaT, which the modulo correctly reports as not-leap; that is load-bearing, so it gets a comment and a test. The only prior coverage was `test_bool_properties`, which compares `PeriodArray` against `PeriodIndex` through the same code path and so would not have caught a regression here.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which made the edits and verified the inlined expression against the original.