### PR TITLE
DOC/TST: whatsnew for GH#66699 omitted assert_extension_array_equal

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -555,7 +555,7 @@ Bug fixes
 - Fixed bug in :func:`testing.assert_frame_equal` incorrectly raising when equivalent :class:`MultiIndex` column labels contained missing values (:issue:`54521`)
 - Fixed bug in :func:`testing.assert_frame_equal`, :func:`testing.assert_index_equal`, :func:`testing.assert_series_equal` and :func:`testing.assert_extension_array_equal` where ``rtol`` and ``atol`` were applied after casting to ``float64``, so integers above ``2**53`` could compare equal while differing by more than the tolerance, or unequal while within it (:issue:`66400`)
 - Fixed bug in :func:`testing.assert_series_equal` showing a misleading class mismatch message when Series values were backed by different :class:`numpy.ndarray` subclasses (:issue:`65770`)
-- Fixed bug in :func:`testing.assert_series_equal`, :func:`testing.assert_index_equal`, and :func:`testing.assert_frame_equal` ignoring ``rtol`` and ``atol`` when comparing large integer and floating dtypes with ``check_dtype=False`` (:issue:`66699`)
+- Fixed bug in :func:`testing.assert_series_equal`, :func:`testing.assert_index_equal`, :func:`testing.assert_frame_equal` and :func:`testing.assert_extension_array_equal` ignoring ``rtol`` and ``atol`` when comparing large integer and floating dtypes with ``check_dtype=False`` (:issue:`66699`)
 - Fixed bug in :func:`to_timedelta` and :class:`Timedelta` not accepting Day offsets (:issue:`64240`)
 
 Categorical

--- a/pandas/tests/util/test_assert_extension_array_equal.py
+++ b/pandas/tests/util/test_assert_extension_array_equal.py
@@ -152,3 +152,18 @@ def test_assert_extension_array_equal_zero_dim_duck_array(check_exact):
     msg = "ExtensionArray are different"
     with pytest.raises(AssertionError, match=msg):
         tm.assert_extension_array_equal(left, right, check_exact=check_exact)
+
+
+def test_assert_extension_array_equal_large_mixed_integer_float():
+    # GH#66699 tolerances must be honored at full integer precision
+    left = pd.array([2**60 + 1], dtype="Int64")
+    right = pd.array([float(2**60)], dtype="Float64")
+
+    for first, second in [(left, right), (right, left)]:
+        with pytest.raises(AssertionError, match="ExtensionArray are different"):
+            tm.assert_extension_array_equal(
+                first, second, check_dtype=False, check_exact=False, rtol=0, atol=0.5
+            )
+        tm.assert_extension_array_equal(
+            first, second, check_dtype=False, check_exact=False, rtol=0, atol=1
+        )


### PR DESCRIPTION
GH-66722 fixed the scalar tail of `assert_almost_equal` so `rtol`/`atol` are honored when a large integer is compared against an integral float (GH-66699). Its whatsnew entry lists `assert_series_equal`, `assert_index_equal` and `assert_frame_equal`.

`assert_extension_array_equal` is affected in exactly the same way and is fixed by the same change: it casts the non-NA values to object dtype, so `array_equivalent` returns `False` and each pair lands in the same per-element scalar path. On main before GH-66722:

```python
import pandas as pd

left = pd.array([2**60 + 1], dtype="Int64")
right = pd.array([float(2**60)], dtype="Float64")
pd.testing.assert_extension_array_equal(
    left, right, check_dtype=False, check_exact=False, rtol=0, atol=0.5
)
# passed, though the values differ by 1 and atol is 0.5
```

So this adds it to that entry, matching the GH-66400 line directly above it, which already names all four. `pandas.testing` exports exactly those four functions, so the line is now complete.

Also adds a direct regression test. GH-66722 reached this entry point only indirectly, via a masked-dtype `Series` case; the new test fails against that PR's parent state of `pandas/_libs/testing.pyx` and passes after it.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which located the omission, wrote the whatsnew edit and the test, and verified the test against the pre-fix `testing.pyx`.