### PR TITLE
DOC: mention ADBC over ODBC as an option before falling back to SQLAlchemy

### DIFF
--- a/doc/source/user_guide/io.rst
+++ b/doc/source/user_guide/io.rst
@@ -5688,6 +5688,19 @@ included in Python's standard library by default.
 You can find an overview of supported drivers for each SQL dialect in the
 `SQLAlchemy docs <https://docs.sqlalchemy.org/en/latest/dialects/index.html>`__.
 
+A database with an ODBC driver but no native ADBC driver can still be used through an
+ADBC connection: `adbcBridge <https://adbcbridge.org>`__ is an ADBC driver that wraps the
+database's ODBC driver and returns a standard ADBC DBAPI connection, which
+:func:`~pandas.read_sql` and :meth:`~DataFrame.to_sql` accept like any other ADBC
+connection.
+
+.. code-block:: python
+
+   import adbcbridge
+
+   with adbcbridge.connect(uri="DSN=warehouse;") as conn:
+       df = pd.read_sql("SELECT * FROM sales", conn)
+
 If SQLAlchemy is not installed, you can use a :class:`sqlite3.Connection` in place of
 a SQLAlchemy engine, connection, or URI string.
 


### PR DESCRIPTION
The SQL section of the IO guide recommends ADBC drivers first and SQLAlchemy where no ADBC driver exists. This adds the case in between: a database that has an ODBC driver but no native ADBC driver can still be used through an ADBC connection, since an ADBC driver that wraps the ODBC driver returns a standard ADBC DBAPI connection that `read_sql` and `to_sql` already accept.

One paragraph and a two-line example, placed between the existing ADBC and SQLAlchemy paragraphs. Docs only.
