### PR TITLE
BUG: Fix online ewm ignoring decay for single-column frames

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -958,6 +958,7 @@ Plotting
 Groupby/resample/rolling
 ^^^^^^^^^^^^^^^^^^^^^^^^
 - :meth:`DataFrame.ewm` and :meth:`Series.ewm` now raise an informative ``NotImplementedError`` instead of a confusing ``AttributeError`` when ``agg``/``aggregate`` is passed an arbitrary callable (:issue:`41700`)
+- Bug in :class:`.ExponentialMovingWindow` with ``online`` ignoring the decay for a single-column :class:`DataFrame`, returning the unweighted cumulative mean (:issue:`66522`)
 - Bug in :class:`PeriodIndex` resampling to a finer frequency where aggregation methods returned the original values instead of aggregating, e.g. ``count`` returned the data values rather than the number of observations per bin; empty bins now contain the method's identity value (e.g. ``0`` for ``sum`` instead of ``NaN``), consistent with :class:`DatetimeIndex` resampling (:issue:`42763`)
 - Bug in :meth:`.DataFrameGroupBy.agg` when there are no groups, multiple keys, and ``group_keys=False`` (:issue:`51445`)
 - Bug in :meth:`.DataFrameGroupBy.agg` would operate on the group as a whole when ``args`` or ``kwargs`` are supplied for the provided ``func``; now this method only operates on each Series of the group (:issue:`39169`)

--- a/pandas/core/window/ewm.py
+++ b/pandas/core/window/ewm.py
@@ -1166,9 +1166,6 @@ class OnlineExponentialMovingWindow(ExponentialMovingWindow):
         is_frame = self._selected_obj.ndim == 2
         if update_times is not None:
             raise NotImplementedError("update_times is not implemented.")
-        update_deltas = np.ones(
-            max(self._selected_obj.shape[-1] - 1, 0), dtype=np.float64
-        )
         if update is not None:
             if self._mean.last_ewm is None:
                 raise ValueError(
@@ -1191,6 +1188,7 @@ class OnlineExponentialMovingWindow(ExponentialMovingWindow):
             else:
                 result_kwargs["name"] = self._selected_obj.name
             np_array = self._selected_obj.astype(np.float64).to_numpy()
+        update_deltas = np.ones(max(len(np_array) - 1, 0), dtype=np.float64)
         ewma_func = generate_online_numba_ewma_func(
             **get_jit_arguments(self.engine_kwargs)
         )

--- a/pandas/core/window/online.py
+++ b/pandas/core/window/online.py
@@ -68,7 +68,7 @@ def generate_online_numba_ewma_func(
                     if is_observations[j] or not ignore_na:
                         # note that len(deltas) = len(vals) - 1 and deltas[i] is to be
                         # used in conjunction with vals[i+1]
-                        old_wt[j] *= old_wt_factor ** deltas[j - 1]
+                        old_wt[j] *= old_wt_factor ** deltas[i - 1]
                         if is_observations[j]:
                             # avoid numerical errors on constant series
                             if weighted_avg[j] != cur[j]:

--- a/pandas/tests/window/test_online.py
+++ b/pandas/tests/window/test_online.py
@@ -33,7 +33,11 @@ class TestEWM:
     @pytest.mark.slow
     @pytest.mark.parametrize(
         "obj",
-        [pd.DataFrame({"a": range(5), "b": range(5)}), pd.Series(range(5), name="foo")],
+        [
+            pd.DataFrame({"a": range(5), "b": range(5)}),
+            pd.DataFrame({"a": range(5)}),
+            pd.Series(range(5), name="foo"),
+        ],
     )
     def test_online_vs_non_online_mean(self, obj, nogil, parallel, adjust, ignore_na):
         expected = obj.ewm(0.5, adjust=adjust, ignore_na=ignore_na).mean()


### PR DESCRIPTION
- [x] closes #66522
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

---

Fixes two off-by-a-dimension bugs in `ExponentialMovingWindow.online` that cause it to ignore the decay for single-column DataFrames, returning the unweighted cumulative mean instead of the exponentially weighted mean.

1. In `OnlineExponentialMovingWindow.mean` (`ewm.py`), `update_deltas` was sized from the column count (`shape[-1]`) instead of the number of rows being processed. For a single-column frame this produced a length-0 array. It is now sized from `len(np_array) - 1`, which also correctly handles the `mean(update=...)` path where the input array is `last_value + update`.
2. In `online_ewma` (`online.py`), the deltas array was indexed with the column index `j` (`deltas[j - 1]`) instead of the row index `i` (`deltas[i - 1]`), contradicting the contract in the adjacent comment.

Regression coverage added for single-column DataFrames (both the initial and `update` paths).