### PR TITLE
ENH: include cell location in ExcelWriter truncation warning

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -57,6 +57,7 @@ Other enhancements
 - Time strings with a space before ``AM``/``PM`` (e.g. ``"3:25:00 PM"``) are now recognized; :meth:`Series.between_time` and :meth:`DataFrame.between_time` previously raised on them, and :meth:`Series.at_time` and :meth:`DataFrame.at_time` warned that they would raise in a future version. Casting such strings to a pyarrow time dtype (``time32``/``time64``) no longer silently gives a missing value (:issue:`18793`)
 - Building from source no longer fails when compiling the windowing extensions against C++ standard libraries that provide only ``std::signbit`` (:issue:`50979`, :issue:`51047`)
 - Setting values with :meth:`DataFrame.at` or :meth:`Series.at` using a non-scalar indexer (e.g. a boolean mask, list, or array) now raises a clearer ``InvalidIndexError`` directing users to ``.loc`` (:issue:`51866`)
+- The ``UserWarning`` raised by :meth:`DataFrame.to_excel` when a cell value exceeds Excel's 32,767-character limit now includes the destination row and column of the truncated cell (:issue:`67470`)
 
 .. ---------------------------------------------------------------------------
 .. _whatsnew_310.notable_bug_fixes:

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -86,6 +86,8 @@ if TYPE_CHECKING:
         WriteExcelBuffer,
     )
 
+    from pandas.io.formats.excel import ExcelCell
+
 EXCEL_ROWS_MAX = 1_048_576
 
 
@@ -1387,7 +1389,7 @@ class ExcelWriter(Generic[_WorkbookT]):
         return sheet_name
 
     def _value_with_fmt(
-        self, val
+        self, cell: ExcelCell
     ) -> tuple[
         int | float | bool | str | datetime.datetime | datetime.date, str | None
     ]:
@@ -1396,14 +1398,15 @@ class ExcelWriter(Generic[_WorkbookT]):
 
         Parameters
         ----------
-        val : object
-            Value to be written into cells
+        cell : ExcelCell
+            Spreadsheet cell data containing the value to be written
 
         Returns
         -------
         Tuple with the first element being the converted value and the second
             being an optional format
         """
+        val = cell.val
         fmt = None
 
         if is_integer(val):
@@ -1428,7 +1431,8 @@ class ExcelWriter(Generic[_WorkbookT]):
             # xref https://support.microsoft.com/en-au/office/excel-specifications-and-limits-1672b34d-7043-467e-8e27-269d656771c3
             if len(val) > 32767:
                 warnings.warn(
-                    f"Cell contents too long ({len(val)}), "
+                    f"Cell contents too long ({len(val)}) in row {cell.row}, "
+                    f"column {cell.col}; "
                     "truncated to 32767 characters",
                     UserWarning,
                     stacklevel=find_stack_level(),

--- a/pandas/io/excel/_odswriter.py
+++ b/pandas/io/excel/_odswriter.py
@@ -191,7 +191,7 @@ class ODSWriter(ExcelWriter):
         from odf.table import TableCell
 
         attributes = self._make_table_cell_attributes(cell)
-        val, fmt = self._value_with_fmt(cell.val)
+        val, fmt = self._value_with_fmt(cell)
         pvalue = value = val
         if isinstance(val, bool):
             value = str(val).lower()

--- a/pandas/io/excel/_openpyxl.py
+++ b/pandas/io/excel/_openpyxl.py
@@ -532,7 +532,7 @@ class OpenpyxlWriter(ExcelWriter):
                 max_col = col_idx
 
             xcell = Cell(wks, row=1, column=1)
-            xcell.value, fmt = self._value_with_fmt(cell.val)
+            xcell.value, fmt = self._value_with_fmt(cell)
             if fmt:
                 xcell.number_format = fmt
 
@@ -601,7 +601,7 @@ class OpenpyxlWriter(ExcelWriter):
             xcell = wks.cell(
                 row=startrow + cell.row + 1, column=startcol + cell.col + 1
             )
-            xcell.value, fmt = self._value_with_fmt(cell.val)
+            xcell.value, fmt = self._value_with_fmt(cell)
             if fmt:
                 xcell.number_format = fmt
 

--- a/pandas/io/excel/_xlsxwriter.py
+++ b/pandas/io/excel/_xlsxwriter.py
@@ -260,7 +260,7 @@ class XlsxWriter(ExcelWriter):
             wks.freeze_panes(*(freeze_panes))
 
         for cell in cells:
-            val, fmt = self._value_with_fmt(cell.val)
+            val, fmt = self._value_with_fmt(cell)
 
             stylekey = json.dumps(cell.style)
             if fmt:

--- a/pandas/tests/io/excel/test_writers.py
+++ b/pandas/tests/io/excel/test_writers.py
@@ -1516,7 +1516,10 @@ class TestExcelWriter:
     def test_to_excel_raising_warning_when_cell_character_exceed_limit(self):
         # GH#56954
         df = pd.DataFrame({"A": ["a" * 32768]})
-        msg = r"Cell contents too long \(32768\), truncated to 32767 characters"
+        msg = (
+            r"Cell contents too long \(32768\) in row 1, column 1; "
+            "truncated to 32767 characters"
+        )
         with tm.assert_produces_warning(
             UserWarning, match=msg, raise_on_extra_warnings=False
         ):


### PR DESCRIPTION
- [x] closes #67470

The `UserWarning` emitted when an Excel cell value exceeds the 32,767-character limit did not say which cell was truncated, forcing users to scan the DataFrame themselves. It now includes the destination row and column:

```
Cell contents too long (<len>) in row <row>, column <col>; truncated to 32767 characters
```

Changes:
- `ExcelWriter._value_with_fmt` now takes the full `ExcelCell` (`cell`) instead of just the raw value, so the warning can report `cell.row` / `cell.col` (both 0-based). The value is still unpacked via `cell.val` at the top of the method.
- Updated the four active call sites to pass `cell` rather than `cell.val`:
  - `_odswriter.py` `_make_table_cell`
  - `_openpyxl.py` `_write_cells_write_only` and `_write_cells_normal`
  - `_xlsxwriter.py` `_write_cells`
- Updated the existing warning test (`test_to_excel_raising_warning_when_cell_character_exceed_limit`) and added a whatsnew entry.

Verified locally: the warning now reads `Cell contents too long (32768) in row 1, column 1; truncated to 32767 characters` for a single-column frame with an index, and `ruff check`/`ruff format` pass on all touched files.

---

AI-assisted contribution disclosure: this change was prepared with the assistance of an AI coding agent (Pi coding agent, model deepseek-v4-pro, reasoning-effort setting off).
