### PR TITLE
BUG: SparseArray.mean warned or raised when every value was missing

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -916,6 +916,7 @@ Sparse
 - Bug in :meth:`Series.reindex` and alignment raising when extending a boolean :class:`SparseDtype`-backed :class:`Series`; missing entries now upcast to ``object`` to match the dense behavior (:issue:`32119`)
 - Bug in :meth:`Series.sum`, :meth:`Series.min`, and :meth:`Series.max` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`SparseArray.astype` where converting a datetime64 :class:`SparseArray` with ``NaT`` fill value to ``"Sparse[int64]"`` silently replaced the fill value with ``0`` instead of ``iNaT`` (:issue:`49631`)
+- Bug in :meth:`SparseArray.mean` emitting a numpy ``RuntimeWarning``, or raising ``ZeroDivisionError`` for object dtype or ``TypeError`` for a non-numeric ``fill_value``, when every value is missing, including an empty array; it now returns the missing value quietly (:issue:`68041`)
 - Bug in :meth:`SparseArray.mean` raising a ``TypeError`` when called with the ``skipna`` argument (:issue:`65478`)
 - Bug in :meth:`SparseArray.sum` with ``skipna=False`` returning ``NA`` for a non-null ``fill_value`` and ignoring missing values under a null ``fill_value`` (:issue:`65478`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -916,7 +916,7 @@ Sparse
 - Bug in :meth:`Series.reindex` and alignment raising when extending a boolean :class:`SparseDtype`-backed :class:`Series`; missing entries now upcast to ``object`` to match the dense behavior (:issue:`32119`)
 - Bug in :meth:`Series.sum`, :meth:`Series.min`, and :meth:`Series.max` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`SparseArray.astype` where converting a datetime64 :class:`SparseArray` with ``NaT`` fill value to ``"Sparse[int64]"`` silently replaced the fill value with ``0`` instead of ``iNaT`` (:issue:`49631`)
-- Bug in :meth:`SparseArray.mean` emitting a numpy ``RuntimeWarning``, or raising ``ZeroDivisionError`` for object dtype or ``TypeError`` for a non-numeric ``fill_value``, when every value is missing, including an empty array; it now returns the missing value quietly (:issue:`68041`)
+- Bug in :meth:`SparseArray.mean` emitting a numpy ``RuntimeWarning``, or raising ``ZeroDivisionError`` for object dtype or ``TypeError`` for a non-numeric ``fill_value``, when every value is missing, including an empty array; it now returns the missing value quietly (:issue:`68087`)
 - Bug in :meth:`SparseArray.mean` raising a ``TypeError`` when called with the ``skipna`` argument (:issue:`65478`)
 - Bug in :meth:`SparseArray.sum` with ``skipna=False`` returning ``NA`` for a non-null ``fill_value`` and ignoring missing values under a null ``fill_value`` (:issue:`65478`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1769,7 +1769,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         Returns
         -------
-        mean : float
+        scalar
         """
         nv.validate_mean(args, kwargs)
         skipna = validate_bool_kwarg(skipna, "skipna")
@@ -1780,11 +1780,18 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         # Compute the reduction before the skipna=False NA short-circuit so
         # unsupported dtypes still raise during the operation validation.
 
+        nsparse = 0 if self._null_fill_value else self.sp_index.ngaps
+        nobs = ct + nsparse
+
+        if not nobs:
+            # nobs == 0 is exactly "every entry is NA", empty arrays included; the
+            # division and the fill_value adjustment both warn or raise there (GH#68041)
+            return na_value_for_dtype(self.dtype.subtype, compat=False)
+
         if self._null_fill_value:
-            mean = sp_sum / ct
+            mean = sp_sum / nobs
         else:
-            nsparse = self.sp_index.ngaps
-            mean = (sp_sum + self.fill_value * nsparse) / (ct + nsparse)
+            mean = (sp_sum + self.fill_value * nsparse) / nobs
 
         if not skipna and self._hasna:
             return na_value_for_dtype(self.dtype.subtype, compat=False)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1785,7 +1785,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         if not nobs:
             # nobs == 0 is exactly "every entry is NA", empty arrays included; the
-            # division and the fill_value adjustment both warn or raise there (GH#68041)
+            # division and the fill_value adjustment both warn or raise there (GH#68087)
             return na_value_for_dtype(self.dtype.subtype, compat=False)
 
         if self._null_fill_value:

--- a/pandas/tests/arrays/sparse/test_reductions.py
+++ b/pandas/tests/arrays/sparse/test_reductions.py
@@ -194,6 +194,36 @@ class TestReductions:
         out = arr.mean(skipna=False)
         assert pd.isna(out)
 
+    @pytest.mark.parametrize(
+        "arr",
+        [
+            SparseArray(np.array([], dtype="float64")),
+            SparseArray(np.array([], dtype="float64"), fill_value=0),
+            SparseArray(np.array([], dtype="int64")),
+            SparseArray(np.array([np.nan, np.nan])),
+            SparseArray(np.array([np.nan]), fill_value=0),
+            SparseArray(np.array([], dtype=object)),
+            SparseArray(np.array([np.nan, np.nan], dtype=object)),
+            # a non-numeric fill_value makes even the nsparse adjustment raise
+            SparseArray(["a", "a", "b"], fill_value="a")[:0],
+            SparseArray(np.array([np.nan], dtype=object), fill_value="a"),
+        ],
+    )
+    @pytest.mark.parametrize("skipna", [True, False])
+    def test_mean_all_na(self, arr, skipna):
+        # GH#68041 dividing by a zero count warned or raised depending on the subtype
+        with tm.assert_produces_warning(None):
+            result = arr.mean(skipna=skipna)
+        assert pd.isna(result)
+
+    def test_mean_all_na_datetimelike(self):
+        # GH#68041 the NA is the subtype's, not float nan
+        arr = SparseArray(np.array([], dtype="m8[ns]"))
+        with tm.assert_produces_warning(None):
+            result = arr.mean()
+        assert isinstance(result, np.timedelta64)
+        assert pd.isna(result)
+
     @pytest.mark.parametrize("skipna", [True, False])
     def test_mean_raises_for_unsupported_object_dtype_with_na(self, skipna):
         arr = SparseArray(["a", np.nan], dtype=pd.SparseDtype(object))

--- a/pandas/tests/arrays/sparse/test_reductions.py
+++ b/pandas/tests/arrays/sparse/test_reductions.py
@@ -211,13 +211,13 @@ class TestReductions:
     )
     @pytest.mark.parametrize("skipna", [True, False])
     def test_mean_all_na(self, arr, skipna):
-        # GH#68041 dividing by a zero count warned or raised depending on the subtype
+        # GH#68087 dividing by a zero count warned or raised depending on the subtype
         with tm.assert_produces_warning(None):
             result = arr.mean(skipna=skipna)
         assert pd.isna(result)
 
     def test_mean_all_na_datetimelike(self):
-        # GH#68041 the NA is the subtype's, not float nan
+        # GH#68087 the NA is the subtype's, not float nan
         arr = SparseArray(np.array([], dtype="m8[ns]"))
         with tm.assert_produces_warning(None):
             result = arr.mean()


### PR DESCRIPTION
`SparseArray.mean` divided the sum by the observation count with no zero guard. Whenever that count was zero — an empty array, or one whose every entry is NA — the user got one of three failures, depending on the subtype and `fill_value`, where the dense equivalent quietly returns the missing value:

```python
import numpy as np
import pandas as pd
from pandas.arrays import SparseArray

SparseArray(np.array([], dtype="float64")).mean()
#   RuntimeWarning: invalid value encountered in scalar divide
SparseArray(np.array([np.nan, np.nan], dtype=object)).mean()
#   ZeroDivisionError: division by zero
SparseArray(["a", "a", "b"], fill_value="a")[:0].mean()
#   TypeError: unsupported operand type(s) for +: 'int' and 'str'

pd.Series([], dtype="float64").mean()   # nan, quietly
```

The guard returns `na_value_for_dtype(subtype)` rather than a bare `np.nan`, which preserves `NaT` for a `timedelta64` subtype — the old `0 / 0` produced `NaT` there. It sits ahead of the `fill_value * nsparse` adjustment so that a non-numeric `fill_value` cannot raise on the way to it.

`nobs == 0` is exactly "every entry is NA": under a null `fill_value` the gaps are NA, so `ct == 0` means all-NA; under a non-null `fill_value`, `nobs == 0` forces both `ngaps == 0` and `ct == 0`. Nothing non-degenerate changes — the two original division expressions are kept intact rather than folded into one, since a unified `sp_sum + fill_value * nsparse` would silently turn `fill_value=inf, ngaps=0` from `nan` into a real mean.

The `datetime64` subtype is untouched and still raises `UFuncTypeError` from `sp_values.sum()`, upstream of this guard; that is a separate pre-existing gap.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and the tests and ran a multi-round review over the diff.
