### PR TITLE
BUG: infer_freq returned "B"/"bh" for indexes with fractional day/hour gaps

### DIFF
--- a/pandas/tests/tseries/frequencies/test_inference.py
+++ b/pandas/tests/tseries/frequencies/test_inference.py
@@ -358,6 +358,72 @@ def test_infer_freq_business_hour(data, expected):
     assert idx.inferred_freq == expected
 
 
+@pytest.mark.parametrize(
+    "klass, data",
+    [
+        # fractional overnight gap: 17.5h, not the 17h of a "bh" day boundary
+        (
+            pd.DatetimeIndex,
+            [
+                "2026-01-01 09:00",
+                "2026-01-01 10:00",
+                "2026-01-01 11:00",
+                "2026-01-02 04:30",
+                "2026-01-02 05:30",
+                "2026-01-02 06:30",
+            ],
+        ),
+        # fractional base step: 1.5h floors to the same 1 as an hourly step
+        (
+            pd.DatetimeIndex,
+            [
+                "2026-01-01 09:00",
+                "2026-01-01 10:30",
+                "2026-01-01 12:00",
+                "2026-01-02 05:30",
+                "2026-01-02 07:00",
+                "2026-01-02 08:30",
+            ],
+        ),
+        # fractional weekend gap: 65.5h, not the 65h of a "bh" weekend
+        (
+            pd.DatetimeIndex,
+            [
+                "2026-01-02 09:00",
+                "2026-01-02 10:00",
+                "2026-01-02 11:00",
+                "2026-01-05 04:30",
+                "2026-01-05 05:30",
+                "2026-01-05 06:30",
+            ],
+        ),
+        # fractional weekend gap: 3.5d, not the 3d of a "B" weekend
+        (
+            pd.DatetimeIndex,
+            [
+                "2026-01-01 09:00",
+                "2026-01-02 09:00",
+                "2026-01-05 21:00",
+                "2026-01-06 21:00",
+                "2026-01-07 21:00",
+                "2026-01-08 21:00",
+                "2026-01-09 21:00",
+            ],
+        ),
+        # _TimedeltaFrequencyInferer inherits the same "bh" check
+        (
+            pd.TimedeltaIndex,
+            ["1h", "2h", "3h", "20h30min", "21h30min", "22h30min"],
+        ),
+    ],
+)
+def test_infer_freq_fractional_gap(klass, data):
+    # GH#68153 a gap that is not a whole number of hours/days must not be
+    #  floored into matching the "bh"/"B" delta patterns
+    idx = klass(data)
+    assert idx.inferred_freq is None
+
+
 def test_not_monotonic():
     rng = pd.DatetimeIndex(["1/31/2000", "1/31/2001", "1/31/2002"])
     rng = rng[::-1]

--- a/pandas/tseries/frequencies.py
+++ b/pandas/tseries/frequencies.py
@@ -330,14 +330,18 @@ class _FrequencyInferer:
             return _maybe_add_count("ns", delta)
 
     @cache_readonly
-    def day_deltas(self) -> list[int]:
+    def day_deltas(self) -> list[float]:
+        # NB: must be true division; flooring would let a fractional gap
+        #  match the exact [1, 3] check in _is_business_daily
         ppd = periods_per_day(self._creso)
-        return [x // ppd for x in self.deltas]
+        return [x / ppd for x in self.deltas]
 
     @cache_readonly
-    def hour_deltas(self) -> list[int]:
+    def hour_deltas(self) -> list[float]:
+        # NB: must be true division, as in day_deltas; this one feeds the
+        #  exact [1, 17]/[1, 65] check in get_freq
         pph = periods_per_day(self._creso) // 24
-        return [x // pph for x in self.deltas]
+        return [x / pph for x in self.deltas]
 
     @cache_readonly
     def fields(self) -> np.ndarray:  # structured array of fields


### PR DESCRIPTION
GH-64575 was a perf PR that also carried an unrelated drive-by: it changed `/` to `//` in `_FrequencyInferer.day_deltas` and `hour_deltas` "to match their `list[int]` return type annotations". Those values feed *exact* membership checks — `hour_deltas in ([1, 17], [1, 65], [1, 17, 65])` for `"bh"` and `day_deltas != [1, 3]` for `"B"` — so flooring lets a fractional gap match a pattern it should not:

```python
>>> data = ["2026-01-01 09:00", "2026-01-01 10:00", "2026-01-01 11:00",
...         "2026-01-02 04:30", "2026-01-02 05:30", "2026-01-02 06:30"]
>>> pd.DatetimeIndex(data).inferred_freq   # 17.5h gap floors to 17
"bh"                                       # expected None

>>> data = ["2026-01-01 09:00", "2026-01-02 09:00", "2026-01-05 21:00",
...         "2026-01-06 21:00", "2026-01-07 21:00", "2026-01-08 21:00",
...         "2026-01-09 21:00"]
>>> pd.DatetimeIndex(data).inferred_freq   # 3.5d gap floors to 3
"B"                                        # expected None
```

Neither round-trips through `date_range`, and `DatetimeIndex(..., freq="infer")` attaches the bogus offset because the infer path skips `_validate_frequency`. `TimedeltaIndex.inferred_freq` is affected too, via the shared `"bh"` branch — `_TimedeltaFrequencyInferer` overrides only `_infer_daily_rule`.

The fix restores true division and corrects the annotations to `list[float]`; the annotation was wrong before GH-64575, not the code. The `np.unique` half of GH-64575, which is where its measured speedup came from, is untouched.

No whatsnew entry: GH-64575 is in no released version, so the regression lived and died inside the unreleased 3.1.0 cycle.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which found the regression during an audit of GH-64575, wrote the fix and tests, and reviewed the branch before this PR was opened.