### PR TITLE
BUG: select_dtypes raised AttributeError for a pyarrow date32/date64 column (GH#68075)

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5870,7 +5870,8 @@ class DataFrame(NDFrame, OpsMixin):
                 if isinstance(dtype_obj, klass_tuple):
                     return True
                 if isinstance(dtype_obj, ArrowDtype):
-                    if dtype_obj.kind == "M" and dtype_obj.pyarrow_dtype.tz is not None:
+                    # tz exists only on pa.timestamp; date32/date64 reach here too
+                    if getattr(dtype_obj.pyarrow_dtype, "tz", None) is not None:
                         # GH#68075: numpy_dtype drops the tz, so a tz-aware
                         # column would match a naive datetime64 spec; a
                         # DatetimeTZDtype column matches none of these either

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -1080,6 +1080,23 @@ def test_select_dtypes_tz_aware_arrow_still_matched_by_arrow_spec():
         tm.assert_frame_equal(df.select_dtypes(include=[spec]), expected)
 
 
+@pytest.mark.parametrize("pa_type", ["date32", "date64"])
+def test_select_dtypes_arrow_date_no_tz_attribute(pa_type):
+    # GH#68075: the tz guard must not assume every kind "M" ArrowDtype is a
+    # timestamp -- date32/date64 have no tz attribute
+    pa = pytest.importorskip("pyarrow")
+    dtype = pd.ArrowDtype(getattr(pa, pa_type)())
+    df = pd.DataFrame({"num": [1, 2], "date": pd.array([1, 2], dtype=dtype)})
+    tm.assert_frame_equal(df.select_dtypes(include="number"), df[["num"]])
+    tm.assert_frame_equal(df.select_dtypes(exclude="number"), df[["date"]])
+    tm.assert_frame_equal(df.select_dtypes(include=dtype), df[["date"]])
+    # the guard must skip these columns, not reject them: their numpy_dtype is
+    # a datetime64, so a naive datetime spec selects them
+    for spec in ["datetime", np.datetime64]:
+        tm.assert_frame_equal(df.select_dtypes(include=spec), df[["date"]])
+        tm.assert_frame_equal(df.select_dtypes(exclude=spec), df[["num"]])
+
+
 @pytest.mark.parametrize("spec", ["interval[int64]", pd.IntervalDtype("int64")])
 def test_select_dtypes_interval_subtype_matches_any_closed(spec):
     # GH#66119, GH#66120: an interval spec with a subtype but no ``closed``


### PR DESCRIPTION
Follow-up to GH-68075, which is unreleased, so no whatsnew entry: its existing bullet still describes the end-state behavior accurately.

The tz guard added there gated on `dtype_obj.kind == "M"` and then read `pyarrow_dtype.tz`. `ArrowDtype` reports kind `"M"` for `date32`/`date64` as well as timestamps (their `numpy_dtype` is a `datetime64`), and `pa.date32()` has no `tz` attribute, so any `select_dtypes` call on a frame holding a pyarrow date column raised — including specs with nothing to do with datetimes:

```python
import pandas as pd, pyarrow as pa

df = pd.DataFrame({"num": [1, 2], "date": pd.array([1, 2], dtype=pd.ArrowDtype(pa.date32()))})
df.select_dtypes(include="number")
# AttributeError: 'pyarrow.lib.DataType' object has no attribute 'tz'
```

`tz` exists only on `pa.timestamp`, so the `kind` precheck was doing no work the `getattr` does not, and dropping it leaves the tz-aware behavior GH-68075 added unchanged while restoring the previous behavior for date columns — a naive datetime spec selects them.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the regression, wrote the fix and tests, and ran a multi-round blind review of the branch.