### PR TITLE
PERF: speed up read_csv NA-value screening

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -442,6 +442,7 @@ Performance improvements
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, largest for files of short strings such as codes, categories and identifiers; concurrent reads from multiple threads also scale better (:issue:`66756`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns under ``future.infer_string`` or ``dtype_backend="pyarrow"``, particularly when strings do not repeat (:issue:`65283`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` for string columns, particularly for multi-threaded reads and chunked (``low_memory``) reads (:issue:`66277`)
+- Performance improvement in :func:`read_csv` with ``engine="c"`` when ``na_filter`` is enabled (the default), largest for numeric and boolean columns and for wide files with many columns (:issue:`68314`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when an extension dtype is requested (e.g. ``dtype="Int64"``, ``dtype="boolean"``, or ``dtype="int64[pyarrow]"``) (:issue:`66279`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing float columns (:issue:`66457`)
 - Performance improvement in :func:`read_csv` with ``engine="c"`` when parsing integer columns (:issue:`65347`, :issue:`66459`, :issue:`66487`)

--- a/pandas/_libs/include/pandas/vendored/klib/khash_python.h
+++ b/pandas/_libs/include/pandas/vendored/klib/khash_python.h
@@ -437,11 +437,62 @@ static inline int kh_strview_hash_equal(kh_strview_t a, kh_strview_t b) {
 KHASH_MAP_INIT_STRVIEW(str, size_t)
 KHASH_MAP_INIT_STRVIEW(strbox, kh_pyobject_t)
 
+// A small set of strings (na_values, true_values, false_values) probed once
+// per token on the read_csv hot path, so lookups are built to reject fast:
+// per first byte, a bitmask of the key lengths present (bit 63 stands for
+// every length >= 63) settles nearly every token with one load, and the keys
+// themselves are kept inline, grouped by first byte, and compared directly.
+// Only a set with more than KH_STR_STARTS_NCAND keys falls through to the
+// hashset, whose hash walks the whole token: with a first-byte check alone,
+// every negative number was hashed against "-nan" / "-1.#IND", and every
+// token starting with "1" against "1.#QNAN".
+#define KH_STR_STARTS_NCAND 64
+
 typedef struct {
   kh_str_t *table;
-  int starts[256];
+  uint64_t start_lens[256];
+  // cand[cand_start[c] .. cand_start[c] + ncand[c]) are the keys whose first
+  // byte is c; cand_start[c] is the count of keys with a smaller first byte.
+  kh_strview_t cand[KH_STR_STARTS_NCAND];
+  uint64_t cand_prefix[KH_STR_STARTS_NCAND]; // kh_str_starts_prefix of each
+  uint8_t cand_start[256];
+  uint8_t ncand[256];
+  uint8_t ncand_total;
+  uint8_t overflow; // more keys than cand holds: probe the hashset instead
   int has_empty;
 } kh_str_starts_t;
+
+static inline uint64_t kh_str_starts_lenbit(size_t len) {
+  return (uint64_t)1 << (len < 63 ? len : 63);
+}
+
+// The first min(len, 8) bytes packed into one word, so a candidate is
+// settled by one compare instead of a byte loop.  Fixed-size loads only: a
+// runtime-length memcpy is a libc call, and reading 8 bytes past a short key
+// would overrun it.  The packing is not a byte order, but it is the same
+// bijection on both sides of the compare, which is all that is needed.
+static inline uint64_t kh_str_starts_prefix(const char *key, size_t len) {
+  uint64_t word = 0;
+  if (len >= 8) {
+    memcpy(&word, key, 8);
+    return word;
+  }
+  if (len & 4) {
+    uint32_t part;
+    memcpy(&part, key, 4);
+    word = part;
+    key += 4;
+  }
+  if (len & 2) {
+    uint16_t part;
+    memcpy(&part, key, 2);
+    word |= (uint64_t)part << 32;
+    key += 2;
+  }
+  if (len & 1)
+    word |= (uint64_t)(unsigned char)*key << 48;
+  return word;
+}
 
 typedef kh_str_starts_t *p_kh_str_starts_t;
 
@@ -465,22 +516,66 @@ static inline khuint_t kh_put_str_starts_item(kh_str_starts_t *table,
     // The empty key gets its own flag rather than a slot in starts[]. Sharing
     // starts['\0'] with it would make every token that merely *begins* with an
     // embedded NUL look like a candidate.
-    if (len == 0)
+    if (len == 0) {
       table->has_empty = 1;
-    else
-      table->starts[(unsigned char)key[0]] = 1;
+    } else {
+      const unsigned char c0 = (unsigned char)key[0];
+      table->start_lens[c0] |= kh_str_starts_lenbit(len);
+      if (table->ncand_total == KH_STR_STARTS_NCAND) {
+        table->overflow = 1;
+      } else if (!table->overflow) {
+        const unsigned pos = table->cand_start[c0] + table->ncand[c0];
+        memmove(&table->cand[pos + 1], &table->cand[pos],
+                (table->ncand_total - pos) * sizeof(kh_strview_t));
+        memmove(&table->cand_prefix[pos + 1], &table->cand_prefix[pos],
+                (table->ncand_total - pos) * sizeof(uint64_t));
+        table->cand[pos] = kh_strview(key, len);
+        table->cand_prefix[pos] = kh_str_starts_prefix(key, len);
+        table->ncand[c0]++;
+        table->ncand_total++;
+        for (unsigned c = c0 + 1; c < 256; ++c)
+          table->cand_start[c]++;
+      }
+    }
   }
   return result;
+}
+
+// Out-of-line so that the per-token call sites inline only the first-byte
+// reject above it, keeping the converter loops short enough for the CPU to
+// overlap the cache misses of several tokens.
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((noinline))
+#endif
+static khuint_t kh_get_str_starts_item_slow(const kh_str_starts_t *table,
+                                            const char *key, size_t len,
+                                            unsigned char c0) {
+  if (table->overflow)
+    return kh_get_str(table->table, kh_strview(key, len)) !=
+           table->table->n_buckets;
+  const uint64_t prefix = kh_str_starts_prefix(key, len);
+  const unsigned start = table->cand_start[c0];
+  const unsigned stop = start + table->ncand[c0];
+  for (unsigned i = start; i < stop; ++i) {
+    if (table->cand_prefix[i] != prefix || table->cand[i].len != len)
+      continue;
+    size_t j = 8;
+    while (j < len && table->cand[i].ptr[j] == key[j])
+      ++j;
+    if (j >= len)
+      return 1;
+  }
+  return 0;
 }
 
 static inline khuint_t kh_get_str_starts_item(const kh_str_starts_t *table,
                                               const char *key, size_t len) {
   if (len == 0)
     return (khuint_t)table->has_empty;
-  if (table->starts[(unsigned char)key[0]] &&
-      kh_get_str(table->table, kh_strview(key, len)) != table->table->n_buckets)
-    return 1;
-  return 0;
+  const unsigned char c0 = (unsigned char)key[0];
+  if (!(table->start_lens[c0] & kh_str_starts_lenbit(len)))
+    return 0;
+  return kh_get_str_starts_item_slow(table, key, len, c0);
 }
 
 static inline void kh_destroy_str_starts(kh_str_starts_t *table) {

--- a/pandas/_libs/khash.pxd
+++ b/pandas/_libs/khash.pxd
@@ -102,7 +102,7 @@ cdef extern from "pandas/vendored/klib/khash_python.h":
 
     ctypedef struct kh_str_starts_t:
         kh_str_t *table
-        int starts[256]
+        uint64_t start_lens[256]
         int has_empty
 
     kh_str_starts_t* kh_init_str_starts() nogil

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -416,6 +416,9 @@ cdef class TextReader:
         list names   # can be None
         set noconvert  # set[int]
         dict datetime_cols  # dict[int, bool]
+        # NA hashset per column (per reader when na_values is not a dict),
+        # built on first use and freed in _close; see _get_na_set
+        dict na_set_cache  # dict[int, tuple[list, set, uintptr_t]]
         dict dt_chunk_states  # dict[int, _DatetimeChunkState] | None
         int64_t lm_chunk_idx
         object _buffer_ref  # keeps pre-loaded bytes alive during parse
@@ -609,6 +612,7 @@ cdef class TextReader:
 
         self.noconvert = set()
         self.datetime_cols = {}
+        self.na_set_cache = {}
         self.dt_chunk_states = None
         self.lm_chunk_idx = 0
 
@@ -1249,25 +1253,16 @@ cdef class TextReader:
             na_fset = set()
 
             if self.na_filter:
-                na_list, na_fset = self._get_na_list(i, name)
+                na_fset = self._get_na_set(i, name, &na_hashset)
                 na_filter = 1
-                na_hashset = kset_from_list(na_list)
             else:
                 na_filter = 0
 
             # Attempt to parse tokens and infer dtype of the column.
             # Should return as the desired dtype (inferred or specified).
-            try:
-                col_res, na_count, na_mask = self._convert_tokens(
-                    i, start, end, name, na_filter, na_hashset,
-                    na_fset, col_dtype)
-            finally:
-                # gh-21353
-                #
-                # Cleanup the NaN hash that we generated
-                # to avoid memory leaks.
-                if na_filter:
-                    self._free_na_set(na_hashset)
+            col_res, na_count, na_mask = self._convert_tokens(
+                i, start, end, name, na_filter, na_hashset,
+                na_fset, col_dtype)
 
             # don't try to upcast EAs
             if (
@@ -1874,8 +1869,43 @@ cdef class TextReader:
         else:
             return _ensure_encoded(self.na_values), self.na_fvalues
 
-    cdef _free_na_set(self, kh_str_starts_t *table):
-        kh_destroy_str_starts(table)
+    cdef object _get_na_key(self, Py_ssize_t i, object name):
+        # The na_values entry column i resolves to, mirroring _get_na_list, so
+        # that columns sharing an entry share a hashset. None means "the
+        # defaults", which most columns of a wide file take; keying on i
+        # instead would build and hold one hashset per column.
+        if not isinstance(self.na_values, dict):
+            return None
+        if name is not None and name in self.na_values:
+            return name
+        if i in self.na_values:
+            return i
+        return None
+
+    cdef set _get_na_set(self, Py_ssize_t i, object name,
+                         kh_str_starts_t **table):
+        """
+        The NA hashset and float NA set for column i, built on first use and
+        reused for every later chunk, and for every other column resolving to
+        the same na_values entry, rather than rebuilt per (column, chunk)
+        under the GIL.
+        """
+        cdef:
+            object key = self._get_na_key(i, name)
+            tuple entry = self.na_set_cache.get(key)
+            list na_list
+            set na_fset
+
+        if entry is None:
+            na_list, na_fset = self._get_na_list(i, name)
+            table[0] = kset_from_list(na_list)
+            # na_list stays referenced here: the hashset's keys point into
+            # its bytes objects
+            entry = (na_list, na_fset, <uintptr_t>table[0])
+            self.na_set_cache[key] = entry
+        else:
+            table[0] = <kh_str_starts_t *><uintptr_t>entry[2]
+        return entry[1]
 
     cdef _get_column_name(self, Py_ssize_t i, Py_ssize_t nused):
         cdef int64_t j
@@ -1923,6 +1953,10 @@ cdef _close(TextReader reader):
     if reader.false_set:
         kh_destroy_str_starts(reader.false_set)
         reader.false_set = NULL
+    if reader.na_set_cache:
+        for entry in reader.na_set_cache.values():
+            kh_destroy_str_starts(<kh_str_starts_t *><uintptr_t>entry[2])
+        reader.na_set_cache = {}
 
 
 cdef:

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -910,6 +910,7 @@ def test_int64_min_with_na_explicit_nullable_dtype(all_parsers):
     tm.assert_frame_equal(result, expected)
 
 
+@skip_pyarrow  # object-dtype NA reads back as None, not NaN
 @pytest.mark.parametrize(
     "na_values, data, expected_values",
     [

--- a/pandas/tests/io/parser/test_na_values.py
+++ b/pandas/tests/io/parser/test_na_values.py
@@ -908,3 +908,31 @@ def test_int64_min_with_na_explicit_nullable_dtype(all_parsers):
     )
     expected = pd.DataFrame({"A": [-9223372036854775808, None, 1]}, dtype="Int64")
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "na_values, data, expected_values",
+    [
+        # share the first byte and length with a default NA spelling but not
+        # the second byte: "-nan" vs "-1.5", "1.#IND" vs "1.2345"
+        (None, "-1.5\n-nan\n1.2345\n1.#IND\n", [-1.5, np.nan, 1.2345, np.nan]),
+        # share the first two bytes and the length with an NA spelling
+        (["-1.#IND"], "-1.2345\n-1.#IND\n", [-1.2345, np.nan]),
+        # single-byte NA spelling
+        (["x"], "x\nxx\n1\n", [np.nan, "xx", "1"]),
+        # spellings at and beyond the 63-byte length bucket
+        (
+            ["a" * 63, "b" * 70],
+            "\n".join(["a" * 63, "a" * 64, "b" * 70, "b" * 63, "c" * 70]) + "\n",
+            [np.nan, "a" * 64, np.nan, "b" * 63, "c" * 70],
+        ),
+    ],
+)
+def test_na_values_prefilter_edge_cases(all_parsers, na_values, data, expected_values):
+    # the C engine screens tokens against na_values by first byte and length,
+    # then compares the packed first 8 bytes; each case shares part of that
+    # signature with a spelling without being one
+    parser = all_parsers
+    result = parser.read_csv(StringIO("col\n" + data), na_values=na_values)
+    expected = pd.DataFrame({"col": expected_values})
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
Screens tokens against `na_values` (and `true_values`/`false_values`) with a per-first-byte bitmask of the key lengths present, so a token whose first byte and length match no NA spelling is rejected with a single load rather than hashed. Sets small enough to hold inline keep their keys grouped by first byte and compare them directly, so the common case never reaches the hashset. The default set occupies only six first bytes (`#`, `-`, `1`, `<`, `N`, `n`), which is why the win tracks how often column values start with one of those — negative numbers previously paid a full hash against `-nan`/`-1.#IND` on every token.

The NA hashset is also built once per reader instead of once per (column, chunk), which is what chunked and wide reads were paying for.

Measured with csvbench on an ephemeral `c7i.4xlarge`, treat and baseline built from the same commit and toolchain on the same instance, interleaved per case (12 rounds, medians with CIs):

| | Linux | Windows |
|---|---|---|
| ints 90% negative | 1.177x | 1.624x |
| bool | 1.121x | 1.614x |
| floats 100% negative | 1.245x | 1.558x |
| adversarial strings | 1.280x | 1.329x |
| mixed | 1.091x | 1.213x |
| wide (100 cols) | 1.113x | 1.123x |
| chunksize=100k | 1.099x | n/a |
| int | 1.021x | 1.110x |
| ints, positive | 1.001x | 1.072x |
| `na_filter=False` (control) | 0.998x | 1.002x |

Linux ran the full 123-case suite: 84 significant wins, 1 significant loss (`wide20 [par]`, 0.988x, which comes out a significant 1.032x win on Windows). Windows ran the 47-case core/na/signs subset: 43 significant wins, 0 significant losses.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the implementation and the benchmark runs; a separate session pressure-tested it against main (randomized differential fuzzing of the lookup and of `read_csv` across keyword combinations, ASan/UBSan, leak and thread checks) and contributed the per-column NA-set cache keying.