### PR TITLE
BUG: Series/DataFrame accumulations raised NotImplementedError on SparseDtype

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1017,6 +1017,7 @@ Reshaping
 Sparse
 ^^^^^^
 - Bug in :meth:`DataFrame.count`, :meth:`DataFrame.sum`, :meth:`DataFrame.mean`, :meth:`DataFrame.min`, and :meth:`DataFrame.max` on :class:`SparseDtype` columns forcing the result into the column's own dtype: ``count`` returned ``1`` for every sparse column, the sum of a narrow integer column silently wrapped around, the mean of an integer column was truncated to an integer, and a missing result (e.g. from ``min_count`` or an empty column) came back as a fill value or raised (:issue:`55123`)
+- Bug in :meth:`Series.cumsum`, :meth:`Series.cumprod`, :meth:`Series.cummin`, :meth:`Series.cummax` and their :class:`DataFrame` counterparts raising ``NotImplementedError`` on :class:`SparseDtype` data (:issue:`68187`)
 - Bug in :meth:`Series.mean` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`Series.reindex` and alignment raising when extending a boolean :class:`SparseDtype`-backed :class:`Series`; missing entries now upcast to ``object`` to match the dense behavior (:issue:`32119`)
 - Bug in :meth:`Series.sum`, :meth:`Series.min`, and :meth:`Series.max` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -94,7 +94,10 @@ from pandas.core.indexers import (
     check_array_indexer,
     unpack_tuple_and_ellipses,
 )
