### PR TITLE
BUG: preserve NaN when constructing Arrow string arrays

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1041,8 +1041,8 @@ Sparse
 
 ExtensionArray
 ^^^^^^^^^^^^^^
-- Bug in :func:`array` raising when constructing string or binary :class:`ArrowDtype` arrays from sequences containing ``NaN`` with ``future.distinguish_nan_and_na=False`` (:issue:`64578`)
 - :func:`api.extensions.register_extension_dtype` now raises an informative ``TypeError`` at registration when the :class:`~pandas.api.extensions.ExtensionDtype` subclass does not define a string ``name`` attribute, instead of a bare ``AssertionError`` when the dtype is later used (:issue:`46093`)
+- Bug in :func:`array` raising when constructing string or binary :class:`ArrowDtype` arrays from sequences containing ``NaN`` with ``future.distinguish_nan_and_na=False`` (:issue:`64578`)
 - Bug in :meth:`DataFrame.any` and :meth:`DataFrame.all` with ``skipna=False`` not propagating ``pd.NA`` on numpy-nullable columns (``boolean``, ``Int*``, ``UInt*``, ``Float*``); ``axis=0`` raised ``ValueError`` and ``axis=1`` returned a concrete ``True``/``False`` (:issue:`65710`)
 - Bug in comparisons between a PyArrow-backed :class:`Series` or :class:`Index` and a :py:class:`range` returning all-``False`` for ``==`` and raising ``TypeError`` for ``<``/``>``, instead of comparing elementwise like the NumPy-backed and nullable equivalents; mismatched lengths now raise ``ValueError`` (:issue:`67979`)
 - Bug in numpy ufuncs like :func:`numpy.isnan` raising ``TypeError`` on :class:`Series` or :class:`Index` backed by PyArrow dtypes when ``future.distinguish_nan_and_na`` is ``True`` (:issue:`62506`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1041,6 +1041,7 @@ Sparse
 
 ExtensionArray
 ^^^^^^^^^^^^^^
+- Bug in :func:`array` raising when constructing string or binary :class:`ArrowDtype` arrays from sequences containing ``NaN`` with ``future.distinguish_nan_and_na=False`` (:issue:`64578`)
 - :func:`api.extensions.register_extension_dtype` now raises an informative ``TypeError`` at registration when the :class:`~pandas.api.extensions.ExtensionDtype` subclass does not define a string ``name`` attribute, instead of a bare ``AssertionError`` when the dtype is later used (:issue:`46093`)
 - Bug in :meth:`DataFrame.any` and :meth:`DataFrame.all` with ``skipna=False`` not propagating ``pd.NA`` on numpy-nullable columns (``boolean``, ``Int*``, ``UInt*``, ``Float*``); ``axis=0`` raised ``ValueError`` and ``axis=1`` returned a concrete ``True``/``False`` (:issue:`65710`)
 - Bug in comparisons between a PyArrow-backed :class:`Series` or :class:`Index` and a :py:class:`range` returning all-``False`` for ``==`` and raising ``TypeError`` for ``<``/``>``, instead of comparing elementwise like the NumPy-backed and nullable equivalents; mismatched lengths now raise ``ValueError`` (:issue:`67979`)

--- a/pandas/core/arrays/arrow/array.py
+++ b/pandas/core/arrays/arrow/array.py
@@ -793,6 +793,9 @@ class ArrowExtensionArray(
             if is_nan_na():
                 try:
                     arr_value = np.asarray(value)
+                    if arr_value.dtype.kind in "US":
+                        # GH#64578: string coercion can hide missing values.
+                        arr_value = np.asarray(value, dtype=object)
                     if arr_value.ndim > 1:
                         # e.g. test_fixed_size_list we have list data.  ndim > 1
                         #  means there were no scalar (NA) entries.

--- a/pandas/tests/arrays/test_arrow.py
+++ b/pandas/tests/arrays/test_arrow.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+import pandas as pd
+import pandas._testing as tm
+
+pa = pytest.importorskip("pyarrow")
+
+
+@pytest.mark.parametrize(
+    "pa_type", [pa.string(), pa.large_string(), pa.binary(), pa.large_binary()]
+)
+@pytest.mark.parametrize("box", [list, tuple])
+def test_string_sequence_with_nan(pa_type, box, using_nan_is_na):
+    # GH#64578
+    is_binary = pa.types.is_binary(pa_type) or pa.types.is_large_binary(pa_type)
+    text = b"nan" if is_binary else "nan"
+    values = box([text, np.nan])
+    dtype = pd.ArrowDtype(pa_type)
+
+    if not using_nan_is_na:
+        msg = "Expected bytes, got a 'float' object"
+        with pytest.raises(pa.ArrowTypeError, match=msg):
+            pd.array(values, dtype=dtype)
+        return
+
+    result = pd.array(values, dtype=dtype)
+    expected = pd.array([text, None], dtype=dtype)
+    tm.assert_extension_array_equal(result, expected)


### PR DESCRIPTION
I have reviewed the changes and believe this fix is reasonably reliable.

Closes #64578.

AI-assisted technical and validation record:
> The patch preserves missing values when NumPy infers a string/bytes dtype while building the Arrow array mask. It follows the conditional-conversion suggestion from @jbrockmendel's review of @tinezivic's previous PR #65307; that fix direction is prior work.
>
> New regression coverage checks string/large_string/binary/large_binary, list/tuple inputs, both NaN/NA modes, and the literal text "nan". On upstream cb13b0e9a4, 8 cases failed and 8 passed; with this patch all 16 passed. Related Arrow tests: 599 passed, 1 xfailed. Ruff 0.16.6 check/format and git diff --check passed. The full pandas suite, full pre-commit suite, and documentation build were not run.
>
> Local microbenchmark of _box_pa_array (1,000 elements; median of 7 rounds, 300 calls per round): numeric ndarray/list ratios were 1.00/0.99; a pure string list was 1.39 (47.2 to 65.5 microseconds). This is a localized tradeoff, not a whole-application benchmark.

AI assistance: Codex assisted with investigation, code, tests and validation. Tool/model: Codex, GPT-6 Astra (gpt-6-astra), medium reasoning effort. The opening statement was translated from my Chinese review statement with Codex.

- [x] closes #64578
- [x] Tests added and passed.
- [ ] All code checks passed (only the checks listed above have been run).
- [x] Added an entry in doc/source/whatsnew/v3.1.0.rst.
- [ ] I have reviewed and followed all contribution guidelines.
- [ ] I did not use AI to develop this pull request.
- [x] I used AI to develop this pull request, with AGENTS.md guidance and personal review as disclosed above.
