### PR TITLE
WEB: fix dead IPython documentation link in ecosystem page

### DIFF
--- a/web/pandas/community/ecosystem.md
+++ b/web/pandas/community/ecosystem.md
@@ -471,7 +471,7 @@ This helps one to scale your pandas code base, at the same time, keeping mainten
 
 For more information, see [documentation](https://hamilton.readthedocs.io/).
 
-#### [IPython](https://ipython.org/documentation.html)
+#### [IPython](https://ipython.readthedocs.io/)
 
 IPython is an interactive command shell and distributed computing
 environment. IPython tab completion works with Pandas methods and also


### PR DESCRIPTION
The IPython entry on the ecosystem page links to `https://ipython.org/documentation.html`, which returns **404**.

IPython's own homepage links its documentation as `https://ipython.readthedocs.io/`, so this points there instead. That URL returns 200.

```diff
-#### [IPython](https://ipython.org/documentation.html)
+#### [IPython](https://ipython.readthedocs.io/)
```

While here I checked all 98 links on `ecosystem.md`; this was the only dead one. (`fred.stlouisfed.org` was slow to respond but resolves, and `huggingface.co/new-dataset` returns 401 only because it requires a login — both fine.)
