### PR TITLE
BUG: fix self-contradictory set_levels/set_codes error for nested value with scalar level (#66287)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -803,6 +803,7 @@ MultiIndex
 - Bug in :meth:`MultiIndex.union` raising ``InvalidIndexError`` when combining levels containing :class:`datetime.date` and :class:`Timestamp` values representing the same date (:issue:`61807`)
 - Bug in the :class:`DataFrame` constructor where passing a :class:`DataFrame` with a unique integer :class:`MultiIndex` together with a flat integer ``index`` raised ``ValueError: Buffer dtype mismatch`` instead of reindexing to an all-``NaN`` result (:issue:`26460`)
 - :meth:`MultiIndex.isin` now raises an informative ``ValueError`` when the values are not tuples matching the number of levels, instead of raising a cryptic ``TypeError`` or ``AssertionError`` or silently returning incorrect results (:issue:`20252`, :issue:`26622`)
+- Bug in the :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` error message for a nested (list-of-lists) value paired with a scalar ``level``, which repeated the misleading "must be list-like" message; it now names the real constraint as "must be list-like, not a list of lists-like" (:issue:`66287`)
 
 I/O
 ^^^

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -803,7 +803,7 @@ MultiIndex
 - Bug in :meth:`MultiIndex.union` raising ``InvalidIndexError`` when combining levels containing :class:`datetime.date` and :class:`Timestamp` values representing the same date (:issue:`61807`)
 - Bug in the :class:`DataFrame` constructor where passing a :class:`DataFrame` with a unique integer :class:`MultiIndex` together with a flat integer ``index`` raised ``ValueError: Buffer dtype mismatch`` instead of reindexing to an all-``NaN`` result (:issue:`26460`)
 - :meth:`MultiIndex.isin` now raises an informative ``ValueError`` when the values are not tuples matching the number of levels, instead of raising a cryptic ``TypeError`` or ``AssertionError`` or silently returning incorrect results (:issue:`20252`, :issue:`26622`)
-- Bug in the :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` error message for a nested (list-of-lists) value paired with a scalar ``level``, which repeated the misleading "must be list-like" message; it now names the real constraint as "must be list-like, not a list of lists-like" (:issue:`66287`)
+- Bug in the :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` error message for a nested (list-of-lists) value paired with a scalar ``level``, which repeated the misleading "must be list-like" message; it now names the real constraint as "must be list-like, not a list of list-likes" (:issue:`66287`)
 
 I/O
 ^^^

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -5142,7 +5142,7 @@ def _require_listlike(level, arr, arrname: str):
         if not is_list_like(arr):
             raise TypeError(f"{arrname} must be list-like")
         if len(arr) > 0 and is_list_like(arr[0]):
-            raise TypeError(f"{arrname} must be list-like")
+            raise TypeError(f"{arrname} must be list-like, not a list of lists-like")
         level = [level]
         arr = [arr]
     elif level is None or is_list_like(level):

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -5142,7 +5142,7 @@ def _require_listlike(level, arr, arrname: str):
         if not is_list_like(arr):
             raise TypeError(f"{arrname} must be list-like")
         if len(arr) > 0 and is_list_like(arr[0]):
-            raise TypeError(f"{arrname} must be list-like, not a list of lists-like")
+            raise TypeError(f"{arrname} must be list-like, not a list of list-likes")
         level = [level]
         arr = [arr]
     elif level is None or is_list_like(level):

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -284,6 +284,13 @@ def test_set_levels_codes_names_bad_input(idx):
     with pytest.raises(TypeError, match="list-like"):
         idx.set_codes(codes, level=0)
 
+    # GH#66287 nested value with a scalar level
+    with pytest.raises(TypeError, match="must be list-like, not a list of lists-like"):
+        idx.set_levels([levels[0]], level=0)
+
+    with pytest.raises(TypeError, match="must be list-like, not a list of lists-like"):
+        idx.set_codes([codes[0]], level=0)
+
     # should have equal lengths
     with pytest.raises(ValueError, match="Length of names"):
         idx.set_names(names[0], level=[0, 1])

--- a/pandas/tests/indexes/multi/test_get_set.py
+++ b/pandas/tests/indexes/multi/test_get_set.py
@@ -285,10 +285,10 @@ def test_set_levels_codes_names_bad_input(idx):
         idx.set_codes(codes, level=0)
 
     # GH#66287 nested value with a scalar level
-    with pytest.raises(TypeError, match="must be list-like, not a list of lists-like"):
+    with pytest.raises(TypeError, match="must be list-like, not a list of list-likes"):
         idx.set_levels([levels[0]], level=0)
 
-    with pytest.raises(TypeError, match="must be list-like, not a list of lists-like"):
+    with pytest.raises(TypeError, match="must be list-like, not a list of list-likes"):
         idx.set_codes([codes[0]], level=0)
 
     # should have equal lengths


### PR DESCRIPTION
Closes #66287

## Summary
`MultiIndex.set_levels` / `set_codes` raised a self-contradictory error when a
single scalar level was paired with a nested (list-of-lists) value:

```
TypeError: Levels must be list-like
```

The value `[["x", "y"]]` *is* list-like, so the message was misleading. This PR
changes the nested-value branch in `_require_listlike` to name the real
constraint:

```
TypeError: Levels must be list-like, not a list of lists-like
```

mirroring the existing "must be list of lists-like" message used for the
list-valued level branch. Tests were added for both `set_levels` and `set_codes`.

## Checklist
- [x] closes #66287
- [x] Tests added and passed
- [x] All code checks passed
- [x] Added type annotations to new arguments/methods/functions (N/A)
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst` file
- [x] I have reviewed and followed all the contribution guidelines
