### PR TITLE
BUG: shift/where/mask/setitem raised AssertionError on void dtype (GH#52373)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -789,7 +789,7 @@ Missing
 ^^^^^^^
 - Bug in :meth:`DataFrame.fillna` with a dict value raising ``RecursionError`` when columns are a :class:`MultiIndex` with duplicate entries (:issue:`53498`)
 - Bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` with ``method`` in ``"index"``, ``"values"`` or ``"time"`` raising when the index had an :class:`ArrowDtype` timestamp or duration dtype; these now match the equivalent :class:`DatetimeIndex` or :class:`TimedeltaIndex` (:issue:`66338`)
-- Bug in :meth:`DataFrame.shift`, :meth:`DataFrame.where`, :meth:`DataFrame.mask`, :meth:`Series.shift`, :meth:`Series.where`, and :meth:`Series.mask` raising an internal ``AssertionError`` for a NumPy bytes or void dtype instead of upcasting to ``object`` to hold a missing value; item assignment now raises the expected ``TypeError`` for the incompatible value (:issue:`52373`, :issue:`68089`)
+- Bug in :meth:`DataFrame.shift`, :meth:`DataFrame.where`, :meth:`DataFrame.mask`, :meth:`Series.shift`, :meth:`Series.where`, and :meth:`Series.mask` raising an internal ``AssertionError`` for a NumPy bytes or void dtype instead of upcasting to ``object`` to hold a missing value; item assignment now raises the expected ``TypeError`` for the incompatible value (:issue:`52373`, :issue:`68185`)
 - Bug in :meth:`Series.combine_first` crashing when Series names are :class:`Timestamp` objects (:issue:`65333`)
 
 MultiIndex

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -789,7 +789,7 @@ Missing
 ^^^^^^^
 - Bug in :meth:`DataFrame.fillna` with a dict value raising ``RecursionError`` when columns are a :class:`MultiIndex` with duplicate entries (:issue:`53498`)
 - Bug in :meth:`DataFrame.interpolate` and :meth:`Series.interpolate` with ``method`` in ``"index"``, ``"values"`` or ``"time"`` raising when the index had an :class:`ArrowDtype` timestamp or duration dtype; these now match the equivalent :class:`DatetimeIndex` or :class:`TimedeltaIndex` (:issue:`66338`)
-- Bug in :meth:`DataFrame.shift`, :meth:`DataFrame.where`, :meth:`DataFrame.mask`, :meth:`Series.shift`, :meth:`Series.where`, and :meth:`Series.mask` raising an internal ``AssertionError`` for a NumPy bytes dtype instead of upcasting to ``object`` to hold a missing value; item assignment now raises the expected ``TypeError`` for the incompatible value (:issue:`52373`)
+- Bug in :meth:`DataFrame.shift`, :meth:`DataFrame.where`, :meth:`DataFrame.mask`, :meth:`Series.shift`, :meth:`Series.where`, and :meth:`Series.mask` raising an internal ``AssertionError`` for a NumPy bytes or void dtype instead of upcasting to ``object`` to hold a missing value; item assignment now raises the expected ``TypeError`` for the incompatible value (:issue:`52373`, :issue:`68089`)
 - Bug in :meth:`Series.combine_first` crashing when Series names are :class:`Timestamp` objects (:issue:`65333`)
 
 MultiIndex

--- a/pandas/core/dtypes/cast.py
+++ b/pandas/core/dtypes/cast.py
@@ -445,7 +445,7 @@ def ensure_dtype_can_hold_na(dtype: DtypeObj) -> DtypeObj:
             #  overriding instead of returning object below.
             return IntervalDtype(np.float64, closed=dtype.closed)
         return _dtype_obj
-    elif dtype.kind in "bS":
+    elif dtype.kind in "bSUV":
         return _dtype_obj
     elif dtype.kind in "iu":
         return np.dtype(np.float64)

--- a/pandas/core/internals/blocks.py
+++ b/pandas/core/internals/blocks.py
@@ -1566,7 +1566,7 @@ class Block(PandasObject, libinternals.Block):
                 fill_value,
             )
         except LossySetitemError:
-            if self.dtype.kind not in "iubS" or not is_valid_na_for_dtype(
+            if self.dtype.kind not in "iubSUV" or not is_valid_na_for_dtype(
                 fill_value, self.dtype
             ):
                 # GH#53802

--- a/pandas/tests/dtypes/test_inference.py
+++ b/pandas/tests/dtypes/test_inference.py
@@ -2240,10 +2240,10 @@ def test_find_result_type_floats(right, result):
     assert find_result_type(left_dtype, right) == result
 
 
-def test_find_result_type_bytes_with_na():
+@pytest.mark.parametrize("left_dtype", ["S1", "U1", "V1"])
+def test_find_result_type_cannot_hold_na(left_dtype):
     # GH#52373
-    left_dtype = np.dtype("S1")
-    assert find_result_type(left_dtype, np.nan) == np.dtype(object)
+    assert find_result_type(np.dtype(left_dtype), np.nan) == np.dtype(object)
 
 
 @pytest.mark.parametrize(

--- a/pandas/tests/frame/methods/test_shift.py
+++ b/pandas/tests/frame/methods/test_shift.py
@@ -809,9 +809,10 @@ class TestDataFrameShift:
         expected = pd.Series([np.nan, pd.Interval(1, 2, closed="right")])
         tm.assert_series_equal(result, expected)
 
-    def test_series_shift_bytes_dtype(self):
+    @pytest.mark.parametrize("dtype", ["S1", "V1"])
+    def test_series_shift_cannot_hold_na_dtype(self, dtype):
         # GH#52373
-        ser = pd.Series(["a", "b", "c"]).astype(bytes)
+        ser = pd.Series(np.array([b"a", b"b", b"c"], dtype=dtype))
 
         with tm.assert_produces_warning(None):
             result = ser.shift(1)

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -168,15 +168,16 @@ class TestSetitemDT64Values:
 
 
 class TestSetitemScalarIndexer:
-    def test_setitem_bytes_dtype_with_na(self):
+    @pytest.mark.parametrize("dtype", ["S1", "V1"])
+    def test_setitem_cannot_hold_na_dtype(self, dtype):
         # GH#52373
-        ser = pd.Series([b"a", b"b", b"c"], dtype="S1")
+        ser = pd.Series(np.array([b"a", b"b", b"c"], dtype=dtype))
 
         msg = "Invalid value 'nan' for dtype"
         with pytest.raises(TypeError, match=msg):
             ser[1] = np.nan
 
-        expected = pd.Series([b"a", b"b", b"c"], dtype="S1")
+        expected = pd.Series(np.array([b"a", b"b", b"c"], dtype=dtype))
         tm.assert_series_equal(ser, expected)
 
     def test_setitem_negative_out_of_bounds(self):

--- a/pandas/tests/series/indexing/test_where.py
+++ b/pandas/tests/series/indexing/test_where.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pandas._testing as tm
 
 
+@pytest.mark.parametrize("dtype", ["S1", "V1"])
 @pytest.mark.parametrize(
     "method,cond",
     [
@@ -14,9 +15,9 @@ import pandas._testing as tm
         ("mask", [False, True, False]),
     ],
 )
-def test_where_mask_bytes_dtype_with_na(method, cond):
+def test_where_mask_cannot_hold_na_dtype(method, cond, dtype):
     # GH#52373
-    ser = pd.Series([b"a", b"b", b"c"], dtype="S1")
+    ser = pd.Series(np.array([b"a", b"b", b"c"], dtype=dtype))
 
     result = getattr(ser, method)(cond)
 


### PR DESCRIPTION
Follow-up to GH-66600, which closed the bytes (`S`) half of this hole. Void (`V`) fails identically — same call chain, same internal assertion:

```python
ser = pd.Series(np.array([b"a", b"b", b"c"], dtype="V8"))
ser.shift(1)                    # AssertionError: Something has gone wrong, please report a bug
ser.where([True, False, True])  # same
ser.mask([False, True, False])  # same
ser[1] = np.nan                 # same
```

`ensure_dtype_can_hold_na` handled `b` and `iu` explicitly and returned every other numpy dtype unchanged, so a kind that genuinely cannot hold NA fell through as "can hold NA". `find_result_type` then handed back the same dtype for an NA right-hand side, the block retried the cast with it, and the retry tripped the assertion.

`"bS"` -> `"bSUV"` makes the set *every* numpy kind that cannot hold NA rather than a list of the ones someone filed an issue about — `b`, `i`, `u`, `S`, `U`, `V` is exhaustive, since `f`/`c` hold `nan`, `m`/`M` hold `NaT`, and `O` holds anything. `"iubS"` -> `"iubSUV"` in `Block.shift` grows alongside it, so `Series.shift()` on the newly-upcasting kinds does not start emitting the GH-53802 `Pandas4Warning`.

All four operations now match the bytes behavior: `shift`/`where`/`mask` return object with `nan`, and item assignment raises the expected `TypeError`.

`U` is unreachable as a block dtype (`Series`/`DataFrame`/`Index` of a `U` ndarray all give `str`, and `astype("U1")` gives object), so it is covered only in the `find_result_type` test, the one place it is reachable. It is included so the predicate states the rule instead of enumerating filed issues.

The GH-52373 tests added in GH-66600 are parametrized over `["S1", "V1"]` rather than duplicated — `V1` produces byte-identical expected values to `S1`, so the test diff is the decorator plus the constructor line.

The three other `ensure_dtype_can_hold_na` callers (`internals/concat`, `reindex`, groupby `_fill`) were checked differentially against a void column before and after: identical results, including their pre-existing unrelated failures.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the diff and tests and ran the differential checks on the other callers; reviewed by me.