### PR TITLE
BUG: make Index.get_indexer treat pd.NA as NaN for array/Index targets

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -744,6 +744,7 @@ Indexing
 - Bug in :meth:`DataFrame.loc` and :meth:`Series.loc` replacing the index name with the key's name when indexing with an :class:`Index` (:issue:`17110`)
 - Bug in :meth:`DataFrame.loc` raising ``ValueError`` when setting a row on a :class:`DataFrame` with no columns and the label is not in the index (:issue:`17895`)
 - Bug in :meth:`DataFrame.loc` returning incorrect dtype when the column key is a ``slice`` (:issue:`63071`)
+- Bug in :meth:`Index.get_indexer` and :meth:`Index.drop` treating ``pd.NA`` in a list target as matching a NaN label of a string-dtype index but not in a numpy-array or :class:`Index` target; all target types now match the NaN label consistently (:issue:`65419`)
 - Bug in :meth:`Index.get_indexer` where ``method="pad"``, ``"backfill"``, or ``"nearest"`` returned incorrect results when the target contained ``NaT`` or ``NaN`` instead of ``-1`` (:issue:`32572`)
 - Bug in :meth:`Series.loc` and :meth:`DataFrame.loc` setitem-with-expansion silently corrupting a value just outside the integer dtype's range (e.g. ``2**63`` for ``int64``) on some platforms instead of keeping the ``float64`` result; ``inf`` was similarly affected, and both leaked a ``RuntimeWarning`` (:issue:`66394`)
 - Bug in :meth:`Series.loc` and :meth:`DataFrame.loc` setitem-with-expansion widening a ``datetime64`` or ``timedelta64`` column to microsecond resolution instead of keeping a coarser unit such as ``s`` or ``ms``, even when the new value fit in it losslessly (:issue:`66402`)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7122,10 +7122,11 @@ class Index(IndexOpsMixin, PandasObject):
             # is object dtype (coercing to string dtype will alter the missing values)
             target_index = Index(target, dtype=self.dtype)
         elif (
-            not hasattr(target, "dtype")
-            and isinstance(self.dtype, StringDtype)
+            isinstance(self.dtype, StringDtype)
             and self.dtype.na_value is np.nan
             and using_string_dtype()
+            and not isinstance(target_index, ABCMultiIndex)
+            and target_index.hasnans
         ):
             # Fill missing values to ensure consistent missing value representation
             target_index = target_index.fillna(np.nan)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7128,8 +7128,11 @@ class Index(IndexOpsMixin, PandasObject):
             and not isinstance(target_index, ABCMultiIndex)
             and target_index.hasnans
         ):
-            # Fill missing values to ensure consistent missing value representation
-            target_index = target_index.fillna(np.nan)
+            # Fill missing values to ensure consistent missing value
+            # representation. Coerce to object first so that datetime-like and
+            # period missing values (NaT) are also normalized to np.nan, matching
+            # the scalar get_loc semantics (GH#65419).
+            target_index = target_index.astype(object).fillna(np.nan)
         return target_index
 
     @final

--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -111,6 +111,26 @@ class TestGetLoc:
             idx.get_loc(pd.NaT)
 
 
