### PR TITLE
TST: run LC_TIME-dependent tests under an explicit English locale

### DIFF
--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -24,6 +24,7 @@ from io import (
     BytesIO,
     StringIO,
 )
+import locale
 import operator
 import pickle
 import re
@@ -33,6 +34,7 @@ import unicodedata
 import numpy as np
 import pytest
 
+from pandas._config.localization import set_locale
 from pandas._libs import lib
 from pandas._libs.tslibs import timezones
 from pandas.compat import (
@@ -4801,9 +4803,10 @@ def test_string_to_time_parsing_cast():
 @pytest.mark.parametrize("dtype", ["time32[s][pyarrow]", "time64[us][pyarrow]"])
 def test_string_to_time_parsing_cast_meridiem(dtype):
     # GH#18793 the space before AM/PM used to make these coerce to null
-    result = pd.Series(["3:25:00 PM"], dtype=dtype)
-    expected = pd.Series(["15:25:00"], dtype=dtype)
-    tm.assert_series_equal(result, expected)
+    with set_locale("C", locale.LC_TIME):
+        result = pd.Series(["3:25:00 PM"], dtype=dtype)
+        expected = pd.Series(["15:25:00"], dtype=dtype)
+        tm.assert_series_equal(result, expected)
 
 
 def test_to_numpy_float():

--- a/pandas/tests/extension/test_arrow.py
+++ b/pandas/tests/extension/test_arrow.py
@@ -35,6 +35,7 @@ import numpy as np
 import pytest
 
 from pandas._config.localization import set_locale
+
 from pandas._libs import lib
 from pandas._libs.tslibs import timezones
 from pandas.compat import (

--- a/pandas/tests/frame/methods/test_between_time.py
+++ b/pandas/tests/frame/methods/test_between_time.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from pandas._config.localization import set_locale
+
 from pandas._libs.tslibs import timezones
 import pandas.util._test_decorators as td
 

--- a/pandas/tests/frame/methods/test_between_time.py
+++ b/pandas/tests/frame/methods/test_between_time.py
@@ -2,10 +2,12 @@ from datetime import (
     datetime,
     time,
 )
+import locale
 
 import numpy as np
 import pytest
 
+from pandas._config.localization import set_locale
 from pandas._libs.tslibs import timezones
 import pandas.util._test_decorators as td
 
@@ -17,26 +19,27 @@ class TestBetweenTime:
     @td.skip_if_not_english_lc_time
     def test_between_time_formats(self, frame_or_series):
         # GH#11818
-        rng = pd.date_range("1/1/2000", "1/5/2000", freq="5min")
-        ts = pd.DataFrame(
-            np.random.default_rng(2).standard_normal((len(rng), 2)), index=rng
-        )
-        ts = tm.get_obj(ts, frame_or_series)
+        with set_locale("C", locale.LC_TIME):
+            rng = pd.date_range("1/1/2000", "1/5/2000", freq="5min")
+            ts = pd.DataFrame(
+                np.random.default_rng(2).standard_normal((len(rng), 2)), index=rng
+            )
+            ts = tm.get_obj(ts, frame_or_series)
 
-        strings = [
-            ("2:00", "2:30"),
-            ("0200", "0230"),
-            ("2:00am", "2:30am"),
-            ("0200am", "0230am"),
-            ("2:00:00", "2:30:00"),
-            ("020000", "023000"),
-            ("2:00:00am", "2:30:00am"),
-            ("020000am", "023000am"),
-        ]
-        expected_length = 28
+            strings = [
+                ("2:00", "2:30"),
+                ("0200", "0230"),
+                ("2:00am", "2:30am"),
+                ("0200am", "0230am"),
+                ("2:00:00", "2:30:00"),
+                ("020000", "023000"),
+                ("2:00:00am", "2:30:00am"),
+                ("020000am", "023000am"),
+            ]
+            expected_length = 28
 
-        for time_string in strings:
-            assert len(ts.between_time(*time_string)) == expected_length
+            for time_string in strings:
+                assert len(ts.between_time(*time_string)) == expected_length
 
     @pytest.mark.parametrize("tzstr", ["US/Eastern", "dateutil/US/Eastern"])
     def test_localized_between_time(self, tzstr, frame_or_series):
@@ -228,9 +231,10 @@ class TestBetweenTime:
 @td.skip_if_not_english_lc_time
 def test_between_time_space_before_meridiem():
     # GH#18793 the space before AM/PM used to make these unparsable
-    index = pd.date_range("2012-01-01", periods=48, freq="h")
-    df = pd.DataFrame({"A": range(len(index))}, index=index)
+    with set_locale("C", locale.LC_TIME):
+        index = pd.date_range("2012-01-01", periods=48, freq="h")
+        df = pd.DataFrame({"A": range(len(index))}, index=index)
 
-    result = df.between_time("3:00 PM", "5:00 PM")
-    expected = df.between_time(time(15, 0), time(17, 0))
-    tm.assert_frame_equal(result, expected)
+        result = df.between_time("3:00 PM", "5:00 PM")
+        expected = df.between_time(time(15, 0), time(17, 0))
+        tm.assert_frame_equal(result, expected)

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -19,6 +19,7 @@ import numpy as np
 import pytest
 
 from pandas._config.localization import set_locale
+
 from pandas._libs import tslib
 from pandas._libs.tslibs import (
     iNaT,

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -10,6 +10,7 @@ from datetime import (
     timezone,
 )
 from decimal import Decimal
+import locale
 import re
 import zoneinfo
 
@@ -17,6 +18,7 @@ from dateutil.parser import parse
 import numpy as np
 import pytest
 
+from pandas._config.localization import set_locale
 from pandas._libs import tslib
 from pandas._libs.tslibs import (
     iNaT,
@@ -355,21 +357,25 @@ class TestTimeConversionFormats:
         ],
     )
     def test_to_datetime_format_time(self, cache, value, format, dt):
-        assert pd.to_datetime(value, format=format, cache=cache) == dt
+        with set_locale("C", locale.LC_TIME):
+            assert pd.to_datetime(value, format=format, cache=cache) == dt
 
     @td.skip_if_not_english_lc_time
     def test_to_datetime_with_non_exact(self, cache):
         # GH 10834
         # 8904
         # exact kw
-        ser = pd.Series(
-            ["19MAY11", "foobar19MAY11", "19MAY11:00:00:00", "19MAY11 00:00:00Z"]
-        )
-        result = pd.to_datetime(ser, format="%d%b%y", exact=False, cache=cache)
-        expected = pd.to_datetime(
-            ser.str.extract(r"(\d+\w+\d+)", expand=False), format="%d%b%y", cache=cache
-        )
-        tm.assert_series_equal(result, expected)
+        with set_locale("C", locale.LC_TIME):
+            ser = pd.Series(
+                ["19MAY11", "foobar19MAY11", "19MAY11:00:00:00", "19MAY11 00:00:00Z"]
+            )
+            result = pd.to_datetime(ser, format="%d%b%y", exact=False, cache=cache)
+            expected = pd.to_datetime(
+                ser.str.extract(r"(\d+\w+\d+)", expand=False),
+                format="%d%b%y",
+                cache=cache,
+            )
+            tm.assert_series_equal(result, expected)
 
     @pytest.mark.parametrize(
         "format, expected",
@@ -3063,10 +3069,11 @@ class TestToDatetimeMisc:
         # this is only locale tested with US/None locales
         # GH 5195
         # with a format and coerce a single item to_datetime fails
-        td = pd.Series(["May 04", "Jun 02", "Dec 11"], index=[1, 2, 3])
-        expected = pd.to_datetime(td, format="%b %y", cache=cache)
-        result = td.apply(pd.to_datetime, format="%b %y", cache=cache)
-        tm.assert_series_equal(result, expected)
+        with set_locale("C", locale.LC_TIME):
+            td = pd.Series(["May 04", "Jun 02", "Dec 11"], index=[1, 2, 3])
+            expected = pd.to_datetime(td, format="%b %y", cache=cache)
+            result = td.apply(pd.to_datetime, format="%b %y", cache=cache)
+            tm.assert_series_equal(result, expected)
 
     def test_to_datetime_timezone_name(self):
         # https://github.com/pandas-dev/pandas/issues/49748
@@ -3080,13 +3087,16 @@ class TestToDatetimeMisc:
         # this is only locale tested with US/None locales
         # GH 5195, GH50251
         # with a format and coerce a single item to_datetime fails
-        td = pd.Series(["May 04", "Jun 02", ""], index=[1, 2, 3])
-        expected = pd.to_datetime(td, format="%b %y", errors=errors, cache=cache)
+        with set_locale("C", locale.LC_TIME):
+            td = pd.Series(["May 04", "Jun 02", ""], index=[1, 2, 3])
+            expected = pd.to_datetime(td, format="%b %y", errors=errors, cache=cache)
 
-        result = td.apply(
-            lambda x: pd.to_datetime(x, format="%b %y", errors="coerce", cache=cache)
-        )
-        tm.assert_series_equal(result, expected)
+            result = td.apply(
+                lambda x: pd.to_datetime(
+                    x, format="%b %y", errors="coerce", cache=cache
+                )
+            )
+            tm.assert_series_equal(result, expected)
 
     def test_to_datetime_empty_stt(self, cache):
         # empty string

--- a/pandas/tests/tools/test_to_time.py
+++ b/pandas/tests/tools/test_to_time.py
@@ -4,9 +4,10 @@ import locale
 import numpy as np
 import pytest
 
+from pandas._config.localization import set_locale
+
 import pandas.util._test_decorators as td
 
-from pandas._config.localization import set_locale
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.tools.times import to_time

--- a/pandas/tests/tools/test_to_time.py
+++ b/pandas/tests/tools/test_to_time.py
@@ -1,10 +1,12 @@
 from datetime import time
+import locale
 
 import numpy as np
 import pytest
 
 import pandas.util._test_decorators as td
 
+from pandas._config.localization import set_locale
 import pandas as pd
 import pandas._testing as tm
 from pandas.core.tools.times import to_time
@@ -31,15 +33,17 @@ class TestToTime:
     )
     def test_parsers_time(self, time_string):
         # GH#11818
-        assert to_time(time_string) == time(14, 15)
+        with set_locale("C", locale.LC_TIME):
+            assert to_time(time_string) == time(14, 15)
 
     @td.skip_if_not_english_lc_time
     def test_parsers_time_space_before_meridiem(self):
         # GH#18793 the space before AM/PM used to make these unparsable
-        arg = ["3:25:00 AM", "3:25:00 PM", "12:30:00 AM", "12:30:00 PM"]
-        expected = [time(3, 25), time(15, 25), time(0, 30), time(12, 30)]
-        assert to_time(arg) == expected
-        assert to_time(arg, infer_time_format=True) == expected
+        with set_locale("C", locale.LC_TIME):
+            arg = ["3:25:00 AM", "3:25:00 PM", "12:30:00 AM", "12:30:00 PM"]
+            expected = [time(3, 25), time(15, 25), time(0, 30), time(12, 30)]
+            assert to_time(arg) == expected
+            assert to_time(arg, infer_time_format=True) == expected
 
     def test_odd_format(self):
         new_string = "14.15"

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -6,12 +6,14 @@ from datetime import (
     UTC,
     datetime,
 )
+import locale
 import re
 
 from dateutil.parser import parse as du_parse
 import numpy as np
 import pytest
 
+from pandas._config.localization import set_locale
 from pandas._libs.tslibs import (
     parsing,
     strptime,
@@ -315,12 +317,13 @@ def test_parsers_month_freq(date_str, expected):
     ],
 )
 def test_guess_datetime_format_with_parseable_formats(string, fmt):
-    msg = r"when dayfirst=False \(the default\) was specified"
-    with tm.maybe_produces_warning(
-        UserWarning, fmt is not None and re.search(r"%d.*%m", fmt), match=msg
-    ):
-        result = parsing.guess_datetime_format(string)
-    assert result == fmt
+    with set_locale("C", locale.LC_TIME):
+        msg = r"when dayfirst=False \(the default\) was specified"
+        with tm.maybe_produces_warning(
+            UserWarning, fmt is not None and re.search(r"%d.*%m", fmt), match=msg
+        ):
+            result = parsing.guess_datetime_format(string)
+        assert result == fmt
 
 
 @pytest.mark.parametrize("dayfirst,expected", [(True, "%d/%m/%Y"), (False, "%m/%d/%Y")])
@@ -340,8 +343,9 @@ def test_guess_datetime_format_with_dayfirst(dayfirst, expected):
     ],
 )
 def test_guess_datetime_format_with_locale_specific_formats(string, fmt):
