### PR TITLE
docs: fix 'affect to' grammar in east_asian_width option doc and a comment

### DIFF
--- a/pandas/core/config_init.py
+++ b/pandas/core/config_init.py
@@ -207,7 +207,7 @@ pc_east_asian_width_doc = """
 : boolean
     Whether to use the Unicode East Asian Width to calculate the display text
     width.
-    Enabling this may affect to the performance (default: False)
+    Enabling this may affect performance (default: False)
 """
 
 

--- a/pandas/core/reshape/concat.py
+++ b/pandas/core/reshape/concat.py
@@ -896,7 +896,7 @@ def _get_sample_object(
                 return obj, objs
     elif keys is None and names is None and levels is None and not intersect:
         # filter out the empties if we have not multi-index possibilities
-        # note to keep empty Series as it affect to result columns / name
+        # note to keep empty Series as it affects the result columns / name
         if ndims.pop() == 2:
             non_empties = [obj for obj in objs if sum(obj.shape)]
         else:


### PR DESCRIPTION
The `display.east_asian_width` option description (user-visible via `pd.describe_option` and the Options API docs page) read "Enabling this may **affect to** the performance". A comment in `pandas/core/reshape/concat.py` had the same pattern ("as it affect to result columns" → "as it affects the result columns"). Grammar-only; no behavior change.

**Automated contributions policy**: AI was used — this fix was found and prepared with AI assistance (Claude, via an automated docs-audit pass); reviewed and submitted by @simpleqt. Trivial typo fix, so no whatsnew entry / linked issue per the exempt-for-typos rule.