+def test_get_indexer_pd_na_matches_nan():
+    # GH#65419
+    idx = pd.Index([np.nan, "b"])
+
+    for target in [
+        [pd.NA],
+        np.array([pd.NA], dtype=object),
+        pd.Index([pd.NA]),
+        pd.Index([pd.NA], dtype="string"),
+    ]:
+        result = idx.get_indexer(target)
+        expected = np.array([0], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+    expected = pd.Index(["b"])
+    for labels in [[pd.NA], np.array([pd.NA], dtype=object), pd.Index([pd.NA])]:
+        result = idx.drop(labels)
+        tm.assert_index_equal(result, expected)
+
+
 def test_get_indexer_monotonic_above_size_cutoff(monkeypatch):
     # GH#14273 get_indexer should avoid building a hash table for large
     # monotonic indices.

--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 
+from pandas._config import using_string_dtype
 from pandas._libs import index as libindex
 
 import pandas as pd
@@ -111,6 +112,9 @@ class TestGetLoc:
             idx.get_loc(pd.NaT)
 
 
+@pytest.mark.skipif(
+    not using_string_dtype(), reason="string dtype inference not enabled"
+)
 def test_get_indexer_pd_na_matches_nan():
     # GH#65419
     idx = pd.Index([np.nan, "b"])

--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 from pandas._config import using_string_dtype
+
 from pandas._libs import index as libindex
 
 import pandas as pd

--- a/pandas/tests/indexes/base_class/test_indexing.py
+++ b/pandas/tests/indexes/base_class/test_indexing.py
@@ -136,6 +136,25 @@ def test_get_indexer_pd_na_matches_nan():
         tm.assert_index_equal(result, expected)
 
 
+def test_get_indexer_nat_matches_nan():
+    # GH#65419
+    # get_loc(pd.NaT) already matches np.nan for a string-dtype index, so
+    # get_indexer should match it regardless of how the target is passed.
+    idx = pd.Index([np.nan, "b"])
+    assert idx.get_loc(pd.NaT) == 0
+
+    for target in [
+        [pd.NaT],
+        np.array([pd.NaT], dtype=object),
+        pd.Index([pd.NaT]),
+        pd.Index([pd.NaT], dtype=object),
+        pd.DatetimeIndex([pd.NaT]),
+    ]:
+        result = idx.get_indexer(target)
+        expected = np.array([0], dtype=np.intp)
+        tm.assert_numpy_array_equal(result, expected)
+
+
 def test_get_indexer_monotonic_above_size_cutoff(monkeypatch):
     # GH#14273 get_indexer should avoid building a hash table for large
     # monotonic indices.


### PR DESCRIPTION
- [x] closes #65419
- [x] Tests added and passed
- [x] All code checks passed.
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the contribution guidelines.

Check exactly one of the following, per the automated contributions policy:

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting.

## Summary

`Index.get_indexer` and `Index.drop` treated `pd.NA` inconsistently when matching a NaN label of a string-dtype index:

```python
idx = pd.Index([np.nan, "b"])          # str dtype

idx.get_indexer([pd.NA])                       # [0]  (matched NaN)
idx.get_indexer(np.array([pd.NA], dtype=object))  # [-1]  (bug: did not match)
idx.get_indexer(pd.Index([pd.NA]))             # [-1]  (bug: did not match)
idx.drop([pd.NA])                               # worked
idx.drop(np.array([pd.NA], dtype=object))       # KeyError (bug)
```

`Index.get_loc(pd.NA)` already matches `np.nan`, so the list-target behavior (and scalar lookup) is the intended semantics; the numpy-array and `Index` targets diverged.

Root cause: `Index._maybe_cast_listlike_indexer` normalizes missing values for a `StringDtype` (na_value `np.nan`) target — `target_index.fillna(np.nan)` — but only when the input was a plain list (`not hasattr(target, "dtype")`). Numpy arrays and `Index` objects already carry a `dtype`, so they skipped the normalization and their `pd.NA` kept a different hash than the stored `np.nan`, missing the lookup.

Fix: drop the `not hasattr(target, "dtype")` gate so array/`Index` targets are normalized too, guarded by `target_index.hasnans` (to avoid a no-op copy on NA-free targets) and excluding `MultiIndex` (whose `hasnans`/`isna` raise `NotImplementedError`).

## Verification

- Reproducer from #65419 now returns `[0]` for list, ndarray, `Index`, and `string`-dtype targets, and `drop` works for all target forms.
- Added `test_get_indexer_pd_na_matches_nan` in `pandas/tests/indexes/base_class/test_indexing.py`.
- `pytest pandas/tests/indexes/` → 18087 passed, 244 skipped, 45 xfailed.
- `pytest pandas/tests/indexes/base_class/` → 136 passed.
- `pytest pandas/tests/extension/test_string.py` → 4528 passed, 796 skipped, 20 xfailed.
- `pytest pandas/tests/reshape/` → 2903 passed, 17 skipped, 6 xfailed.
- `ruff check` / `ruff format --check` on touched files → clean.

## Automated contribution disclosure

- Tool: Pi coding agent (https://github.com/earendil-works/pi-coding-agent)
- Model: deepseek-v4-pro (via company-newapi)
- Reasoning-effort setting: off

The agent reproduced the inconsistency, traced it to the `not hasattr(target, "dtype")` gate in `_maybe_cast_listlike_indexer`, relaxed the gate with a `hasnans` guard and a `MultiIndex` exclusion, and wrote the regression test. I reviewed the change against the indexing code paths, verified the fix with the reproducer and the indexes/string/reshape test suites, and confirmed no regressions.