-    result = parsing.guess_datetime_format(string)
-    assert result == fmt
+    with set_locale("C", locale.LC_TIME):
+        result = parsing.guess_datetime_format(string)
+        assert result == fmt
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 
 from pandas._config.localization import set_locale
+
 from pandas._libs.tslibs import (
     parsing,
     strptime,

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -26,7 +26,7 @@ For more information, refer to the ``pytest`` documentation on ``skipif``.
 
 from __future__ import annotations
 
-from datetime import datetime
+import locale
 import sys
 from typing import TYPE_CHECKING
 
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pandas._typing import F
 
+from pandas._config.localization import can_set_locale
 from pandas.compat import (
     IS64,
     WASM,
@@ -113,23 +114,9 @@ skip_if_32bit = pytest.mark.skipif(not IS64, reason="skipping for 32 bit")
 skip_if_windows = pytest.mark.skipif(is_platform_windows(), reason="Running on Windows")
 
 
-def _has_english_lc_time() -> bool:
-    """
-    Whether LC_TIME yields English month/day names and AM/PM markers.
-
-    Only LC_TIME matters for strftime/strptime, and CPython sets just LC_CTYPE
-    from the environment at startup, so this is normally True no matter what
-    LANG or LC_ALL are set to. It is False only when something in the process
-    has called ``setlocale`` for LC_TIME.
-    """
-    # 2020-01-01 was a Wednesday
-    stamp = datetime(2020, 1, 1, 13)
-    return stamp.strftime("%b|%B|%a|%A|%p") == "Jan|January|Wed|Wednesday|PM"
-
-
 skip_if_not_english_lc_time = pytest.mark.skipif(
-    not _has_english_lc_time(),
-    reason="LC_TIME does not use English month names and AM/PM markers",
+    not can_set_locale("C", locale.LC_TIME),
+    reason="LC_TIME cannot be set to an English locale",
 )
 
 skip_if_wasm = pytest.mark.skipif(

--- a/pandas/util/_test_decorators.py
+++ b/pandas/util/_test_decorators.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from pandas._typing import F
 
 from pandas._config.localization import can_set_locale
+
 from pandas.compat import (
     IS64,
     WASM,


### PR DESCRIPTION
- [x] closes #67984

`skip_if_not_english_lc_time` currently skips ~20 tests whenever the ambient `LC_TIME` is not English. This change keeps the decorator but narrows it to skip only when an English locale cannot be obtained at all, and wraps each test body in `set_locale("C", locale.LC_TIME)` so the tests run and pass regardless of the ambient locale.

Sites updated: `test_arrow.py`, `test_between_time.py`, `test_to_datetime.py`, `test_to_time.py`, `test_parsing.py`. `_has_english_lc_time` is removed since the decorator now uses `can_set_locale("C", locale.LC_TIME)`.

Verification: all affected tests pass under an English `LC_TIME` (197 + 20 passed), and under a simulated non-English `LC_TIME` (`de_DE.UTF-8`) they run and pass (16 passed) instead of being skipped, with no locale leak after the `set_locale` context manager exits. ruff check/format pass.

---

AI-assisted contribution disclosure: this change was prepared with the assistance of an AI coding agent (Pi coding agent, model deepseek-v4-pro, reasoning-effort setting off).

