### PR TITLE
CI: check pixi-version is pinned consistently across config files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -312,6 +312,12 @@ repos:
         files: ^(pixi\.toml|\.github/workflows/unit-tests\.yml|pandas/tests/.*\.py|pandas/conftest\.py)$
         additional_dependencies: [pyyaml]
         pass_filenames: false
+    -   id: validate-pixi-version
+        name: Check pixi version is pinned consistently
+        entry: python -m scripts.validate_pixi_version
+        language: python
+        files: ^(\.github/actions/setup-pixi/action\.yml|\.github/workflows/update-pixi-lock\.yml)$
+        pass_filenames: false
     -   id: validate-errors-locations
         name: Validate errors locations
         description: Validate errors are in appropriate locations.

--- a/scripts/tests/test_validate_pixi_version.py
+++ b/scripts/tests/test_validate_pixi_version.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from scripts.validate_pixi_version import check_pixi_versions
+
+
+def _write(path: Path, *lines: str) -> None:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_consistent_pins_pass(tmp_path: Path) -> None:
+    action = tmp_path / "action.yml"
+    workflow = tmp_path / "workflow.yml"
+    _write(
+        action,
+        "        pixi-version: v0.76.2",
+        "        pixi-version: v0.76.2",
+    )
+    _write(workflow, "        pixi-version: v0.76.2")
+    assert check_pixi_versions([action, workflow]) == 0
+
+
+def test_mismatched_pins_fail(tmp_path: Path) -> None:
+    action = tmp_path / "action.yml"
+    workflow = tmp_path / "workflow.yml"
+    _write(
+        action,
+        "        pixi-version: v0.76.2",
+        "        pixi-version: v0.76.2",
+    )
+    _write(workflow, "        pixi-version: v0.76.3")
+    assert check_pixi_versions([action, workflow]) == 1
+
+
+def test_missing_pin_fails(tmp_path: Path) -> None:
+    action = tmp_path / "action.yml"
+    _write(action, "        run-install: false")
+    assert check_pixi_versions([action]) == 1
+
+
+def test_missing_file_fails(tmp_path: Path) -> None:
+    assert check_pixi_versions([tmp_path / "nope.yml"]) == 1

--- a/scripts/validate_pixi_version.py
+++ b/scripts/validate_pixi_version.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Check the pinned pixi version agrees across the CI config files that pin it.
+
+The version is pinned in three places and nothing links them, so a mismatch
+silently produces CI jobs installing under different pixi versions (and can
+commit a pixi.lock produced by a different pixi than the one consuming it):
+
+    .github/actions/setup-pixi/action.yml
+    .github/workflows/update-pixi-lock.yml
+
+This is meant to be run as a pre-commit hook - to run it manually, you can do:
+
+    pre-commit run validate-pixi-version --all-files
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+BASE_PATH = pathlib.Path(__file__).parents[1]
+ACTION_PATH = BASE_PATH / ".github/actions/setup-pixi/action.yml"
+WORKFLOW_PATH = BASE_PATH / ".github/workflows/update-pixi-lock.yml"
+
+PIXI_VERSION_RE = re.compile(r"^\s*pixi-version:\s*(\S+)\s*$")
+
+
+def check_pixi_versions(paths: Iterable[pathlib.Path]) -> int:
+    """Return 0 when every ``pixi-version`` pin agrees, 1 otherwise."""
+    locations: dict[str, list[str]] = {}
+    for path in paths:
+        try:
+            f = open(path, encoding="utf-8")
+        except OSError as err:
+            print(f"Could not read {path}: {err}")
+            return 1
+        with f:
+            for lineno, line in enumerate(f, 1):
+                match = PIXI_VERSION_RE.match(line)
+                if match:
+                    locations.setdefault(match.group(1), []).append(f"{path}:{lineno}")
+
+    if not locations:
+        print(
+            "No pixi-version pin found. If pixi is no longer used, remove this "
+            "check from .pre-commit-config.yaml."
+        )
+        return 1
+
+    if len(locations) == 1:
+        return 0
+
+    print("pixi-version is pinned inconsistently across CI config files:")
+    for version, pins in sorted(locations.items()):
+        print(f"  {version} found at:")
+        for pin in pins:
+            print(f"    {pin}")
+    print("Please align every pin to the same pixi version.")
+    return 1
+
+
+def main() -> int:
+    return check_pixi_versions([ACTION_PATH, WORKFLOW_PATH])
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
- [x] closes #67982

Takes the "check instead of dedupe" path from the issue: the other option ("pin once" by collapsing `action.yml`'s two `setup-pixi` steps into a single expression-driven step) depends on undocumented `setup-pixi` input-coercion behavior, so this instead leaves the structure alone and makes a drift between the three pins fail loudly.

Changes:
- New `scripts/validate_pixi_version.py`, registered as a pre-commit hook (`validate-pixi-version`), that parses every `pixi-version:` pin in `.github/actions/setup-pixi/action.yml` and `.github/workflows/update-pixi-lock.yml` and fails when the values disagree.
- New `scripts/tests/test_validate_pixi_version.py` covering: consistent pins pass, mismatched pins fail, a missing pin fails, and an unreadable file fails.

Verified locally: `python -m scripts.validate_pixi_version` exits 0 on the current tree (all three pins at `v0.76.2`), the new tests pass (`4 passed`), and `ruff check`/`ruff format` are clean for both new files.

---

AI-assisted contribution disclosure: this change was prepared with the assistance of an AI coding agent (Pi coding agent, model deepseek-v4-pro, reasoning-effort setting off).

