### PR TITLE
BUG: DataFrame.median(axis=1) returned a Series holding a 0-dim array

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -1094,7 +1094,10 @@ def nanmedian(
                         values.shape[0] == 1 and axis == 1
                     ):
                         # GH52788: fastpath when squeezable, nanmedian for 2D array slow
-                        res = np.nanmedian(np.squeeze(values), keepdims=True)
+                        # atleast_1d: see test_nanmedian_2d_matches_numpy (GH#68191)
+                        res = np.nanmedian(
+                            np.atleast_1d(np.squeeze(values)), keepdims=True
+                        )
                     else:
                         res = np.nanmedian(values, axis=axis)
 

--- a/pandas/tests/frame/test_reductions.py
+++ b/pandas/tests/frame/test_reductions.py
@@ -2148,6 +2148,22 @@ class TestDataFrameReductions:
         expected = pd.Series([winner, pd.NaT], dtype=df["dz1"].dtype)
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "values",
+        [
+            pd.date_range("2020-01-01", periods=1),
+            pd.date_range("2020-01-01", periods=1, tz="US/Pacific"),
+            pd.timedelta_range("1 day", periods=1),
+            pd.period_range("2020-01-01", periods=1, freq="D"),
+        ],
+        ids=["dt64", "dt64tz", "td64", "period"],
+    )
+    def test_reduce_axis1_median_single_row_single_col(self, values):
+        # GH#68191: the result held a 0-dim array that repr could not render
+        df = pd.DataFrame({"a": values})
+        result = df.median(axis=1)
+        tm.assert_series_equal(result, df["a"], check_names=False)
+
     def test_reduce_axis1_dt64tz_mixed_tz_falls_back(self):
         # GH#65500: different tz across blocks must not enter the EA fast
         # path (which would silently produce a wrong-dtype result); fall

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -956,6 +956,22 @@ def test_nanmedian_complex_without_bottleneck(disable_bottleneck):
     assert nanops.nanmedian(values) == 0.5 + 3.5j
 
 
+@pytest.mark.parametrize("shape", [(1, 1), (1, 3), (3, 1), (3, 3)])
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("skipna", [True, False])
+def test_nanmedian_2d_matches_numpy(disable_bottleneck, shape, axis, skipna):
+    # GH#68191: the squeezable fastpath returned a 0-d result for a (1, 1) array
+    values = np.arange(shape[0] * shape[1], dtype="f8").reshape(shape)
+    if values.shape[axis] > 1:
+        # an all-NaN slice would only be testing numpy's warning behaviour
+        values[0, 0] = np.nan
+    expected = (
+        np.nanmedian(values, axis=axis) if skipna else np.median(values, axis=axis)
+    )
+    result = nanops.nanmedian(values, axis=axis, skipna=skipna)
+    tm.assert_numpy_array_equal(result, expected)
+
+
 def test_ensure_numeric_passthrough():
     # non-object dtypes are handed back untouched
     values = np.array([1, 2, 3])


### PR DESCRIPTION
`nanmedian`'s GH-52788 "squeezable" fastpath collapses a `(1, 1)` array to 0-d with `np.squeeze`, and `keepdims=True` then keeps it 0-d instead of returning length-1. Reducing a 2-D array along an axis must give a 1-D result.

```python
import pandas as pd

df = pd.DataFrame({"a": pd.date_range("2020", periods=1)})
print(repr(df.median(axis=1)))
```

On main this segfaults the interpreter (rc=139): the result is an object-dtype Series whose single element is a 0-dim `DatetimeArray`, and `repr` crashes on it. Same for `datetime64tz` and `timedelta64`; `period` raises `TypeError: iteration over a 0-d array` instead.

The `nanmedian` defect predates its reachability. Two things had masked it: `Block.reduce` does `result.reshape(-1, 1)`, so the transpose/`axis=0` path never saw the 0-d; and `float64` dispatches to bottleneck, which is shape-correct. The single-block `axis=1` fastpath added in GH-66131 passes a 2-D EA block's `_reduce(axis=0)` output straight to `_constructor_sliced` with no shape fixup, which is what made the 0-d observable.

No whatsnew: GH-66131 is in no release tag and 3.1.0 is unreleased, so no shipped pandas ever produced this result.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which root-caused the crash, wrote the fix and tests, and ran a reduction x shape x dtype differential against the transpose path to confirm nothing else returns a wrong-rank result.