### PR TITLE
DOC: complete eight doc fixes that missed a sibling copy or an adjacent line

### DIFF
--- a/doc/source/development/contributing_documentation.rst
+++ b/doc/source/development/contributing_documentation.rst
@@ -115,7 +115,7 @@ on how to format the docstring.
 The examples in the docstring ('doctests') must be valid Python code,
 that in a deterministic way returns the presented output, and that can be
 copied and run by users. This can be checked with the script above, and is
-also tested on Travis. A failing doctest will be a blocker for merging a PR.
+also tested by GitHub Actions. A failing doctest will be a blocker for merging a PR.
 Check the :ref:`examples <docstring.examples>` section in the docstring guide
 for some tips and tricks to get the doctests passing.
 
@@ -199,7 +199,7 @@ Building main branch documentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When pull requests are merged into the pandas ``main`` branch, the main parts of
-the documentation are also built by Github Actions. These docs are then hosted `here
+the documentation are also built by GitHub Actions. These docs are then hosted `here
 <https://pandas.pydata.org/docs/dev/>`__, see also
 the :any:`Continuous Integration <contributing.ci>` section.
 

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -445,7 +445,7 @@ The general rules for the various types of input:
 
 - The new default resolution when parsing strings is microseconds, falling back
   to nanoseconds when the precision of the string requires it.
-- The resolution of the input is preserved for stdlib  ``datetime`` objects (i.e. microseconds)
+- The resolution of the input is preserved for stdlib ``datetime`` objects (i.e. microseconds)
   or ``np.datetime64``/``np.timedelta64`` objects (i.e. the unit, capped to
   the supported range of seconds to nanoseconds).
 - For integer input, the resolution used to interpret the integer value is used

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -439,7 +439,7 @@ Prior to pandas 3.0, whenever converting a sequence of strings, stdlib ``datetim
 objects, ``np.datetime64`` objects, or integers to a ``datetime64`` / ``timedelta64``
 dtype, this would always have resulted in nanosecond resolution (or raised an
 out-of-bounds error).
-Now it performs inference on the appropriate resolution (a.k.a. ``unit``) for the output dtype. This affects both the generric constructors (:class:`Series`, :class:`DataFrame`, :class:`Index`, :class:`DatetimeIndex`) as specific conversion or creation functions (:func:`to_datetime`, :func:`to_timedelta`, :func:`date_range`, :func:`timedelta_range`, :class:`Timestamp`, :class:`Timedelta`).
+Now it performs inference on the appropriate resolution (a.k.a. ``unit``) for the output dtype. This affects both the generic constructors (:class:`Series`, :class:`DataFrame`, :class:`Index`, :class:`DatetimeIndex`) and specific conversion or creation functions (:func:`to_datetime`, :func:`to_timedelta`, :func:`date_range`, :func:`timedelta_range`, :class:`Timestamp`, :class:`Timedelta`).
 
 The general rules for the various types of input:
 
@@ -448,7 +448,7 @@ The general rules for the various types of input:
 - The resolution of the input is preserved for stdlib  ``datetime`` objects (i.e. microseconds)
   or ``np.datetime64``/``np.timedelta64`` objects (i.e. the unit, capped to
   the supported range of seconds to nanoseconds).
-- For integer input, the resolution how the integer value is interpreted is used
+- For integer input, the resolution used to interpret the integer value is used
   as the resulting resolution (or capped to the supported range of seconds to nanoseconds).
 
 For example, the following would always have given nanosecond resolution previously,
@@ -473,7 +473,7 @@ but now infer:
    >>> print(pd.Series([np.datetime64("2024-03-22", "ms")]).dtype)
    datetime64[ms]
 
-Similar when passed a sequence of ``np.datetime64`` objects, the resolution of the passed objects will be retained (or for lower-than-second resolution, second resolution will be used).
+Similarly, when passed a sequence of ``np.datetime64`` objects, the resolution of the passed objects will be retained (or for lower-than-second resolution, second resolution will be used).
 
 When parsing strings, the default is now microseconds (which also impacts I/O
 methods reading from text files, such as :func:`read_csv` and :func:`read_json`).
@@ -537,7 +537,7 @@ times. These cases will now raise a ``ValueError``.
 If you were relying on pandas to use ``pytz`` timezones and accessing the timezone
 through a ``.tz`` attribute, you may now get different timezone objects than before.
 In most cases, this should not cause any issues, but if you were relying on specific
-behavior of ``pytz`` timezones, you may need to update your code or used ``pytz`` explicitly.
+behavior of ``pytz`` timezones, you may need to update your code or use ``pytz`` explicitly.
 See this `pytz migration guide <https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html>`__ for more details.
 
 .. warning::

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -215,7 +215,7 @@ def contains(cat, key, container) -> bool:
 
     Parameters
     ----------
-    cat : :class:`Categorical`or :class:`CategoricalIndex`
+    cat : :class:`Categorical` or :class:`CategoricalIndex`
     key : a hashable object
         The key to check membership for.
     container : Container (e.g. list-like or mapping)

--- a/pandas/core/arrays/categorical.py
+++ b/pandas/core/arrays/categorical.py
@@ -208,7 +208,7 @@ def contains(cat, key, container) -> bool:
     Helper for membership check for ``key`` in ``cat``.
 
     This is a helper method for :meth:`__contains__`
