### PR TITLE
DOC: Maintain sidebar position when moving between pages

### DIFF
--- a/doc/_templates/sidebar-nav-bs.html
+++ b/doc/_templates/sidebar-nav-bs.html
@@ -1,4 +1,4 @@
-<nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+<nav class="bd-docs-nav bd-links" id="bd-docs-nav" aria-label="Main navigation">
   <div class="bd-toc-item navbar-nav">
     {% if pagename.startswith("reference") %}
     {{ generate_toctree_html("sidebar", maxdepth=4, collapse=True, includehidden=True, titles_only=True) }}


### PR DESCRIPTION
Closes #58177
Continuation of #66624

The addition of `bd-docs-nav` should have no adverse impact since it isn't in any of our stylesheets.