### PR TITLE
DOC: clarify Series.map elementwise usage

### DIFF
--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4992,9 +4992,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         """
         Map values of Series according to an input mapping or function.
 
-        Used for substituting each value in a Series with another value,
-        that may be derived from a function, a ``dict`` or
-        a :class:`Series`.
+        This is the preferred method for elementwise operations on a Series.
+        It can substitute each value with another value derived from a
+        function, a ``dict`` or a :class:`Series`.
 
         Parameters
         ----------
@@ -5115,6 +5115,15 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         3    None
         4    None
         dtype: object
+
+        For example, use ``map`` with a lambda function to increment each value:
+
+        >>> ser = pd.Series([1, 2, 3])
+        >>> ser.map(lambda x: x + 1)
+        0    2
+        1    3
+        2    4
+        dtype: int64
         """
         if func is None:
             if "arg" in kwargs:

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -4992,9 +4992,9 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         """
         Map values of Series according to an input mapping or function.
 
-        This is the preferred method for elementwise operations on a Series.
-        It can substitute each value with another value derived from a
-        function, a ``dict`` or a :class:`Series`.
+        The mapping is applied elementwise, substituting each value with
+        another value derived from a function, a ``dict`` or a
+        :class:`Series`.
 
         Parameters
         ----------
@@ -5116,14 +5116,18 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         4    None
         dtype: object
 
-        For example, use ``map`` with a lambda function to increment each value:
+        Functions without a vectorized equivalent can be applied to each
+        value:
 
-        >>> ser = pd.Series([1, 2, 3])
-        >>> ser.map(lambda x: x + 1)
-        0    2
+        >>> s = pd.Series([1, 2.5, "abc"])
+        >>> s.map(lambda x: len(str(x)))
+        0    1
         1    3
-        2    4
+        2    3
         dtype: int64
+
+        When a vectorized operation exists, it is much faster; for
+        example, use ``s + 1`` rather than ``s.map(lambda x: x + 1)``.
         """
         if func is None:
             if "arg" in kwargs:


### PR DESCRIPTION
Closes #58184.

DataFrame.map opens with 'Apply a function to a Dataframe elementwise' but Series.map opened with a generic 'Map values...' line and only had string/dict examples, so readers kept reaching for Series.apply for elementwise lambdas. The opening now states the mapping is applied elementwise, and the example block gains a mixed-dtype case after the categorical block:

>>> s = pd.Series([1, 2.5, "abc"])
>>> s.map(lambda x: len(str(x)))
0    1
1    3
2    3
dtype: int64

with a note that a vectorized operation is much faster when one exists (use s + 1 rather than s.map(lambda x: x + 1)).

I looked at the two earlier tries: #65412 put the new example in the middle of an existing block (review asked to move it), #66364 had the right placement and only needed one nit, dropping the 'also' in 'It can also substitute...'. This picks up from there with that wording fixed.

Checked on main at 04dff44:
- repro script reads pandas/core/series.py + frame.py directly: before, the Series opening had no elementwise wording and the added example was absent; after, both are present and the example output is [1, 3, 3], dtype int64.
- battery over dict, string-format func, numeric lambda, defaultdict, na_action ignore/preserve, empty, all-NaN, categorical, Series-as-mapping, and DataFrame.map: all match expected values. Series.map **kwargs is 3.0-gated so I noted it as skipped on my local 2.2.2 env instead of dropping it silently.
- safe because the diff is 16+/3- in the docstring only: no lines starting with def/if/return/for/import or assignments; runtime paths untouched.
- ruff check is 23 errors before and after (identical, pre-existing), ruff format --check clean, git diff --check clean, added lines max 80 chars, no trailing whitespace.
- pandas/tests/series/methods/test_map.py does not collect against a 2.2.2 install (needs Pandas4Warning from main plus built extensions), so I ran the equivalent map paths above rather than claiming the suite ran. CI will cover the real suite.