-    and :class:`CategoricalIndex.__contains__`.
+    and :meth:`CategoricalIndex.__contains__`.
 
     Returns True if ``key`` is in ``cat.categories`` and the
     location of ``key`` in ``categories`` is in ``container``.

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -13827,7 +13827,7 @@ class DataFrame(NDFrame, OpsMixin):
         margins_name : str, default 'All'
             Name of the row / column that will contain the totals
             when margins is True.
-        observed : bool, default False
+        observed : bool, default True
             This only applies if any of the groupers are Categoricals.
             If True: only show observed values for categorical groupers.
             If False: show all values for categorical groupers.

--- a/pandas/core/indexes/datetimes.py
+++ b/pandas/core/indexes/datetimes.py
@@ -533,7 +533,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
         Returns
         -------
         Array or Index
-            Datetme Array/Index with target `tz`.
+            Datetime Array/Index with target `tz`.
 
         Raises
         ------
@@ -632,7 +632,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
             - 'raise' will raise a ValueError if there are ambiguous
               times.
 
-        nonexistent : 'shift_forward', 'shift_backward, 'NaT', timedelta, \
+        nonexistent : 'shift_forward', 'shift_backward', 'NaT', timedelta, \
         default 'raise'
             A nonexistent time does not exist in a particular timezone
             where clocks moved forward due to DST.
@@ -719,7 +719,7 @@ class DatetimeIndex(DatetimeTimedeltaMixin):
 
         If the DST transition causes nonexistent times, you can shift these
         dates forward or backwards with a timedelta object or `'shift_forward'`
-        or `'shift_backwards'`.
+        or `'shift_backward'`.
 
         >>> s = pd.to_datetime(pd.Series(['2015-03-29 02:30:00',
         ...                               '2015-03-29 03:30:00'], dtype="M8[ns]"))

--- a/pandas/core/ops/missing.py
+++ b/pandas/core/ops/missing.py
@@ -166,7 +166,7 @@ def dispatch_fill_zeros(op, left, right, result):
         #  we want.
         result = mask_zero_div_zero(left, right, result)
     elif op is roperator.rfloordiv:
-        # Note: no need to do this for rtruediv; numpy behaves the wayS
+        # Note: no need to do this for rtruediv; numpy behaves the way
         #  we want.
         result = mask_zero_div_zero(right, left, result)
     elif op is operator.mod:

--- a/pandas/core/ops/missing.py
+++ b/pandas/core/ops/missing.py
@@ -11,7 +11,6 @@ from numpy in the following ways:
        pandas convention is to return [-inf, nan, inf] for all dtype
        combinations.
 
-
     2) np.array([-1, 0, 1], dtype=dtype1) % np.array([0, 0, 0], dtype=dtype2)
        gives precisely the same results as the // operation.
 

--- a/pandas/io/formats/style.py
+++ b/pandas/io/formats/style.py
@@ -577,7 +577,7 @@ class Styler(StylerRenderer):
             Write engine to use, 'openpyxl' or 'xlsxwriter'. You can also set this
             via the options ``io.excel.xlsx.writer`` or
             ``io.excel.xlsm.writer``.
-        merge_cells : bool or 'columns', default False
+        merge_cells : bool or 'columns', default True
             If True, write MultiIndex index and columns as merged cells.
             If 'columns', merge MultiIndex column cells only.
         encoding : str or None, default None


### PR DESCRIPTION
Each of these merged PRs corrected one site and left an identical or immediately adjacent
defect of the same class in place. This finishes all eight.

Wrong documented defaults (docstring contradicts the signature):

- `DataFrame.pivot_table` documented `observed : bool, default False` while the signature is
  `True` — and its own `versionchanged:: 3.0.0` note directly below says the default is now
  `True`. GH-64989 fixed the top-level `pandas.pivot_table` copy in `reshape/pivot.py` only.
- `Styler.to_excel` documented `merge_cells ... default False` while the signature is `True`.
  GH-66363 fixed the `NDFrame.to_excel` copy in `generic.py` only.

Typos duplicated across a sibling copy:

- GH-64632 fixed `Datetme`, a missing closing quote in `'shift_backward,`, and
  `'shift_backwards'` in `arrays/datetimes.py`; `indexes/datetimes.py` carries a near-verbatim
  duplicate of those docstrings for the public `DatetimeIndex.tz_localize` / `tz_convert`, and
  kept all three.
- GH-64473 was a typo sweep over the `categorical.contains` docstring that rewrote two lines
  and left a defect of the same class on each: `:class:`Categorical`or` (rendering as
  \"Categoricalor\"), and `:class:` used for `CategoricalIndex.__contains__`, which is a method.

Typos in or adjacent to the text the PR itself introduced:

- GH-63795: `generric`, `both ... as` for `both ... and`, \"the resolution how the integer value
  is interpreted\", \"Similar when passed\", and a double space, all in the 3.0.0 whatsnew
  datetime-resolution section.
- GH-65137: \"update your code or used ``pytz`` explicitly\" in the 3.0.0 pytz migration note.
- GH-63724: a comment cleanup in `ops/missing.py` rewrote `numpy behaves the way` to
  `behaves the wayS` and left a doubled blank line in the hunk above it.
- GH-66500: de-Travis'd one line of `contributing_documentation.rst` but left the file's other
  Travis mention, which was the last non-whatsnew Travis reference in the tree; doctests in
  fact run in the GHA `Doctests` job. Also normalizes `Github Actions` to `GitHub Actions` to
  match the rest of the file.

Docs only — no runtime change. The two default-value corrections were checked against
`inspect.signature` on a local build.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the residual
defects, verified each still reproduced on main, and wrote the patch.