### PR TITLE
BUG: clip with missing datetime/timedelta threshold raises TypeError

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -547,6 +547,7 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
+- Fixed bug in :meth:`Series.clip` and :meth:`DataFrame.clip` where missing values in a datetime or timedelta threshold raised a ``TypeError`` instead of acting as no bounds (:issue:`44785`)
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :class:`Series` where empty frozensets were formatted incorrectly (:issue:`66192`)
 - Fixed bug in :func:`testing.assert_frame_equal` incorrectly raising when equivalent :class:`MultiIndex` column labels contained missing values (:issue:`54521`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -547,7 +547,6 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
-- Fixed bug in :meth:`Series.clip` and :meth:`DataFrame.clip` where missing values in a datetime or timedelta threshold raised a ``TypeError`` instead of acting as no bounds (:issue:`44785`)
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :class:`Series` where empty frozensets were formatted incorrectly (:issue:`66192`)
 - Fixed bug in :func:`testing.assert_frame_equal` incorrectly raising when equivalent :class:`MultiIndex` column labels contained missing values (:issue:`54521`)
@@ -555,6 +554,7 @@ Bug fixes
 - Fixed bug in :func:`testing.assert_series_equal` showing a misleading class mismatch message when Series values were backed by different :class:`numpy.ndarray` subclasses (:issue:`65770`)
 - Fixed bug in :func:`testing.assert_series_equal`, :func:`testing.assert_index_equal`, and :func:`testing.assert_frame_equal` ignoring ``rtol`` and ``atol`` when comparing large integer and floating dtypes with ``check_dtype=False`` (:issue:`66699`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
+- Fixed bug in :meth:`Series.clip` and :meth:`DataFrame.clip` where missing values in a datetime or timedelta threshold raised a ``TypeError`` instead of acting as no bounds (:issue:`44785`)
 
 Categorical
 ^^^^^^^^^^^

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8732,12 +8732,60 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         # GH 40420
         # Treat missing thresholds as no bounds, not clipping the values
         if is_list_like(threshold):
-            fill_value = np.inf if method.__name__ == "le" else -np.inf
-            threshold_inf = threshold.fillna(fill_value)
+            if isinstance(threshold, ABCDataFrame):
+                is_dt_like = all(d.kind in "mM" for d in threshold.dtypes)
+            else:
+                dtype = getattr(threshold, "dtype", None)
+                is_dt_like = (
+                    dtype is not None and dtype.kind in "mM"
+                )
+            if is_dt_like:
+                # GH 44785: ±np.inf cannot be compared against datetime or
+                # timedelta values, so track the missing positions
+                # explicitly and keep the original values there.
+                no_bound_mask = threshold.isna()
+                threshold_inf = threshold
+            else:
+                fill_value = np.inf if method.__name__ == "le" else -np.inf
+                threshold_inf = threshold.fillna(fill_value)
+                no_bound_mask = None
         else:
             threshold_inf = threshold
+            no_bound_mask = None
 
         subset = method(threshold_inf, axis=axis) | isna(self)
+        if no_bound_mask is not None:
+            if isinstance(no_bound_mask, ABCSeries):
+                # Align the missing-threshold positions to the shape of
+                # the comparison result along the axis the threshold
+                # was applied on.
+                if isinstance(subset, ABCSeries):
+                    no_bound_mask = no_bound_mask.reindex(
+                        subset.index, fill_value=True
+                    )
+                elif axis in (0, None):
+                    values = no_bound_mask.reindex(
+                        subset.index, fill_value=True
+                    ).to_numpy()
+                    no_bound_mask = self._constructor(
+                        np.tile(values[:, None], (1, len(subset.columns))),
+                        index=subset.index,
+                        columns=subset.columns,
+                    )
+                else:
+                    values = no_bound_mask.reindex(
+                        subset.columns, fill_value=True
+                    ).to_numpy()
+                    no_bound_mask = self._constructor(
+                        np.tile(values, (len(subset.index), 1)),
+                        index=subset.index,
+                        columns=subset.columns,
+                    )
+            elif no_bound_mask.shape != subset.shape:
+                no_bound_mask = no_bound_mask.reindex_like(
+                    subset, fill_value=True
+                )
+            subset = subset | no_bound_mask
 
         # GH 40420
         return self.where(subset, threshold, axis=axis, inplace=inplace)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8736,9 +8736,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 is_dt_like = all(d.kind in "mM" for d in threshold.dtypes)
             else:
                 dtype = getattr(threshold, "dtype", None)
-                is_dt_like = (
-                    dtype is not None and dtype.kind in "mM"
-                )
+                is_dt_like = dtype is not None and dtype.kind in "mM"
             if is_dt_like:
                 # GH 44785: ±np.inf cannot be compared against datetime or
                 # timedelta values, so track the missing positions
@@ -8760,9 +8758,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 # the comparison result along the axis the threshold
                 # was applied on.
                 if isinstance(subset, ABCSeries):
-                    no_bound_mask = no_bound_mask.reindex(
-                        subset.index, fill_value=True
-                    )
+                    no_bound_mask = no_bound_mask.reindex(subset.index, fill_value=True)
                 elif axis in (0, None):
                     values = no_bound_mask.reindex(
                         subset.index, fill_value=True
@@ -8782,9 +8778,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                         columns=subset.columns,
                     )
             elif no_bound_mask.shape != subset.shape:
-                no_bound_mask = no_bound_mask.reindex_like(
-                    subset, fill_value=True
-                )
+                no_bound_mask = no_bound_mask.reindex_like(subset, fill_value=True)
             subset = subset | no_bound_mask
 
         # GH 40420

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8732,21 +8732,35 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         # GH 40420
         # Treat missing thresholds as no bounds, not clipping the values
         if is_list_like(threshold):
+            fill_value = np.inf if method.__name__ == "le" else -np.inf
             if isinstance(threshold, ABCDataFrame):
-                is_dt_like = all(d.kind in "mM" for d in threshold.dtypes)
+                dt_like = threshold.dtypes.map(lambda dt: dt.kind in "mM")
+                if not dt_like.any():
+                    threshold_inf = threshold.fillna(fill_value)
+                    no_bound_mask = None
+                else:
+                    # GH 44785: +/-np.inf cannot be compared against datetime
+                    # or timedelta values. Fill only the remaining columns
+                    # and track the missing positions explicitly, keeping
+                    # the original values where the threshold is missing.
+                    non_dt_cols = [
+                        col for col in threshold.columns if not dt_like[col]
+                    ]
+                    threshold_inf = threshold.copy() if non_dt_cols else threshold
+                    for col in non_dt_cols:
+                        threshold_inf[col] = threshold[col].fillna(fill_value)
+                    no_bound_mask = threshold.isna()
             else:
                 dtype = getattr(threshold, "dtype", None)
-                is_dt_like = dtype is not None and dtype.kind in "mM"
-            if is_dt_like:
-                # GH 44785: ±np.inf cannot be compared against datetime or
-                # timedelta values, so track the missing positions
-                # explicitly and keep the original values there.
-                no_bound_mask = threshold.isna()
-                threshold_inf = threshold
-            else:
-                fill_value = np.inf if method.__name__ == "le" else -np.inf
-                threshold_inf = threshold.fillna(fill_value)
-                no_bound_mask = None
+                if dtype is not None and dtype.kind in "mM":
+                    # GH 44785: +/-np.inf cannot be compared against datetime
+                    # or timedelta values, so track the missing positions
+                    # explicitly and keep the original values there.
+                    threshold_inf = threshold
+                    no_bound_mask = threshold.isna()
+                else:
+                    threshold_inf = threshold.fillna(fill_value)
+                    no_bound_mask = None
         else:
             threshold_inf = threshold
             no_bound_mask = None
@@ -8778,12 +8792,15 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                         columns=subset.columns,
                     )
             elif no_bound_mask.shape != subset.shape:
-                no_bound_mask = no_bound_mask.reindex_like(subset, fill_value=True)
+                no_bound_mask = no_bound_mask.reindex(
+                    index=subset.index,
+                    columns=subset.columns,
+                    fill_value=True,
+                )
             subset = subset | no_bound_mask
 
         # GH 40420
         return self.where(subset, threshold, axis=axis, inplace=inplace)
-
     @final
     def clip(
         self,

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -8743,9 +8743,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                     # or timedelta values. Fill only the remaining columns
                     # and track the missing positions explicitly, keeping
                     # the original values where the threshold is missing.
-                    non_dt_cols = [
-                        col for col in threshold.columns if not dt_like[col]
-                    ]
+                    non_dt_cols = [col for col in threshold.columns if not dt_like[col]]
                     threshold_inf = threshold.copy() if non_dt_cols else threshold
                     for col in non_dt_cols:
                         threshold_inf[col] = threshold[col].fillna(fill_value)
@@ -8801,6 +8799,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         # GH 40420
         return self.where(subset, threshold, axis=axis, inplace=inplace)
+
     @final
     def clip(
         self,

--- a/pandas/tests/frame/methods/test_clip.py
+++ b/pandas/tests/frame/methods/test_clip.py
@@ -39,6 +39,38 @@ class TestDataFrameClip:
             assert (clipped_df.values[lb_mask] == lb).all()
             assert (clipped_df.values[ub_mask] == ub).all()
             assert (clipped_df.values[mask] == df.values[mask]).all()
+    def test_clip_datetime_columns_with_missing_threshold(self):
+        # GH#44785
+        df = pd.DataFrame(
+            {
+                "a": pd.to_datetime(["2020-01-05", "2020-01-01"]),
+                "b": pd.to_datetime(["2020-01-04", "2020-01-02"]),
+            }
+        )
+        # axis=1: threshold aligned along the columns
+        threshold = pd.Series(
+            ["2020-01-03", None], index=["a", "b"], dtype="datetime64[ns]"
+        )
+        result = df.clip(lower=threshold, axis=1)
+        expected = pd.DataFrame(
+            {
+                "a": pd.to_datetime(["2020-01-05", "2020-01-03"]),
+                "b": pd.to_datetime(["2020-01-04", "2020-01-02"]),
+            }
+        )
+        tm.assert_frame_equal(result, expected)
+
+        # axis=0: threshold aligned along the rows
+        threshold = pd.Series([None, "2020-01-03"], dtype="datetime64[ns]")
+        result = df.clip(lower=threshold, axis=0)
+        expected = pd.DataFrame(
+            {
+                "a": pd.to_datetime(["2020-01-05", "2020-01-03"]),
+                "b": pd.to_datetime(["2020-01-04", "2020-01-03"]),
+            }
+        )
+        tm.assert_frame_equal(result, expected)
+
 
     def test_clip_mixed_numeric(self):
         # clip on mixed integer or floats

--- a/pandas/tests/frame/methods/test_clip.py
+++ b/pandas/tests/frame/methods/test_clip.py
@@ -72,6 +72,38 @@ class TestDataFrameClip:
         )
         tm.assert_frame_equal(result, expected)
 
+    def test_clip_datetime_threshold_with_unaligned_index(self):
+        # GH#44785
+        # a DataFrame threshold that is not aligned to the index must still
+        # treat missing (NaT) positions as no bounds
+        df = pd.DataFrame(
+            {"a": pd.to_datetime(["2020-01-05", "2020-01-01"])}, index=[0, 1]
+        )
+        threshold = pd.DataFrame(
+            {"a": pd.to_datetime(["2020-01-03", None])}, index=[1, 2]
+        )
+        result = df.clip(lower=threshold)
+        expected = pd.DataFrame(
+            {"a": pd.to_datetime(["2020-01-05", "2020-01-03"])}, index=[0, 1]
+        )
+        tm.assert_frame_equal(result, expected)
+
+    def test_clip_mixed_dtype_threshold_with_missing_values(self):
+        # GH#44785
+        # datetime columns must not be filled with inf even when other
+        # columns are; missing positions act as no bounds per column
+        df = pd.DataFrame(
+            {"a": pd.to_datetime(["2020-01-05", "2020-01-01"]), "n": [1.0, 2.0]}
+        )
+        threshold = pd.DataFrame(
+            {"a": pd.to_datetime(["2020-01-03", None]), "n": [np.nan, 5.0]}
+        )
+        result = df.clip(lower=threshold)
+        expected = pd.DataFrame(
+            {"a": pd.to_datetime(["2020-01-05", "2020-01-01"]), "n": [1.0, 5.0]}
+        )
+        tm.assert_frame_equal(result, expected)
+
     def test_clip_mixed_numeric(self):
         # clip on mixed integer or floats
         # GH#24162, clipping now preserves numeric types per column

--- a/pandas/tests/frame/methods/test_clip.py
+++ b/pandas/tests/frame/methods/test_clip.py
@@ -39,6 +39,7 @@ class TestDataFrameClip:
             assert (clipped_df.values[lb_mask] == lb).all()
             assert (clipped_df.values[ub_mask] == ub).all()
             assert (clipped_df.values[mask] == df.values[mask]).all()
+
     def test_clip_datetime_columns_with_missing_threshold(self):
         # GH#44785
         df = pd.DataFrame(
@@ -70,7 +71,6 @@ class TestDataFrameClip:
             }
         )
         tm.assert_frame_equal(result, expected)
-
 
     def test_clip_mixed_numeric(self):
         # clip on mixed integer or floats

--- a/pandas/tests/series/methods/test_clip.py
+++ b/pandas/tests/series/methods/test_clip.py
@@ -124,6 +124,23 @@ class TestSeriesClip:
         )
         tm.assert_series_equal(result, expected)
 
