### PR TITLE
BUG: big-endian timedelta64 construction silently byteswapped every value

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -637,6 +637,7 @@ Timedelta
 ^^^^^^^^^
 - Bug in :attr:`TimedeltaIndex.resolution` raising when the index has no frequency (:issue:`65186`)
 - Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
+- Bug in :class:`Series`, :class:`DataFrame`, :class:`TimedeltaIndex` construction and :func:`to_timedelta` from a big-endian ``timedelta64`` numpy array, where every value was silently read back byteswapped and ``NaT`` became an ordinary duration; such input is now normalized to native byteorder (:issue:`68321`)
 - Bug in :class:`Timedelta` constructor and :func:`to_timedelta` raising a bare ``OverflowError`` instead of ``OutOfBoundsTimedelta`` for infinite or overflowing float input, which also prevented ``errors="coerce"`` from returning ``NaT`` (:issue:`66247`)
 - Bug in :class:`Timedelta` constructor and :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timedelta` constructor where keyword arguments (e.g. ``days=365000``) that exceeded nanosecond int64 bounds raised ``OutOfBoundsTimedelta`` instead of falling back to a coarser resolution (:issue:`46587`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -637,7 +637,7 @@ Timedelta
 ^^^^^^^^^
 - Bug in :attr:`TimedeltaIndex.resolution` raising when the index has no frequency (:issue:`65186`)
 - Bug in :class:`DateOffset` where ``DateOffset(1)`` and ``DateOffset(days=1)`` returned different results near daylight saving time transitions (:issue:`61862`)
-- Bug in :class:`Series`, :class:`DataFrame`, :class:`TimedeltaIndex` construction and :func:`to_timedelta` from a big-endian ``timedelta64`` numpy array, where every value was silently read back byteswapped and ``NaT`` became an ordinary duration; such input is now normalized to native byteorder (:issue:`68321`)
+- Bug in :class:`Series`, :class:`DataFrame`, :class:`TimedeltaIndex` construction and :func:`to_timedelta` from a big-endian ``timedelta64`` numpy array, where every value was silently read back byteswapped and ``NaT`` became an ordinary duration; such input is now normalized to native byteorder (:issue:`68342`)
 - Bug in :class:`Timedelta` constructor and :func:`to_timedelta` raising a bare ``OverflowError`` instead of ``OutOfBoundsTimedelta`` for infinite or overflowing float input, which also prevented ``errors="coerce"`` from returning ``NaT`` (:issue:`66247`)
 - Bug in :class:`Timedelta` constructor and :func:`to_timedelta` where passing ``np.str_`` objects would fail in Cython string parsing (:issue:`48974`)
 - Bug in :class:`Timedelta` constructor where keyword arguments (e.g. ``days=365000``) that exceeded nanosecond int64 bounds raised ``OutOfBoundsTimedelta`` instead of falling back to a coarser resolution (:issue:`46587`)

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1348,6 +1348,12 @@ def sequence_to_td64ns(
         copy = False
 
     elif lib.is_np_dtype(data.dtype, "m"):
+        if data.dtype.byteorder == ">":
+            # GH#68321 supported units are otherwise stored as-is; the swap also
+            #  has to precede the cast, whose finer->coarser branch views i8 raw
+            data = data.astype(data.dtype.newbyteorder("<"))
+            copy = False
+
         if not is_supported_dtype(data.dtype):
             # cast to closest supported unit, i.e. s or ns
             new_dtype = get_supported_dtype(data.dtype)

--- a/pandas/core/arrays/timedeltas.py
+++ b/pandas/core/arrays/timedeltas.py
@@ -1349,7 +1349,7 @@ def sequence_to_td64ns(
 
     elif lib.is_np_dtype(data.dtype, "m"):
         if data.dtype.byteorder == ">":
-            # GH#68321 supported units are otherwise stored as-is; the swap also
+            # GH#68342 supported units are otherwise stored as-is; the swap also
             #  has to precede the cast, whose finer->coarser branch views i8 raw
             data = data.astype(data.dtype.newbyteorder("<"))
             copy = False

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -704,7 +704,7 @@ def test_select_dtypes_dt64_td64_string_byteorder_unitless(kind):
 
 def test_select_dtypes_td64_non_native_column():
     # GH#40234 a string spec matches by resolution, an instance spec stays exact.
-    # Construction no longer yields a non-native column (GH#68321); the fixture
+    # Construction no longer yields a non-native column (GH#68342); the fixture
     # leans on a unit-changing astype, itself a bug, so the assert is a tripwire
     df = pd.DataFrame(
         {

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -703,16 +703,16 @@ def test_select_dtypes_dt64_td64_string_byteorder_unitless(kind):
 
 
 def test_select_dtypes_td64_non_native_column():
-    # GH#40234 a td64 column can be stored in non-native byteorder (dt64 is
-    # normalized on construction, td64 is not), so a string spec must match it
-    # by resolution regardless of byteorder, while an instance spec stays exact
+    # GH#40234 a string spec matches by resolution, an instance spec stays exact.
+    # Construction no longer yields a non-native column (GH#68321); the fixture
+    # leans on a unit-changing astype, itself a bug, so the assert is a tripwire
     df = pd.DataFrame(
         {
-            "be": pd.Series(np.array([1, 2], dtype=">m8[s]")),
+            "be": pd.Series(np.array([1, 2], dtype="<m8[ms]")),
             "le": pd.Series(np.array([1, 2], dtype="<m8[s]")),
             "ms": pd.Series(np.array([1, 2], dtype="<m8[ms]")),
         }
-    )
+    ).astype({"be": ">m8[s]"})
     assert df["be"].dtype.byteorder == ">"
 
     # a string spec is byteorder-agnostic on both sides

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1215,7 +1215,7 @@ class TestSeriesConstructors:
 
     @pytest.mark.parametrize("unit", ["D", "h", "s", "ms", "us", "ns", "ps", "fs"])
     def test_constructor_timedelta64_bigendian(self, unit):
-        # GH#68321 the byteswap also turned NaT into an ordinary duration; ps/fs
+        # GH#68342 the byteswap also turned NaT into an ordinary duration; ps/fs
         #  are load-bearing, only the finer->coarser cast views i8 unswapped
         arr = np.array([1000, "NaT"], dtype=f">m8[{unit}]")
 

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -1213,6 +1213,19 @@ class TestSeriesConstructors:
         assert expected.dtype == "M8[ms]"
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("unit", ["D", "h", "s", "ms", "us", "ns", "ps", "fs"])
+    def test_constructor_timedelta64_bigendian(self, unit):
+        # GH#68321 the byteswap also turned NaT into an ordinary duration; ps/fs
+        #  are load-bearing, only the finer->coarser cast views i8 unswapped
+        arr = np.array([1000, "NaT"], dtype=f">m8[{unit}]")
+
+        result = pd.Series(arr)
+        expected = pd.Series(arr.astype(f"<m8[{unit}]"))
+        assert result.dtype.byteorder != ">"
+        assert result.isna().tolist() == [False, True]
+        tm.assert_series_equal(result, expected)
+        tm.assert_index_equal(pd.to_timedelta(arr), pd.Index(expected))
+
     @pytest.mark.parametrize("interval_constructor", [pd.IntervalIndex, IntervalArray])
     def test_construction_interval(self, interval_constructor):
         # construction from interval & array of intervals


### PR DESCRIPTION
Constructing from a big-endian `timedelta64` numpy array reinterpreted every value with the wrong endianness:

```python
arr = np.array([1, 2], dtype=">m8[s]")          # 1 second, 2 seconds
pd.Series(arr).tolist()
# [Timedelta("833999930994 days 12:52:16"), Timedelta("1667999861989 days 01:44:32")]
```

`NaT` was hit too, and more damagingly: `iNaT` byteswaps to 128, so a `NaT` silently became a 2m08s duration that passed `isna()`.

`_construct_from_dt64_naive` already normalizes non-native `datetime64` input (GH-29684, GH-30976); `sequence_to_td64ns` simply had no equivalent, which is the whole difference. This adds it, so `Series`/`DataFrame`/`TimedeltaIndex` construction and `to_timedelta` all normalize. Reproduces on 3.0.5, so it is not a regression.

One wrinkle worth flagging for review: the swap has to go **before** the unsupported-unit `astype_overflowsafe` cast, not after it the way the `datetime64` site does. That cast's finer→coarser branch takes its own unswapped `i8` view, so copying the `datetime64` ordering verbatim still leaves `>m8[ps|fs|as]` broken. The test parametrizes over `ps`/`fs` to pin this; `D`/`h` do not pin it, since they convert the other direction and already reach the existing swap in `np_datetime.pyx`. The `datetime64` site has the same latent hole for sub-nanosecond units — filed separately rather than widened into this PR.

`test_select_dtypes_td64_non_native_column` (added in GH-67973) keeps its non-native column, rebuilt on a unit-changing `astype`, which is the only remaining public route to one now that construction normalizes.

Draft: the source fix and its test are settled, but I would like a second opinion on whether normalizing here is right at all, given pandas deliberately *preserves* non-native byteorder for numeric dtypes (GH-43042, `test_constructor_preserves_byteorder`). This follows the `datetime64` precedent instead, which seems correct for a dtype whose values are read through an `i8` view, but it is an inconsistency worth a maintainer's eye.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and ran a multi-round blind review of the branch; all findings were verified against the source before being acted on.