### PR TITLE
DOCS: Update contribution guidelines for pull requests

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -131,8 +131,7 @@ description, for example ``closes #1234``.
 Your pull request must be linked to an issue that is **assigned to you**. If you
 open one linked to an issue you haven't claimed, the bot adds the
 ``Needs Issue Assignment`` label, closes the pull request, and comments with
-what to do next: comment ``/take`` on the issue to claim it, then reopen your
-pull request (you can reopen it yourself — nothing is lost).
+what to do next: comment ``/take`` on the issue to claim it, then you will need to open a new pull request, as Github permissions prevent non-admin contributors from reopening a pull request closed by an automated bot.
 
 Review and staleness
 --------------------


### PR DESCRIPTION
Clarified instructions for reopening pull requests after claiming an issue.

- [x] closes #67751 
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

*Note on AI Use: I used an AI assistant model to help verify the exact location of the text block inside `contributing.rst` and cross-reference the related GitHub community feature logs to confirm the platform permissions bug.*