+    def test_clip_with_datetime_like_threshold_and_missing_values(self):
+        # GH#44785
+        # missing values in a datetime/timedelta threshold must act as no
+        # bounds (keeping the original values) instead of raising a
+        # TypeError from comparing Timestamp/timedelta against ±np.inf.
+        ser = pd.Series(pd.to_datetime(["2020-01-02", "2020-01-01"]))
+        lower = pd.Series([None, "2020-01-03"], dtype="datetime64[ns]")
+        result = ser.clip(lower=lower)
+        expected = pd.Series(pd.to_datetime(["2020-01-02", "2020-01-03"]))
+        tm.assert_series_equal(result, expected)
+
+        ser = pd.Series(pd.to_timedelta(["2 days", "1 day"]))
+        upper = pd.Series([None, "3 days"], dtype="timedelta64[ns]")
+        result = ser.clip(upper=upper)
+        expected = pd.Series(pd.to_timedelta(["2 days", "1 day"]))
+        tm.assert_series_equal(result, expected)
+
     def test_clip_with_timestamps_and_oob_datetimes_object(self):
         # GH-42794
         ser = pd.Series([datetime(1, 1, 1), datetime(9999, 9, 9)], dtype=object)


### PR DESCRIPTION
Closes #44785

`Series.clip` / `DataFrame.clip` with a datetime or timedelta threshold
that contains missing values raises:

```
TypeError: '>=' not supported between instances of 'Timestamp' and 'float'
```

because GH#40420 fills the missing thresholds with `±np.inf` before
comparing, and `±np.inf` cannot be compared against Timestamp or
timedelta values.

This change treats the missing positions explicitly: for datetime-like
thresholds the missing positions are tracked with a mask and the
original values are kept there (matching the documented behavior that
"a missing threshold will not clip the value"), while numeric
thresholds keep the existing `±np.inf` fill path untouched.

- Series threshold (lower/upper bound)
- DataFrame with a Series threshold along `axis=0` (rows) or `axis=1`
  (columns)
- DataFrame with a datetime-like DataFrame threshold

Regression tests added in `test_clip.py` for both Series and
DataFrame, plus a whatsnew entry.

<details>
<summary>Copy-pasteable example from the issue</summary>

```python
import pandas as pd

pd.Series([1.0, 1.0], dtype="datetime64[ns]").clip(
    pd.Series([None, 1.0], dtype="datetime64[ns]")
)
```
</details>

cc @ghost (who diagnosed the root cause in #44785)

---

*Replacement PR — original #68175 was closed by the stale-bot; GitHub API refuses PATCH state=open (422 empty errors). This PR carries the same branch/commit (552ca7dc).*