### PR TITLE
BUG: IntervalIndex set ops and astype with RangeIndex raising TypeError

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -550,6 +550,7 @@ Performance improvements
 
 Bug fixes
 ~~~~~~~~~
+- Fixed bug in :meth:`Index.union`, :meth:`Index.symmetric_difference` and other set operations of :class:`IntervalIndex` raising ``TypeError`` when passed an empty :class:`RangeIndex`; constructing an :class:`IntervalIndex` (or calling ``astype`` to interval dtype) from a :class:`RangeIndex` also no longer raises a confusing ``TypeError`` (:issue:`68343`)
 - Fixed bug in :class:`Index` repr where attributes were not wrapped to respect ``display.width`` (:issue:`11552`)
 - Fixed bug in :class:`Series` where empty frozensets were formatted incorrectly (:issue:`66192`)
 - Fixed bug in :func:`testing.assert_frame_equal` incorrectly raising when equivalent :class:`MultiIndex` column labels contained missing values (:issue:`54521`)

--- a/pandas/core/arrays/interval.py
+++ b/pandas/core/arrays/interval.py
@@ -65,6 +65,7 @@ from pandas.core.dtypes.generic import (
     ABCDatetimeIndex,
     ABCIntervalIndex,
     ABCPeriodIndex,
+    ABCRangeIndex,
 )
 from pandas.core.dtypes.missing import (
     is_valid_na_for_dtype,
@@ -1941,6 +1942,11 @@ def _maybe_convert_platform_interval(values) -> ArrayLike:
         # empty lists/tuples get object dtype by default, but this is
         # prohibited for IntervalArray, so coerce to integer instead
         return np.array([], dtype=np.int64)
+    elif isinstance(values, ABCRangeIndex):
+        # GH#68343 RangeIndex passes the hasattr(values, "dtype") checks below
+        # but is not an ndarray, which raises a confusing TypeError from
+        # intervals_to_interval_bounds; ensure we get an ndarray instead
+        values = np.asarray(values)
     elif not is_list_like(values) or isinstance(values, ABCDataFrame):
         # This will raise later
         return values

--- a/pandas/tests/arrays/interval/test_astype.py
+++ b/pandas/tests/arrays/interval/test_astype.py
@@ -4,6 +4,21 @@ import pandas as pd
 import pandas._testing as tm
 
 
+class TestAstypeFromRangeIndex:
+    def test_astype_interval_empty_rangeindex(self):
+        # GH#68343
+        rng = pd.RangeIndex(0)
+        result = rng.astype("interval[int64, right]")
+        expected = pd.IntervalIndex([])
+        tm.assert_index_equal(result, expected)
+
+    def test_astype_interval_nonempty_rangeindex_raises(self):
+        # GH#68343: integer values are not intervals, matching Index([2, 3])
+        rng = pd.RangeIndex(2, 4)
+        with pytest.raises(TypeError, match="is not an interval"):
+            rng.astype("interval[int64, right]")
+
+
 class TestAstype:
     @pytest.mark.parametrize("ordered", [True, False])
     def test_astype_categorical_retains_ordered(self, ordered):

--- a/pandas/tests/indexes/interval/test_setops.py
+++ b/pandas/tests/indexes/interval/test_setops.py
@@ -203,3 +203,27 @@ class TestIntervalIndex:
             expected = index
         result = set_op(other, sort=sort)
         tm.assert_index_equal(result, expected)
+
+
+class TestSetopEmptyRangeIndex:
+    def test_union_empty_rangeindex(self, closed, sort):
+        # GH#68343
+        index = monotonic_index(0, 5, closed=closed)
+        other = pd.RangeIndex(0)
+
+        result = index.union(other, sort=sort)
+        tm.assert_index_equal(result, index)
+
+        result = other.union(index, sort=sort)
+        tm.assert_index_equal(result, index)
+
+    def test_symmetric_difference_empty_rangeindex(self, closed, sort):
+        # GH#68343
+        index = monotonic_index(0, 5, closed=closed)
+        other = pd.RangeIndex(0)
+
+        result = index.symmetric_difference(other, sort=sort)
+        tm.assert_index_equal(result, index)
+
+        result = other.symmetric_difference(index, sort=sort)
+        tm.assert_index_equal(result, index)


### PR DESCRIPTION
- [x] closes #68343
- [x] Tests added and passed
- [x] All code checks passed: `ruff check` and `ruff format --check` clean on all changed files
- [x] Added an entry in the latest `doc/source/whatsnew/v3.1.0.rst`

## What this fixes

Set operations between an ``IntervalIndex`` and a ``RangeIndex`` raised a confusing Cython ``TypeError`` when the ``RangeIndex`` was empty:

```python
iv = pd.IntervalIndex.from_breaks([0, 2, 4])
iv.union(pd.RangeIndex(0))
# TypeError: Argument 'intervals' has incorrect type (expected numpy.ndarray, got RangeIndex)
```

Every other empty array-like (``Index([], dtype="int64")``, ``np.array([])``, empty ``Series``, ``[]``) worked. The mirror (``pd.RangeIndex(0).union(iv)``), ``symmetric_difference``, and the direct constructors (``pd.IntervalIndex(pd.RangeIndex(...))``, ``IntervalArray(...)``, ``RangeIndex.astype("interval")``) hit the same error for empty and non-empty ``RangeIndex`` alike.

## Root cause

``_maybe_convert_platform_interval`` only coerces ``values`` to an ndarray when it lacks a ``dtype`` attribute; ``RangeIndex`` has one, so it reaches the Cython ``intervals_to_interval_bounds`` as a non-ndarray. In set ops, an empty ``RangeIndex`` specifically triggers this because ``_find_common_type_compat`` resolves the common dtype to ``interval[int64, right]`` (an empty ``Index`` resolves to ``object`` instead), so ``other.astype(interval_dtype)`` crashes before the empty-``other`` short-circuit.

## Fix

Convert ``RangeIndex`` to an ndarray in ``_maybe_convert_platform_interval``, the same special-casing place that already handles empty lists (GH19016). After the fix:

- ``iv.union(pd.RangeIndex(0))`` / ``iv.symmetric_difference(pd.RangeIndex(0))`` / ``pd.RangeIndex(0).union(iv)`` return the original interval index
- ``pd.IntervalIndex(pd.RangeIndex(0))`` and ``RangeIndex(0).astype("interval[int64, right]")`` build an empty ``IntervalIndex``
- ``pd.IntervalIndex(pd.RangeIndex(2, 4))`` and ``RangeIndex(2, 4).astype("interval[int64, right]")`` raise the regular ``TypeError: ... is not an interval`` message, consistent with ``pd.IntervalIndex([2, 3])``

## Verification

Run against the ``cb13b0e9a4`` build (main at the time of the report):

- ``pandas/tests/indexes/interval/`` + ``pandas/tests/arrays/interval/``: **1992 passed, 26 skipped, 2 xfailed**
- ``pandas/tests/indexes/ranges/`` + ``pandas/tests/indexes/test_setops.py``: **3739 passed, 28 skipped, 1 xfailed**
- New regression tests: 18 passed (parametrized over ``closed`` and ``sort``)

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>

_(Reopened as a new PR - the earlier #68344 was auto-closed by the issue-assignment bot before `/take` went through; branch and content are identical.)_

