### PR TITLE
DOC: copy code only in docs code cells

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -450,8 +450,16 @@ random.seed(42)"""
 # nbsphinx do not use requirejs (breaks bootstrap)
 nbsphinx_requirejs_path = ""
 
-# https://sphinx-toggleprompt.readthedocs.io/en/stable/#offset
-toggleprompt_offset_right = 35
+# Strip input prompts when copying code cells so only code (not prompts or
+# outputs) is copied. Pattern covers the stock Python REPL, bash, and the
+# IPython/Jupyter prompts emitted by the ipython directive used across the
+# user guide (e.g. `In [1]:` with `...:` continuations). When prompt lines
+# are detected, only those lines are copied, which excludes outputs
+# automatically. See https://sphinx-copybutton.readthedocs.io/en/latest/use.html
+# Note: sphinx-toggleprompt is intentionally not used here; it is broken for
+# the current Sphinx (https://github.com/jurasofish/sphinx-toggleprompt/issues/23).
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["../_templates"]


### PR DESCRIPTION
Closes #56388.

The groupby user guide (and every other '.. ipython:: python' page) renders with 'In [1]:' / '...:' prompts plus 'Out[n]:' output blocks, but clicking copy grabs everything — prompts, code, and output tables. sphinx-copybutton was already enabled yet had no prompt config, so it never knew what to strip. There was also a leftover toggleprompt_offset_right pointing at sphinx-toggleprompt, which is broken on current Sphinx and not even installed.

I set the canonical copybutton prompt pattern from copybutton's own docs (REPL + bash + IPython/Jupyter continuations) so only prompt lines get copied and outputs drop out on their own. I deliberately did not re-add sphinx-toggleprompt — that was the wrong half of #62108.

Checked on current main:
- repro reads conf.py directly: copybutton on, no prompt config, dangling toggleprompt var, groupby uses ipython directive. After the change the gap is gone.
- regex sanity over '>>>', '...', '$', 'In [1]:', 'In []:', continuations, plus negatives for 'Out[2]:' and output rows — all match as intended. Simulated the issue's exact block: copied text is just the two input statements, no prompts, no table.
- safe because the diff is conf.py only (10+/2-), no dependency changes, no toggleprompt extension. conf.py compiles, 'git diff --check' clean, ruff 7 errors before and after (identical, pre-existing).
- full docs build needs the built pandas + sphinx stack, so I verified config + regex locally rather than claiming a full build ran. Doc build CI will cover the real thing.