### PR TITLE
BUG: __array_ufunc__ infinite recursion / crash with pandas where/out kwargs

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1058,6 +1058,8 @@ Other
 - Bug in :meth:`Series.transform` and :meth:`DataFrame.transform` where passing a list of duplicate function names did not raise :class:`errors.SpecificationError` (:issue:`54929`)
 - Bug in ``register_option`` where registering an option whose name was a prefix of an existing option (e.g. ``"a.b"`` when ``"a.b.c"`` was already registered) silently overwrote the existing option's namespace instead of raising (:issue:`29242`)
 - Bug in the ``display.max_colwidth`` option where values smaller than ``4`` were silently ignored, leaving the repr untruncated and its column headers misaligned (:issue:`16097`)
+- Bug in ufunc calls such as ``np.maximum(series, 0, where=series > 2)`` where passing a :class:`Series`, :class:`Index`, or other pandas object as the ``where`` argument recursed infinitely, raising ``RecursionError`` or crashing the interpreter, instead of masking the result (:issue:`60611`)
+- Bug in ufunc calls with both ``out`` and ``where`` arguments where passing a :class:`Series` or :class:`Index` as ``out`` raised ``TypeError`` from ``numpy.putmask`` instead of writing the masked result into it (:issue:`60611`)
 
 .. ***DO NOT USE THIS SECTION***
 

--- a/pandas/core/arraylike.py
+++ b/pandas/core/arraylike.py
@@ -293,6 +293,13 @@ def array_ufunc(self, ufunc: np.ufunc, method: str, *inputs: Any, **kwargs: Any)
 
     kwargs = _standardize_out_kwarg(**kwargs)
 
+    if "where" in kwargs:
+        # GH#60611 if `where` is a Series/Index/ExtensionArray, leaving it
+        # in kwargs means it gets passed straight through to the ufunc,
+        # which re-triggers our __array_ufunc__ on it and recurses
+        # infinitely (eventually raising RecursionError or segfaulting).
+        kwargs["where"] = extract_array(kwargs["where"], extract_numpy=True)
+
     # for binary ops, use our custom dunder methods
     result = maybe_dispatch_ufunc_to_dunder_op(self, ufunc, method, *inputs, **kwargs)
     if result is not NotImplemented:
@@ -494,8 +501,15 @@ def _assign_where(out, result, where) -> None:
     if where is None:
         # no 'where' arg passed to ufunc
         out[:] = result
-    else:
+    elif isinstance(out, np.ndarray):
         np.putmask(out, where, result)
+    else:
+        # GH#60611 np.putmask requires `out` to be an ndarray, but `out` may
+        # instead be a Series/Index passed by the user. `out` is 1D in this
+        # case, so masked assignment via __setitem__ is equivalent to
+        # putmask; convert `result` to an ndarray first so boolean indexing
+        # is elementwise rather than e.g. DataFrame's row-selection.
+        out[where] = np.asarray(result)[where]
 
 
 def default_array_ufunc(self, ufunc: np.ufunc, method: str, *inputs, **kwargs):

--- a/pandas/tests/series/test_ufunc.py
+++ b/pandas/tests/series/test_ufunc.py
@@ -246,6 +246,17 @@ def test_binary_ufunc_out_pandas_object():
     tm.assert_series_equal(out, expected)
 
 
+def test_binary_ufunc_where_pandas_object():
+    # GH#60611 passing a Series as the ufunc `where` argument used to recurse
+    #  infinitely (RecursionError / segfault) instead of masking the result.
+    a = pd.Series([-3.22, 4.0])
+
+    result = np.maximum(a, 0, where=a > 2, out=a.copy())
+
+    expected = pd.Series([-3.22, 4.0])
+    tm.assert_series_equal(result, expected)
+
+
 def test_object_series_ok():
     class Dummy:
         def __init__(self, value) -> None:


### PR DESCRIPTION
- [x] closes #60611
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

- [x] I used AI to develop this pull request. Tool: Claude Code. Model: claude sonnet 5 (reasoning effort 80). I prompted it to find and fix long-standing, hard-to-fix pandas issues per `AGENTS.md`; I reviewed the diff and the reasoning behind it, and verified the fix reproduces the reported crash before the change and resolves it after, with the full `pandas/tests/series/test_ufunc.py` and `pandas/tests/frame/test_ufunc.py` suites (and a 75k+ test sweep across `series`/`frame`/`groupby`/`extension`/`window`) passing.

### Summary

`np.maximum(series, 0, where=series > 2)` recursed infinitely inside `NDFrame.__array_ufunc__` (raising `RecursionError`, or segfaulting on platforms where the C stack overflows before Python's recursion check fires), because `arraylike.array_ufunc` passed the `where` kwarg straight through to the underlying ufunc call without unwrapping it from the Series — so numpy called back into `__array_ufunc__` on it, forever.

This also surfaced a second bug in the same code path: when both `out` and `where` are pandas objects, `_assign_where` called `np.putmask(out, ...)`, which requires `out` to be a raw ndarray and raised `TypeError` otherwise.

`where` is now extracted to its underlying array up front (mirroring what already happens for `out`), and `_assign_where` falls back to boolean-index assignment (equivalent to `putmask` for same-shaped arrays) when `out` isn't an ndarray.