### PR TITLE
BUG: to_numpy raises when na_value passed and no missing values

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -555,6 +555,7 @@ Bug fixes
 - Fixed bug in :func:`testing.assert_series_equal` showing a misleading class mismatch message when Series values were backed by different :class:`numpy.ndarray` subclasses (:issue:`65770`)
 - Fixed bug in :func:`testing.assert_series_equal`, :func:`testing.assert_index_equal`, and :func:`testing.assert_frame_equal` ignoring ``rtol`` and ``atol`` when comparing large integer and floating dtypes with ``check_dtype=False`` (:issue:`66699`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
+- Fixed bug in :meth:`DataFrame.to_numpy` raising ``ValueError`` when ``na_value`` was passed and there were no missing values, e.g. ``na_value=np.nan`` with an integer ``dtype`` (:issue:`56233`)
 
 Categorical
 ^^^^^^^^^^^

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -555,7 +555,6 @@ Bug fixes
 - Fixed bug in :func:`testing.assert_series_equal` showing a misleading class mismatch message when Series values were backed by different :class:`numpy.ndarray` subclasses (:issue:`65770`)
 - Fixed bug in :func:`testing.assert_series_equal`, :func:`testing.assert_index_equal`, and :func:`testing.assert_frame_equal` ignoring ``rtol`` and ``atol`` when comparing large integer and floating dtypes with ``check_dtype=False`` (:issue:`66699`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
-- Fixed bug in :meth:`DataFrame.to_numpy` raising ``ValueError`` when ``na_value`` was passed and there were no missing values, e.g. ``na_value=np.nan`` with an integer ``dtype`` (:issue:`56233`)
 
 Categorical
 ^^^^^^^^^^^
@@ -714,6 +713,7 @@ Conversion
 - Fixed bug in :meth:`DataFrame.from_records` where ``exclude`` was ignored when ``data`` was an iterator and ``nrows=0`` (:issue:`63774`)
 - Fixed bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``TypeError`` when ``to_replace`` was ``Ellipsis`` (``...``) (:issue:`50373`)
 - Fixed bug in :meth:`DataFrame.to_dict` with ``orient="index"`` did not respect the ``into`` argument in nested mappings (:issue:`65778`)
+- Fixed bug in :meth:`DataFrame.to_numpy` raising ``ValueError`` when ``na_value`` was passed and there were no missing values, e.g. ``na_value=np.nan`` with an integer ``dtype`` (:issue:`56233`)
 
 Strings
 ^^^^^^^

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1908,7 +1908,13 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         elif arr.dtype.kind == "f" and passed_nan:
             pass
         else:
-            arr[isna(arr)] = na_value
+            # GH#56233 skip the assignment when there is no NA to replace --
+            # numpy rejects casting the na_value (e.g. nan into int64) at
+            # assignment time even for an all-False mask, and the assignment
+            # would be a no-op in that case anyway
+            mask = isna(arr)
+            if mask.any():
+                arr[mask] = na_value
 
         return arr.transpose()
 

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -1908,10 +1908,7 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         elif arr.dtype.kind == "f" and passed_nan:
             pass
         else:
-            # GH#56233 skip the assignment when there is no NA to replace --
-            # numpy rejects casting the na_value (e.g. nan into int64) at
-            # assignment time even for an all-False mask, and the assignment
-            # would be a no-op in that case anyway
+            # GH#56233 avoid raising in the case of an all false mask
             mask = isna(arr)
             if mask.any():
                 arr[mask] = na_value

--- a/pandas/tests/frame/methods/test_to_numpy.py
+++ b/pandas/tests/frame/methods/test_to_numpy.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import pandas as pd
 import pandas._testing as tm
@@ -17,31 +18,21 @@ class TestToNumpy:
         result = df.to_numpy(dtype="int64")
         tm.assert_numpy_array_equal(result, expected)
 
-    def test_to_numpy_na_value_no_missing(self):
+    @pytest.mark.parametrize(
+        "data, dtype",
+        [
+            ({"a": [1, 2, 3]}, "Int64"),
+            ({"a": [1, 2, 3], "b": [4, 5, 6]}, "Int64"),
+            ({"a": [1, 2, 3]}, "int64"),
+        ],
+    )
+    def test_to_numpy_na_value_no_missing(self, data, dtype):
         # GH#56233 assigning na_value is a no-op when there is no NA, even
         # when the na_value cannot be cast to the target dtype
-        df = pd.DataFrame(
-            [
-                1577840521123543000,
-                1577934062321654000,
-                1578027849987321000,
-            ],
-            dtype="Int64",
-            columns=["col1"],
-        )
-        expected = np.array(
-            [[1577840521123543000], [1577934062321654000], [1578027849987321000]],
-            dtype="int64",
-        )
-        result = df.to_numpy(dtype="int64", na_value=float("nan"))
+        df = pd.DataFrame(data, dtype=dtype)
+        result = df.to_numpy(na_value=float("nan"))
+        expected = df.to_numpy()
         tm.assert_numpy_array_equal(result, expected)
-        # Series path already worked and must stay consistent
-        result_series = df["col1"].to_numpy(dtype="int64", na_value=float("nan"))
-        expected_series = np.array(
-            [1577840521123543000, 1577934062321654000, 1578027849987321000],
-            dtype="int64",
-        )
-        tm.assert_numpy_array_equal(result_series, expected_series)
 
     def test_to_numpy_copy(self):
         arr = np.random.default_rng(2).standard_normal((4, 3))

--- a/pandas/tests/frame/methods/test_to_numpy.py
+++ b/pandas/tests/frame/methods/test_to_numpy.py
@@ -17,6 +17,32 @@ class TestToNumpy:
         result = df.to_numpy(dtype="int64")
         tm.assert_numpy_array_equal(result, expected)
 
+    def test_to_numpy_na_value_no_missing(self):
+        # GH#56233 assigning na_value is a no-op when there is no NA, even
+        # when the na_value cannot be cast to the target dtype
+        df = pd.DataFrame(
+            [
+                1577840521123543000,
+                1577934062321654000,
+                1578027849987321000,
+            ],
+            dtype="Int64",
+            columns=["col1"],
+        )
+        expected = np.array(
+            [[1577840521123543000], [1577934062321654000], [1578027849987321000]],
+            dtype="int64",
+        )
+        result = df.to_numpy(dtype="int64", na_value=float("nan"))
+        tm.assert_numpy_array_equal(result, expected)
+        # Series path already worked and must stay consistent
+        result_series = df["col1"].to_numpy(dtype="int64", na_value=float("nan"))
+        expected_series = np.array(
+            [1577840521123543000, 1577934062321654000, 1578027849987321000],
+            dtype="int64",
+        )
+        tm.assert_numpy_array_equal(result_series, expected_series)
+
     def test_to_numpy_copy(self):
         arr = np.random.default_rng(2).standard_normal((4, 3))
         df = pd.DataFrame(arr)


### PR DESCRIPTION
Fixes #56233

### Bug description

`DataFrame.to_numpy` raised `ValueError: cannot convert float NaN to integer` when `na_value` was passed and there were no missing values, while the equivalent `Series.to_numpy` call worked. `BlockManager.as_array` ran the trailing `arr[isna(arr)] = na_value` unconditionally whenever an explicit `na_value` was given; numpy rejects casting the `na_value` (e.g. `nan` into `int64`) at assignment time even for an all-`False` mask.

### Solution

Compute the mask and skip the assignment when it has no `True` entries (it is a no-op in that case anyway). Behavior with missing values is unchanged.

### API breaking change

None

### Test Plan

- New regression test fails on `main` and passes with the fix.
- `tests/frame/methods/test_to_numpy.py`, `tests/series/methods/test_to_numpy.py`, `tests/internals/test_internals.py`, `tests/arrays/{masked,integer,floating}` pass.