-from pandas.core.nanops import check_below_min_count
+from pandas.core.nanops import (
+    check_below_min_count,
+    na_accum_func,
+)
 
 if TYPE_CHECKING:
     from collections.abc import (
@@ -1735,6 +1738,33 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             if check_below_min_count(valid_vals.shape, None, min_count - nsparse):
                 return na_value_for_dtype(self.dtype.subtype, compat=False)
             return sp_sum + self.fill_value * nsparse
+
+    def _accumulate(self, name: str, *, skipna: bool = True, **kwargs) -> SparseArray:
+        accum_func = {
+            "cumsum": np.cumsum,
+            "cumprod": np.cumprod,
+            "cummin": np.minimum.accumulate,
+            "cummax": np.maximum.accumulate,
+        }.get(name)
+        if accum_func is None:
+            raise NotImplementedError(f"cannot perform {name} with type {self.dtype}")
+
+        if name == "cumsum" and skipna and self.dtype.subtype.kind in "biufc":
+            # numeric cumsum keeps the NA gaps as gaps instead of densifying;
+            # other subtypes go dense to match its NA handling
+            return self.cumsum(**kwargs)
+
+        result: ExtensionArray | np.ndarray
+        values = ensure_wrapped_if_datetimelike(self.to_dense())
+        if isinstance(values, ExtensionArray):
+            # datetimelike subtypes have their own accumulations
+            result = values._accumulate(name, skipna=skipna, **kwargs)
+        else:
+            result = na_accum_func(values, accum_func, skipna=skipna)
+
+        # like cumsum, the result's fill value is NA regardless of our own
+        fill_value = na_value_for_dtype(result.dtype, compat=False)
+        return type(self)(result, fill_value=fill_value)
 
     def cumsum(self, axis: AxisInt = 0, *args, **kwargs) -> SparseArray:
         """

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -424,6 +424,47 @@ def test_cumsum_float_fill_value_zero():
     tm.assert_sp_array_equal(result, expected)
 
 
+@pytest.mark.parametrize("op_name", ["cumsum", "cumprod", "cummin", "cummax"])
+@pytest.mark.parametrize("skipna", [True, False])
+@pytest.mark.parametrize("fill_value", [np.nan, 0.0])
+def test_accumulate_matches_dense(op_name, skipna, fill_value):
+    # GH#68187 these raised NotImplementedError from Series/DataFrame
+    values = np.array([1.0, 2.0, np.nan, 3.0])
+    ser = pd.Series(SparseArray(values, fill_value=fill_value))
+
+    result = getattr(ser, op_name)(skipna=skipna)
+    expected = getattr(pd.Series(values), op_name)(skipna=skipna)
+
+    assert result.dtype == pd.SparseDtype("float64", np.nan)
+    tm.assert_series_equal(result.sparse.to_dense(), expected)
+
+    frame_result = getattr(pd.DataFrame({"a": ser}), op_name)(skipna=skipna)
+    tm.assert_series_equal(
+        frame_result["a"].sparse.to_dense(), expected, check_names=False
+    )
+
+
+def test_accumulate_integer_subtype():
+    # GH#68187 the fill value widens to NaN, as it does for cumsum
+    arr = SparseArray([1, 0, 2], fill_value=0)
+    result = pd.Series(arr).cumprod()
+    expected = pd.Series(SparseArray([1, 0, 0], fill_value=np.nan))
+    tm.assert_series_equal(result, expected)
+
+
+def test_accumulate_datetime64():
+    # GH#68187 a datetimelike subtype accumulates through its own array
+    dti = pd.to_datetime(["2020-01-02", "NaT", "2020-01-01"])
+    ser = pd.Series(SparseArray(dti))
+
+    result = ser.cummax()
+    tm.assert_series_equal(result.sparse.to_dense(), pd.Series(dti).cummax())
+
+    msg = "Accumulation cumsum not supported"
+    with pytest.raises(TypeError, match=msg):
+        ser.cumsum()
+
+
 def test_setting_fill_value_updates():
     arr = SparseArray([0.0, np.nan], fill_value=0)
     arr.fill_value = np.nan

--- a/pandas/tests/extension/test_sparse.py
+++ b/pandas/tests/extension/test_sparse.py
@@ -105,6 +105,9 @@ class TestSparseArray(base.ExtensionTests):
             return pd.SparseDtype("float64", arr.fill_value)
         return arr.dtype
 
+    def _supports_accumulation(self, ser: pd.Series, op_name: str) -> bool:
+        return True
+
     def _supports_reduction(self, obj, op_name: str) -> bool:
         if op_name in [
             "prod",


### PR DESCRIPTION
`SparseArray` has a working `cumsum` but never defined `_accumulate`, so `Series.cumsum()`/`cumprod()`/`cummin()`/`cummax()` and their `DataFrame` counterparts all hit `ExtensionArray._accumulate`'s default raise:

```python
arr = pd.arrays.SparseArray([1.0, 2.0, np.nan, 3.0])
arr.cumsum()             # <SparseArray> [1.0, 3.0, nan, 6.0]  -- works
pd.Series(arr).cumsum()  # NotImplementedError: cannot perform cumsum with type Sparse[float64, nan]
```

`SparseArray._accumulate` now dispatches:

- numeric `cumsum` with `skipna=True` to the existing `cumsum`, which keeps the NA gaps as gaps instead of densifying;
- datetimelike subtypes to `DatetimeArray`/`TimedeltaArray._accumulate`;
- everything else to `nanops.na_accum_func` on the densified values — the same helper the dense path uses, so NA/`skipna` handling matches by construction rather than being re-derived.

As `cumsum` already documented, the result's fill value is NA regardless of the input's. Object subtype is deliberately kept off the `cumsum` fast path: dense object `cumsum` with an NA raises (it adds `0.0` to a string), where `sp_values.cumsum()` would have silently succeeded.

`_supports_accumulation` is flipped on in `tests/extension/test_sparse.py`, which gives the dense differential for free; the targeted tests cover the Series and DataFrame paths, integer-subtype fill widening, and the datetime64 branch. Off-PR I also ran a dense-vs-sparse differential over float32/float64/int/bool/complex/object/M8/m8/empty x fill values x 4 ops x `skipna` with no divergence in value or raise type.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix, the tests and this description under my review.