### PR TITLE
BUG: DataFrame.replace/Series.replace silently stored a callable value

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -712,6 +712,7 @@ Conversion
 - Fixed bug in :func:`to_numeric` where values preceding the first complex number in ``object``-dtype data were replaced with uninitialized memory, so e.g. ``to_numeric(Series(["1.5", 2j]))`` returned ``0j`` in place of ``1.5+0j`` (:issue:`35051`)
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``TypeError`` when ``to_replace`` was ``Ellipsis`` (``...``) (:issue:`50373`)
+- Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` silently storing a callable ``value`` instead of applying it or raising (:issue:`68199`)
 - Fixed bug in :meth:`DataFrame.to_dict` with ``orient="index"`` did not respect the ``into`` argument in nested mappings (:issue:`65778`)
 
 Strings

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7586,6 +7586,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         TypeError
             * If `to_replace` is not a scalar, array-like, ``dict``, or ``None``
+            * If `value` is callable
             * If `to_replace` is a ``dict`` and `value` is not a ``list``,
               ``dict``, ``ndarray``, or ``Series``
             * If `to_replace` is ``None`` and `regex` is not compilable
@@ -7830,6 +7831,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "Expecting 'to_replace' to be either a scalar, array-like, "
                 "dict or None, got invalid type "
                 f"{type(to_replace).__name__!r}"
+            )
+
+        if callable(value):
+            raise TypeError(
+                f"'value' cannot be callable, got invalid type {type(value).__name__!r}"
             )
 
         if value is lib.no_default and not (

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1326,6 +1326,14 @@ class TestDataFrameReplace:
         with pytest.raises(TypeError, match=msg):
             df.replace(lambda x: x.strip())
 
+    @pytest.mark.parametrize("regex", [False, True])
+    def test_replace_invalid_value_callable(self, regex):
+        # GH#68199 replace() should raise instead of storing a callable value
+        df = pd.DataFrame({"one": ["a1", "b2"]})
+        msg = "'value' cannot be callable, got invalid type 'function'"
+        with pytest.raises(TypeError, match=msg):
+            df.replace(r"\d" if regex else "a1", lambda m: "X", regex=regex)
+
     def test_replace_ellipsis(self):
         # GH#50373 Ellipsis should be accepted as a scalar to_replace
         df = pd.DataFrame({"a": [1, 2, 3], "b": [..., ..., ...]})

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -461,6 +461,14 @@ class TestSeriesReplace:
         with pytest.raises(TypeError, match=msg):
             series.replace(lambda x: x.strip())
 
+    @pytest.mark.parametrize("regex", [False, True])
+    def test_replace_invalid_value_callable(self, regex):
+        # GH#68199 replace() should raise instead of storing a callable value
+        series = pd.Series(["a1", "b2"])
+        msg = "'value' cannot be callable, got invalid type 'function'"
+        with pytest.raises(TypeError, match=msg):
+            series.replace(r"\d" if regex else "a1", lambda m: "X", regex=regex)
+
     def test_replace_ellipsis(self):
         # GH#50373 Ellipsis should be accepted as a scalar to_replace
         series = pd.Series([..., 2, 3])


### PR DESCRIPTION
`NDFrame.replace` validates `to_replace` up front but never checks `value`. A callable `value` passes straight through, so `s.replace(r"\d", lambda m: "X", regex=True)` stores the function object in the result instead of applying it or raising, and later operations on that object-dtype data fail far from the actual mistake.

```python
s = pd.Series(["a1", "b2"])
s.replace(r"\d", lambda m: "X", regex=True)
# 0    <function <lambda> at 0x...>
# 1    <function <lambda> at 0x...>
```

This adds the same kind of check that already exists for `to_replace`: `replace` now raises `TypeError` when `value` is callable, matching the error already raised for a callable `to_replace` (GH-18634). Covered for `Series` and `DataFrame`, with and without `regex=True`.

Fixes #68199

AI disclosure: drafted with Claude Code (`claude sonnet 5 (low)`), which found the missing validation and wrote the fix and the regression tests.
