### PR TITLE
BUG: read_excel/ExcelFile raised AttributeError for an xlrd.Book without an explicit engine

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -851,7 +851,7 @@ I/O
 - Fixed bug in :func:`read_csv` with the ``c`` engine where running out of memory while the parser was reporting an error crashed the interpreter instead of raising ``ParserError`` (:issue:`66660`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with ``dtype="S"`` (:issue:`19886`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with an explicit string-like ``dtype`` (``object``, ``"str"``, ``"string"`` or ``"category"``) (:issue:`66525`)
-- Fixed bug in :func:`read_excel` and :class:`ExcelFile` where passing an ``xlrd.Book`` without an explicit ``engine`` raised ``AttributeError: 'Book' object has no attribute 'seek'`` instead of reading the workbook (:issue:`68075`)
+- Fixed bug in :func:`read_excel` and :class:`ExcelFile` where passing an ``xlrd.Book`` without an explicit ``engine`` raised ``AttributeError: 'Book' object has no attribute 'seek'`` instead of reading the workbook (:issue:`68086`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug in :func:`read_excel` with ``engine="odf"`` where ``<table:covered-table-cell>`` elements with explicit ``office:value`` attributes were incorrectly read as missing values. (:issue:`66579`)
 - Fixed bug in :func:`read_excel` with the ``openpyxl`` engine where reading a sheet set its ``max_row`` and ``max_column`` to ``None`` on the workbook exposed through ``ExcelFile.book`` (:issue:`63010`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -851,6 +851,7 @@ I/O
 - Fixed bug in :func:`read_csv` with the ``c`` engine where running out of memory while the parser was reporting an error crashed the interpreter instead of raising ``ParserError`` (:issue:`66660`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with ``dtype="S"`` (:issue:`19886`)
 - Fixed bug in :func:`read_csv` with the ``c`` engine where two fields differing only after an embedded NUL byte were read as the same value with an explicit string-like ``dtype`` (``object``, ``"str"``, ``"string"`` or ``"category"``) (:issue:`66525`)
+- Fixed bug in :func:`read_excel` and :class:`ExcelFile` where passing an ``xlrd.Book`` without an explicit ``engine`` raised ``AttributeError: 'Book' object has no attribute 'seek'`` instead of reading the workbook (:issue:`68075`)
 - Fixed bug in :func:`read_excel` where usage of ``skiprows`` could lead to an infinite loop (:issue:`64027`)
 - Fixed bug in :func:`read_excel` with ``engine="odf"`` where ``<table:covered-table-cell>`` elements with explicit ``office:value`` attributes were incorrectly read as missing values. (:issue:`66579`)
 - Fixed bug in :func:`read_excel` with the ``openpyxl`` engine where reading a sheet set its ``max_row`` and ``max_column`` to ``None`` on the workbook exposed through ``ExcelFile.book`` (:issue:`63010`)

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -11,6 +11,7 @@ import datetime
 from decimal import Decimal
 from functools import partial
 import os
+import sys
 from typing import (
     IO,
     TYPE_CHECKING,
@@ -28,10 +29,7 @@ import zipfile
 from pandas._config.config import _global_config as config
 
 from pandas._libs import lib
-from pandas.compat._optional import (
-    get_version,
-    import_optional_dependency,
-)
+from pandas.compat._optional import import_optional_dependency
 from pandas.errors import (
     EmptyDataError,
     Pandas4Warning,
@@ -45,14 +43,12 @@ from pandas.util._validators import check_dtype_backend
 from pandas.core.dtypes.common import (
     is_bool,
     is_decimal,
-    is_file_like,
     is_float,
     is_integer,
     is_list_like,
 )
 
 from pandas.core.frame import DataFrame
-from pandas.util.version import Version
 
 from pandas.io.common import (
     IOHandles,
@@ -1653,20 +1649,13 @@ class ExcelFile:
             # Only determine ext if it is needed
             ext: str | None = None
 
-            if not isinstance(
-                path_or_buffer, (str, os.PathLike, ExcelFile)
-            ) and not is_file_like(path_or_buffer):
-                # GH#56692 - avoid importing xlrd if possible
-                if import_optional_dependency("xlrd", errors="ignore") is None:
-                    xlrd_version = None
-                else:
-                    import xlrd
-
-                    xlrd_version = Version(get_version(xlrd))
-
-                if xlrd_version is not None and isinstance(path_or_buffer, xlrd.Book):
-                    ext = "xls"
-                    engine = "xlrd"
+            # GH#56692 - avoid importing xlrd; a Book only exists if the caller
+            # already imported it. GH#68075 - must precede inspect_excel_format,
+            # which seeks.
+            xlrd = sys.modules.get("xlrd")
+            if xlrd is not None and isinstance(path_or_buffer, xlrd.Book):
+                ext = "xls"
+                engine = "xlrd"
 
             if ext is None:
                 ext = inspect_excel_format(

--- a/pandas/io/excel/_base.py
+++ b/pandas/io/excel/_base.py
@@ -1650,7 +1650,7 @@ class ExcelFile:
             ext: str | None = None
 
             # GH#56692 - avoid importing xlrd; a Book only exists if the caller
-            # already imported it. GH#68075 - must precede inspect_excel_format,
+            # already imported it. GH#68086 - must precede inspect_excel_format,
             # which seeks.
             xlrd = sys.modules.get("xlrd")
             if xlrd is not None and isinstance(path_or_buffer, xlrd.Book):

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -1,4 +1,5 @@
 import io
+import sys
 
 import numpy as np
 import pytest
@@ -82,3 +83,29 @@ def test_xlrd_engine_deprecated(datapath):
     path = datapath("io", "data", "excel", "test1.xls")
     with tm.assert_produces_warning(Pandas4Warning, match="xlrd engine is deprecated"):
         pd.read_excel(path, engine="xlrd")
+
+
+def test_read_xlrd_book_no_engine(datapath):
+    # GH#68075 - a Book has "read" but no "seek", so it passes is_file_like
+    # and used to reach inspect_excel_format instead of the xlrd branch
+    sheet_name = "Sheet1"
+    pth = datapath("io", "data", "excel", "test1.xls")
+    expected = pd.read_excel(pth, sheet_name=sheet_name, engine="xlrd", index_col=0)
+
+    with xlrd.open_workbook(pth) as book:
+        with ExcelFile(book) as xl:
+            assert xl.engine == "xlrd"
+            result = pd.read_excel(xl, sheet_name=sheet_name, index_col=0)
+    with xlrd.open_workbook(pth) as book:
+        from_book = pd.read_excel(book, sheet_name=sheet_name, index_col=0)
+
+    tm.assert_frame_equal(result, expected)
+    tm.assert_frame_equal(from_book, expected)
+
+
+def test_read_excel_does_not_import_xlrd(datapath, monkeypatch):
+    # GH#56692 - the xlrd.Book check must not import xlrd
+    monkeypatch.delitem(sys.modules, "xlrd", raising=False)
+    with pd.option_context("io.excel.xlsx.reader", "openpyxl"):
+        pd.read_excel(datapath("io", "data", "excel", "test1.xlsx"))
+    assert "xlrd" not in sys.modules

--- a/pandas/tests/io/excel/test_xlrd.py
+++ b/pandas/tests/io/excel/test_xlrd.py
@@ -86,7 +86,7 @@ def test_xlrd_engine_deprecated(datapath):
 
 
 def test_read_xlrd_book_no_engine(datapath):
-    # GH#68075 - a Book has "read" but no "seek", so it passes is_file_like
+    # GH#68086 - a Book has "read" but no "seek", so it passes is_file_like
     # and used to reach inspect_excel_format instead of the xlrd branch
     sheet_name = "Sheet1"
     pth = datapath("io", "data", "excel", "test1.xls")


### PR DESCRIPTION
`pd.ExcelFile(book)` and `pd.read_excel(book)` for an `xlrd.Book` raise `AttributeError: 'Book' object has no attribute 'seek'` instead of reading the workbook:

```python
import pandas as pd
import xlrd

book = xlrd.open_workbook("pandas/tests/io/data/excel/test1.xls")
pd.ExcelFile(book)
# AttributeError: 'Book' object has no attribute 'seek'
```

The `isinstance(path_or_buffer, xlrd.Book)` branch in `ExcelFile.__init__` is unreachable. GH-57708 put it behind a `not is_file_like(path_or_buffer)` guard to keep `import xlrd` off the common path, but an `xlrd.Book` has a `read` attribute, so `is_file_like` is `True` and control falls through to `inspect_excel_format`, which seeks. First released in 3.0.0.

Only engine auto-detection is affected — an explicit `engine="xlrd"` has always worked, which is what the existing `test_read_xlrd_book` covers — so the docstrings listing `xlrd.Book` as accepted input are right and stay.

Since the guard was only ever about the import, this checks `sys.modules` instead of importing: an `xlrd.Book` can only exist if the caller already imported xlrd. The check is then free, so it can run before `inspect_excel_format` rather than behind a guard. That also tightens GH-56692's original goal — previously any non-path, non-file-like input (an `openpyxl.Workbook`, a `dict`) triggered a real `import xlrd`, and now nothing does. `xlrd_version` was only ever tested against `None`, and dropping it leaves `get_version`, `Version` and `is_file_like` with no remaining users in the module.

`test_read_excel_does_not_import_xlrd` is a forward guard on that invariant rather than a regression test — GH-56692 shipped without one, and the `sys.modules` check is what now carries it.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the dead branch, wrote the fix and tests, and ran a multi-round blind review of the result.
