### PR TITLE
BUG: DataFrame.replace/Series.replace silently stored a callable value

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -712,6 +712,7 @@ Conversion
 - Fixed bug in :func:`to_numeric` where values preceding the first complex number in ``object``-dtype data were replaced with uninitialized memory, so e.g. ``to_numeric(Series(["1.5", 2j]))`` returned ``0j`` in place of ``1.5+0j`` (:issue:`35051`)
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``TypeError`` when ``to_replace`` was ``Ellipsis`` (``...``) (:issue:`50373`)
+- Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` silently storing a callable ``value`` instead of applying it or raising (:issue:`68199`)
 - Fixed bug in :meth:`DataFrame.to_dict` with ``orient="index"`` did not respect the ``into`` argument in nested mappings (:issue:`65778`)
 
 Strings

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -712,7 +712,6 @@ Conversion
 - Fixed bug in :func:`to_numeric` where values preceding the first complex number in ``object``-dtype data were replaced with uninitialized memory, so e.g. ``to_numeric(Series(["1.5", 2j]))`` returned ``0j`` in place of ``1.5+0j`` (:issue:`35051`)
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``TypeError`` when ``to_replace`` was ``Ellipsis`` (``...``) (:issue:`50373`)
-- Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` silently storing a callable ``value`` instead of applying it or raising (:issue:`68199`)
 - Fixed bug in :meth:`DataFrame.to_dict` with ``orient="index"`` did not respect the ``into`` argument in nested mappings (:issue:`65778`)
 
 Strings
@@ -1059,6 +1058,7 @@ Other
 - Bug in :meth:`DataFrame.eval` where a duplicate column name was resolved to a single column (yielding a :class:`Series`), inconsistent with :func:`pandas.eval` using ``resolvers=(df,)`` and with :meth:`DataFrame.__getitem__`, which include every column with that label (:issue:`65588`)
 - Bug in :meth:`DataFrame.from_dict` where passing a dict of only scalar values raised a :class:`ValueError` telling users to pass an ``index``, even though :meth:`DataFrame.from_dict` has no ``index`` parameter; the message now points to ``orient='index'`` or the :class:`DataFrame` constructor (:issue:`25515`)
 - Bug in :meth:`DataFrame.query` where an expression referencing a duplicated column label returned an unfiltered all-``NaN`` frame instead of selecting rows; it now raises ``ValueError`` unless the expression evaluates to a one-dimensional row mask (:issue:`65588`)
+- Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` silently storing a callable ``value`` instead of raising (:issue:`68199`)
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` with ``inplace=True`` and a list-like or dict ``to_replace`` where the result stopped being copy-on-write protected, so a view taken afterwards shared memory with it and writing to either one silently modified the other (:issue:`58966`)
 - Bug in :meth:`DataFrame.replace` raising ``IndexError`` instead of replacing when ``to_replace`` was list-like or dict-like, the replacement changed a column's dtype, and two or more other columns were left unchanged (:issue:`61972`)
 - Bug in :meth:`DataFrame.select_dtypes` with an :class:`~pandas.api.extensions.ExtensionDtype` subclass such as :class:`ArrowDtype` or :class:`DatetimeTZDtype` raising ``TypeError``, emitting a spurious ``UserWarning``, or selecting the wrong columns; passing such a class now selects every column whose dtype is an instance of that class (:issue:`65366`)

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -7586,6 +7586,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         TypeError
             * If `to_replace` is not a scalar, array-like, ``dict``, or ``None``
+            * If `value` is callable
             * If `to_replace` is a ``dict`` and `value` is not a ``list``,
               ``dict``, ``ndarray``, or ``Series``
             * If `to_replace` is ``None`` and `regex` is not compilable
@@ -7830,6 +7831,11 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 "Expecting 'to_replace' to be either a scalar, array-like, "
                 "dict or None, got invalid type "
                 f"{type(to_replace).__name__!r}"
