### PR TITLE
DOC: Fix installation command formatting in install.rst

### DIFF
--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -105,7 +105,7 @@ Installing the development version is the quickest way to:
 * Check whether a bug you encountered has been fixed since the last release.
 
 The development version is usually uploaded daily to the scientific-python-nightly-wheels
-index from the PyPI registry of anaconda.org. You can install it by running.
+index from the PyPI registry of anaconda.org. You can install it by running:
 
 .. code-block:: shell
 


### PR DESCRIPTION
Corrected the installation command formatting in the documentation.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [x] I did **not** use AI to develop this pull request.
- [ ] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
