### PR TITLE
BUG: Index.replace raised AssertionError for a dtype-changing replacement

### DIFF
--- a/doc/source/reference/indexing.rst
+++ b/doc/source/reference/indexing.rst
@@ -70,6 +70,7 @@ Modifying and computations
    Index.reindex
    Index.rename
    Index.repeat
+   Index.replace
    Index.where
    Index.take
    Index.putmask

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6877,7 +6877,7 @@ class Index(IndexOpsMixin, PandasObject):
         return Index(new_values, dtype=dtype, copy=False, name=self.name)
 
     def replace(
-        self, to_replace: Any = None, value: Any = lib.no_default, regex: bool = False
+        self, to_replace: Any = None, value: Any = lib.no_default, regex: Any = False
     ) -> Index:
         """
         Replace values in the Index.
@@ -6887,12 +6887,12 @@ class Index(IndexOpsMixin, PandasObject):
 
         Parameters
         ----------
-        to_replace : scalar, list, or dict
-            The value(s) to be replaced. If a dict is provided, value must be omitted.
-        value : scalar, default None
-            The value to replace occurrences of to_replace with.
-        regex : bool, default False
-            Whether to interpret to_replace as a regular expression.
+        to_replace : str, regex, list, dict, Series, scalar, or None
+            The value(s) to be replaced. If a dict is provided, `value` must be omitted.
+        value : scalar, dict, list, str, regex, default None
+            The value to replace occurrences of `to_replace` with.
+        regex : bool or same types as `to_replace`, default False
+            Whether to interpret `to_replace` and/or `value` as regular expressions.
 
         Returns
         -------
@@ -6913,10 +6913,16 @@ class Index(IndexOpsMixin, PandasObject):
         if self._is_multi:
             raise NotImplementedError("replace is not implemented for MultiIndex")
 
-        ser = self.to_series()
+        from pandas import Series
+
+        # Pass pandas objects (not their underlying arrays) so that CoW
+        #  references are tracked in the no-copy cases (GH#65265).
+        ser = Series(self, copy=False)
         replaced = ser.replace(to_replace, value, regex=regex)
 
-        return self._shallow_copy(replaced._values, name=self.name)
+        # Not _shallow_copy: self's subclass may not be able to hold a dtype-changing
+        # result, see test_index_replace_widening_to_object
+        return Index(replaced, dtype=replaced.dtype, name=self.name, copy=False)
 
     # TODO: De-duplicate with map, xref GH#32349
     @final

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6920,8 +6920,6 @@ class Index(IndexOpsMixin, PandasObject):
         ser = Series(self, copy=False)
         replaced = ser.replace(to_replace, value, regex=regex)
 
-        # Not _shallow_copy: self's subclass may not be able to hold a dtype-changing
-        # result, see test_index_replace_widening_to_object
         return Index(replaced, dtype=replaced.dtype, name=self.name, copy=False)
 
     # TODO: De-duplicate with map, xref GH#32349

--- a/pandas/tests/copy_view/index/test_index.py
+++ b/pandas/tests/copy_view/index/test_index.py
@@ -155,6 +155,33 @@ def test_index_where_noop():
     tm.assert_index_equal(idx, expected)
 
 
+def test_index_replace_noop():
+    # GH#65265 CoW references should be tracked through Index.replace
+    idx = pd.Index([1, 2, 3])
+    result = idx.replace(4, 100)
+    assert np.shares_memory(get_array(idx), get_array(result))
+    assert result._references.has_reference()
+
+    expected = idx.copy(deep=True)
+    result = pd.Series(result)
+    result.iloc[0] = 100
+    tm.assert_index_equal(idx, expected)
+
+
+def test_index_replace_noop_from_series():
+    # GH#65265 the result keeps tracking the Series the Index was built from,
+    #  even once the intermediate Index is gone
+    ser = pd.Series([1, 2, 3])
+    idx = pd.Index(ser)
+    result = idx.replace(4, 100)
+    idx = None  # overwrite to clear reference
+    assert np.shares_memory(get_array(ser), get_array(result))
+
+    expected = result.copy(deep=True)
+    ser.iloc[0] = 100
+    tm.assert_index_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "data, dtype",
     [

--- a/pandas/tests/indexes/test_base.py
+++ b/pandas/tests/indexes/test_base.py
@@ -198,6 +198,61 @@ class TestIndex:
 
         assert result.name == "test"
 
+    @pytest.mark.parametrize(
+        "idx",
+        [
+            pd.date_range("2020-01-01", periods=3),
+            pd.date_range("2020-01-01", periods=3, tz="US/Pacific"),
+            pd.timedelta_range("1 day", periods=3),
+            pd.period_range("2020-01-01", periods=3, freq="D"),
+            pd.IntervalIndex.from_breaks([0, 1, 2, 3]),
+        ],
+    )
+    def test_index_replace_widening_to_object(self, idx):
+        # GH#65099 replacement that widens to object used to raise AssertionError
+        result = idx.replace(idx[1], "foo")
+
+        expected = Index([idx[0], "foo", idx[2]], dtype=object)
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "idx, value, expected",
+        [
+            (
+                pd.date_range("2020-01-01", periods=3, unit="s"),
+                pd.Timestamp("2020-01-02 00:00:00.000001"),
+                pd.DatetimeIndex(
+                    ["2020-01-01", "2020-01-02 00:00:00.000001", "2020-01-03"],
+                    dtype="datetime64[us]",
+                ),
+            ),
+            (
+                pd.IntervalIndex.from_breaks([0, 1, 2, 3]),
+                pd.Interval(0.5, 1.5),
+                pd.IntervalIndex.from_tuples([(0.0, 1.0), (0.5, 1.5), (2.0, 3.0)]),
+            ),
+        ],
+    )
+    def test_index_replace_changing_dtype_keeps_subclass(self, idx, value, expected):
+        # guard against over-correcting GH#65099: these already worked before the fix
+        result = idx.replace(idx[1], value)
+
+        tm.assert_index_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "idx, expected",
+        [
+            (pd.RangeIndex(5), Index([0, 1, 2, 3, 4], dtype="int64")),
+            (Index(["a", "b"], dtype=object), Index(["a", "b"], dtype=object)),
+        ],
+    )
+    def test_index_replace_no_op_dtype(self, idx, expected):
+        # GH#65099 a no-op replace demotes RangeIndex and preserves object rather than
+        # re-inferring it, both matching Series.replace
+        result = idx.replace(999, -1)
+
+        tm.assert_index_equal(result, expected, exact=True)
+
     def test_index_replace_regex(self):
         idx = Index(["foo", "bar", "baz"])
         result = idx.replace("^ba", "x", regex=True)


### PR DESCRIPTION
Follow-up to GH-65099, which added `Index.replace`.

The method ended with `self._shallow_copy(replaced._values, name=self.name)`. `_shallow_copy` routes to `self._simple_new`, whose only input guard is `assert isinstance(values, cls._data_cls)`, so a replacement that changes the dtype handed a bare object ndarray to a narrow Index subclass:

```python
>>> pd.date_range("2020-01-01", periods=3).replace(pd.Timestamp("2020-01-02"), "foo")
AssertionError: <class 'numpy.ndarray'>
```

Same for tz-aware `DatetimeIndex`, `TimedeltaIndex`, `PeriodIndex` and `IntervalIndex`. Under `PYTHONOPTIMIZE=1` the assert is stripped and it instead returned a `DatetimeIndex` whose `_data` was an object ndarray, which then raised `AttributeError` on repr.

The fix mirrors `Index.where`, which was given this exact shape by GH-65265: build the intermediate with `Series(self, copy=False)` so copy-on-write references are tracked in the no-copy cases, and wrap the result with `Index(...)` instead of `_shallow_copy`. That also removes the redundant copy `to_series()` was making, and stops `_shallow_copy` attaching `self._references` to an array that shared no memory with `self`.

`Index.replace` has not appeared in a released pandas, so the two resulting behavior changes regress nothing, and both are now covered by tests:

- a no-op replace on a `RangeIndex` returns `Index[int64]` rather than `RangeIndex`, as `Index.where`, `Index.map` and `Index.repeat` already do;
- an object-dtype Index is no longer silently re-inferred to `str`.

No whatsnew entry: the method is new in the unreleased 3.1.0 and the existing ENH note there covers it.

Also included, since GH-65099 omitted them: `Index.replace` is added to the API reference, and its `Parameters` section is corrected — it understated the types the delegation actually accepts (`Series`/list/dict `to_replace`, list and dict `regex`, the latter being the form its own error message recommends).

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and ran a multi-round review of the branch; all findings were verified against the code before being acted on.