+            )
+
+        if callable(value):
+            raise TypeError(
+                f"'value' cannot be callable, got invalid type {type(value).__name__!r}"
             )
 
         if value is lib.no_default and not (

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -225,6 +225,26 @@ def _is_np_bool_backed(obj: NDFrame) -> bool:
     return all(lib.is_np_dtype(dtype, "b") for dtype in dtypes)
 
 
+def _check_replace_value_not_callable(value) -> None:
+    """
+    Raise if `value` (or any element nested inside a list-like or
+    dict-like `value`) is callable (GH#68199).
+    """
+    if callable(value):
+        raise TypeError(
+            f"'value' cannot be callable, got invalid type {type(value).__name__!r}"
+        )
+    if is_dict_like(value):
+        # use .items() rather than .values() since the latter means
+        # something different for a dict (the values) than for a Series
+        # (the underlying ndarray)
+        for _, v in value.items():
+            _check_replace_value_not_callable(v)
+    elif is_list_like(value) and not isinstance(value, str):
+        for v in value:
+            _check_replace_value_not_callable(v)
+
+
 class NDFrame(PandasObject, indexing.IndexingMixin):
     """
     N-dimensional analogue of DataFrame. Store multi-dimensional in a
@@ -7586,7 +7606,6 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
 
         TypeError
             * If `to_replace` is not a scalar, array-like, ``dict``, or ``None``
-            * If `value` is callable
             * If `to_replace` is a ``dict`` and `value` is not a ``list``,
               ``dict``, ``ndarray``, or ``Series``
             * If `to_replace` is ``None`` and `regex` is not compilable
@@ -7595,6 +7614,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
             * When replacing multiple ``bool`` or ``datetime64`` objects and
               the arguments to `to_replace` does not match the type of the
               value being replaced
+            * If `value` is callable, or contains a callable
 
         ValueError
             * If a ``list`` or an ``ndarray`` is passed to `to_replace` and
@@ -7833,10 +7853,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 f"{type(to_replace).__name__!r}"
             )
 
-        if callable(value):
-            raise TypeError(
-                f"'value' cannot be callable, got invalid type {type(value).__name__!r}"
-            )
+        _check_replace_value_not_callable(value)
 
         if value is lib.no_default and not (
             is_dict_like(to_replace) or is_dict_like(regex)

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1326,13 +1326,24 @@ class TestDataFrameReplace:
         with pytest.raises(TypeError, match=msg):
             df.replace(lambda x: x.strip())
 
-    @pytest.mark.parametrize("regex", [False, True])
-    def test_replace_invalid_value_callable(self, regex):
-        # GH#68199 replace() should raise instead of storing a callable value
+    @pytest.mark.parametrize(
+        "replace_kwargs",
+        [
+            {"to_replace": "a1", "value": lambda m: "X"},
+            {"to_replace": r"\d", "value": lambda m: "X", "regex": True},
+            {"to_replace": ["a1"], "value": [lambda m: "X"]},
+            {"to_replace": {"a1": lambda m: "X"}},
+            {"regex": {r"\d": lambda m: "X"}},
+        ],
+    )
+    def test_replace_invalid_value_callable(self, replace_kwargs):
+        # GH#68199 replace() should raise instead of storing a callable
+        # value, however it is spelled (scalar, regex, list-like, or
+        # dict-like)
         df = pd.DataFrame({"one": ["a1", "b2"]})
         msg = "'value' cannot be callable, got invalid type 'function'"
         with pytest.raises(TypeError, match=msg):
-            df.replace(r"\d" if regex else "a1", lambda m: "X", regex=regex)
+            df.replace(**replace_kwargs)
 
     def test_replace_ellipsis(self):
         # GH#50373 Ellipsis should be accepted as a scalar to_replace

--- a/pandas/tests/frame/methods/test_replace.py
+++ b/pandas/tests/frame/methods/test_replace.py
@@ -1326,6 +1326,14 @@ class TestDataFrameReplace:
         with pytest.raises(TypeError, match=msg):
             df.replace(lambda x: x.strip())
 
+    @pytest.mark.parametrize("regex", [False, True])
+    def test_replace_invalid_value_callable(self, regex):
+        # GH#68199 replace() should raise instead of storing a callable value
+        df = pd.DataFrame({"one": ["a1", "b2"]})
+        msg = "'value' cannot be callable, got invalid type 'function'"
+        with pytest.raises(TypeError, match=msg):
+            df.replace(r"\d" if regex else "a1", lambda m: "X", regex=regex)
+
     def test_replace_ellipsis(self):
         # GH#50373 Ellipsis should be accepted as a scalar to_replace
         df = pd.DataFrame({"a": [1, 2, 3], "b": [..., ..., ...]})

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -461,13 +461,24 @@ class TestSeriesReplace:
         with pytest.raises(TypeError, match=msg):
             series.replace(lambda x: x.strip())
 
-    @pytest.mark.parametrize("regex", [False, True])
-    def test_replace_invalid_value_callable(self, regex):
-        # GH#68199 replace() should raise instead of storing a callable value
+    @pytest.mark.parametrize(
+        "replace_kwargs",
+        [
+            {"to_replace": "a1", "value": lambda m: "X"},
+            {"to_replace": r"\d", "value": lambda m: "X", "regex": True},
+            {"to_replace": ["a1"], "value": [lambda m: "X"]},
+            {"to_replace": {"a1": lambda m: "X"}},
+            {"regex": {r"\d": lambda m: "X"}},
+        ],
+    )
+    def test_replace_invalid_value_callable(self, replace_kwargs):
+        # GH#68199 replace() should raise instead of storing a callable
+        # value, however it is spelled (scalar, regex, list-like, or
+        # dict-like)
         series = pd.Series(["a1", "b2"])
         msg = "'value' cannot be callable, got invalid type 'function'"
         with pytest.raises(TypeError, match=msg):
-            series.replace(r"\d" if regex else "a1", lambda m: "X", regex=regex)
+            series.replace(**replace_kwargs)
 
     def test_replace_ellipsis(self):
         # GH#50373 Ellipsis should be accepted as a scalar to_replace

--- a/pandas/tests/series/methods/test_replace.py
+++ b/pandas/tests/series/methods/test_replace.py
@@ -461,6 +461,14 @@ class TestSeriesReplace:
         with pytest.raises(TypeError, match=msg):
             series.replace(lambda x: x.strip())
 
+    @pytest.mark.parametrize("regex", [False, True])
+    def test_replace_invalid_value_callable(self, regex):
+        # GH#68199 replace() should raise instead of storing a callable value
+        series = pd.Series(["a1", "b2"])
+        msg = "'value' cannot be callable, got invalid type 'function'"
+        with pytest.raises(TypeError, match=msg):
+            series.replace(r"\d" if regex else "a1", lambda m: "X", regex=regex)
+
     def test_replace_ellipsis(self):
         # GH#50373 Ellipsis should be accepted as a scalar to_replace
         series = pd.Series([..., 2, 3])


### PR DESCRIPTION
`NDFrame.replace` validates `to_replace` up front but never checks `value`. A callable `value` passes straight through, so `s.replace(r"\d", lambda m: "X", regex=True)` stores the function object in the result instead of applying it or raising, and later operations on that object-dtype data fail far from the actual mistake.

```python
s = pd.Series(["a1", "b2"])
s.replace(r"\d", lambda m: "X", regex=True)
# 0    <function <lambda> at 0x...>
# 1    <function <lambda> at 0x...>
```

This adds the same kind of check that already exists for `to_replace`: `replace` now raises `TypeError` when `value` is callable, matching the error already raised for a callable `to_replace` (GH-18634). The check is recursive so it also catches a callable hiding inside a list-like or dict-like `value` (`replace([...], [callable])`, `replace({...: callable})`, `replace(regex={...: callable})`), not just a bare callable passed directly. Covered for `Series` and `DataFrame`, across all of those spellings.

Fixes #68199

AI disclosure: drafted with Claude Code (`claude sonnet 5 (low)`), which found the missing validation and wrote the fix and the regression tests.

(Reopens the work from #68202, which the bot closed because #68199 wasn't claimed yet at the time; the issue is now assigned and the original PR could not be reopened via the API, so this is a fresh PR carrying the same branch/commits plus one follow-up commit from review.)
