### PR TITLE
BUG: fix "boolean value of NA is ambiguous" in iloc setitem with nullable Series RHS

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -790,6 +790,7 @@ Indexing
 - Fixed bug in :meth:`DataFrame.loc` where assigning a :class:`Series` to a subset of rows of one column upcast the dtype of other columns in a single-dtype :class:`DataFrame` (:issue:`66105`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
 - Fixed segfault in :meth:`DataFrame.loc` when repeatedly adding new rows to an object-dtype-indexed :class:`DataFrame` (:issue:`21968`)
+- Bug in :meth:`Series.iloc` setitem raising ``TypeError`` ("boolean value of NA is ambiguous") when the right-hand side is a nullable :class:`Series` (e.g. ``Int64``) containing a missing value with a non-default index, because the coercion compared the value positionally against the original by label (:issue:`62473`) 
 -
 
 Missing

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -787,10 +787,10 @@ Indexing
 - Bug in setitem (e.g. :meth:`Series.iloc`) silently storing wrong values when assigning a nullable or :class:`ArrowDtype` extension array into a NumPy-dtype column that could not hold it losslessly, such as a negative value into an unsigned-integer column (``-1`` became ``18446744073709551615``) or a value overflowing a narrower float dtype (:issue:`47776`)
 - Bug in setitem on nullable masked arrays (``Int64``, ``Float64``, ``boolean``, ...) silently coercing list-like values that the equivalent scalar setitem would reject — e.g. ``arr[[0]] = ['1']`` parsed the string into the numeric dtype, ``arr[[0]] = [True]`` on ``Int64``/``Float64`` coerced the boolean to ``1``, and an out-of-bounds value such as ``arr[[0]] = [1000]`` on ``Int8`` silently wrapped instead of raising (:issue:`45404`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning an iterable to a single cell in an ``object`` dtype column incorrectly raised a ``ValueError`` (:issue:`26333`, :issue:`57962`)
+- Bug in :meth:`Series.iloc` setitem raising ``TypeError`` ("boolean value of NA is ambiguous") when the right-hand side is a nullable :class:`Series` (e.g. ``Int64``) containing a missing value with a non-default index, because the coercion compared the value positionally against the original by label (:issue:`62473`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning a :class:`Series` to a subset of rows of one column upcast the dtype of other columns in a single-dtype :class:`DataFrame` (:issue:`66105`)
 - Fixed bug in :meth:`DataFrame.loc` where assigning with duplicate column names and new columns corrupted unrelated columns (:issue:`58317`)
 - Fixed segfault in :meth:`DataFrame.loc` when repeatedly adding new rows to an object-dtype-indexed :class:`DataFrame` (:issue:`21968`)
-- Bug in :meth:`Series.iloc` setitem raising ``TypeError`` ("boolean value of NA is ambiguous") when the right-hand side is a nullable :class:`Series` (e.g. ``Int64``) containing a missing value with a non-default index, because the coercion compared the value positionally against the original by label (:issue:`62473`) 
 -
 
 Missing

--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -225,7 +225,14 @@ def _coerce_to_data_and_mask(values, dtype, copy: bool, dtype_cls: type[NumericD
             values = np.ones(values.shape, dtype=dtype)
         else:
             idx = np.nanargmax(values)
-            if int(values[idx]) != original[idx]:
+            # `values` is positionally aligned with the input; when the input
+            # is a Series with a non-default index, ``original[idx]`` would do
+            # a label lookup and can land on a missing element even when
+            # ``values[idx]`` is concrete (GH#62473). Access positionally.
+            original_idx = getattr(original, "iloc", original)[idx]
+            if not libmissing.checknull(
+                original_idx
+            ) and int(values[idx]) != original_idx:
                 # We have ints that lost precision during the cast.
                 inferred_type = lib.infer_dtype(original, skipna=True)
                 if (

--- a/pandas/core/arrays/numeric.py
+++ b/pandas/core/arrays/numeric.py
@@ -230,9 +230,10 @@ def _coerce_to_data_and_mask(values, dtype, copy: bool, dtype_cls: type[NumericD
             # a label lookup and can land on a missing element even when
             # ``values[idx]`` is concrete (GH#62473). Access positionally.
             original_idx = getattr(original, "iloc", original)[idx]
-            if not libmissing.checknull(
-                original_idx
-            ) and int(values[idx]) != original_idx:
+            if (
+                not libmissing.checknull(original_idx)
+                and int(values[idx]) != original_idx
+            ):
                 # We have ints that lost precision during the cast.
                 inferred_type = lib.infer_dtype(original, skipna=True)
                 if (

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -742,9 +742,7 @@ class TestSetitemCasting:
         assert result.dtype == "Int64"
         # The outcome is positional: the RHS index labels must not matter.
         expected = ser.copy()
-        expected.iloc[indices] = pd.Series(
-            [4, 6, 9, None, 10, 13, 15], dtype="Int64"
-        )
+        expected.iloc[indices] = pd.Series([4, 6, 9, None, 10, 13, 15], dtype="Int64")
         tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/series/indexing/test_setitem.py
+++ b/pandas/tests/series/indexing/test_setitem.py
@@ -715,6 +715,38 @@ class TestSetitemCasting:
         with pytest.raises(TypeError, match="Invalid value"):
             ser[1:] = arr[1:]  # has an NA -> cast to boolean dtype
 
+    def test_setitem_iloc_rhs_series_non_default_index_with_na(self):
+        # GH#62473
+        # Assigning a nullable Int64 Series with an NA as the RHS of an iloc
+        # setitem used to raise "boolean value of NA is ambiguous" when the
+        # RHS had a non-default index: the precision-loss check in
+        # ``_coerce_to_data_and_mask`` compared ``values[idx]`` (positional)
+        # against ``original[idx]``, which on a Series does a *label* lookup
+        # and could land on the NA element even when the value at that
+        # position is concrete.
+        ser = pd.Series(
+            [4, 6, 9, None, 10, 13, 15],
+            index=[6, 1, 5, 0, 3, 2, 4],
+            dtype="Int64",
+        )
+        indices = pd.Series([6, 1, 5, 0, 3, 2, 4], dtype="int64")
+        values = pd.Series(
+            [4, 6, 9, None, 10, 13, 15],
+            index=[4, 1, 2, 6, 0, 5, 3],
+            dtype="Int64",
+        )
+
+        result = ser.copy()
+        result.iloc[indices] = values
+
+        assert result.dtype == "Int64"
+        # The outcome is positional: the RHS index labels must not matter.
+        expected = ser.copy()
+        expected.iloc[indices] = pd.Series(
+            [4, 6, 9, None, 10, 13, 15], dtype="Int64"
+        )
+        tm.assert_series_equal(result, expected)
+
 
 class SetitemCastingEquivalents:
     """


### PR DESCRIPTION
xref: #62473

### Issue and Reproducible Example

Assigning a nullable (e.g. ``Int64``) ``Series`` containing a missing value as
the right-hand side of a ``Series.iloc`` setitem raised

    TypeError: boolean value of NA is ambiguous

when the RHS had a non-default index:

```python
import pandas as pd

ser = pd.Series([4, 6, 9, None, 10, 13, 15], index=[6, 1, 5, 0, 3, 2, 4], dtype="Int64")
indices = pd.Series([6, 1, 5, 0, 3, 2, 4], dtype="int64")
values = pd.Series([4, 6, 9, None, 10, 13, 15], index=[4, 1, 2, 6, 0, 5, 3], dtype="Int64")

ser.iloc[indices] = values
```

### Root Cause

In ``_coerce_to_data_and_mask`` (``pandas/core/arrays/numeric.py``), the
precision-loss check compares the positionally-coerced float value against the
original:

```python
idx = np.nanargmax(values)
if int(values[idx]) != original[idx]:
```

``values`` is positionally aligned with the input, but when the input is a
``Series`` with a non-default index, ``original[idx]`` performs a *label* lookup
and can land on a missing (NA) element even when the value at position ``idx``
is concrete. Comparing a concrete value against NA yields NA, and the ``if``
then raises "boolean value of NA is ambiguous".

### Fix

Access the original value positionally (a ``Series`` is read via ``.iloc``;
arrays and lists are already read positionally) and skip the check when the
original value is null. ``np.nanargmax`` already guarantees ``values[idx]`` is
concrete, so the positional original is not the missing element in practice; the
null guard is defensive.

### Tests

``test_setitem_iloc_rhs_series_non_default_index_with_na`` (new, in
``pandas/tests/series/indexing/test_setitem.py``) reproduces the issue and
asserts the outcome is positional: a non-default-indexed RHS yields the same
result as the equivalent default-indexed RHS.

---
This contribution was developed with the assistance of an AI coding assistant.
