### PR TITLE
BUG: Preserve index order when sorting no MultiIndex levels

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -804,6 +804,7 @@ MultiIndex
 ^^^^^^^^^^
 - Bug in :class:`MultiIndex` where pickling a :class:`DataFrame` with a ``datetime64[ns]`` level raised ``NotImplementedError`` (:issue:`63078`)
 - Bug in :meth:`DataFrame.loc` with a :class:`MultiIndex` where using a tuple indexer with a scalar and a list (e.g., ``(scalar, list)``) did not drop the scalar-indexed level (:issue:`18631`)
+- Bug in :meth:`DataFrame.sort_index`, :meth:`Series.sort_index`, and :meth:`MultiIndex.sortlevel` raising ``IndexError`` with ``level=[]`` and ``sort_remaining=False`` instead of preserving the original order (:issue:`25831`)
 - Bug in :meth:`MultiIndex.get_loc` where looking up a tuple key containing a scalar inside an :class:`IntervalIndex` level with overlapping intervals raised ``KeyError`` or returned incorrect results (:issue:`27456`)
 - Bug in :meth:`MultiIndex.set_levels` and :meth:`MultiIndex.set_codes` raising ``IndexError`` instead of a clear ``ValueError`` when passing an empty sequence with ``level=None`` or a list-like ``level`` (:issue:`16147`)
 - Bug in :meth:`MultiIndex.sortlevel` not raising ``TypeError`` when sorting a level with incomparable types (e.g., ``Timestamp`` and ``str``) (:issue:`21136`)

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3330,6 +3330,8 @@ class MultiIndex(Index):
             sortorder = level[0]
 
         if not codes:
+            if na_position not in ["first", "last"]:
+                raise ValueError(f"invalid na_position: {na_position}")
             return self.copy(), np.arange(len(self), dtype=np.intp)
 
         indexer = lexsort_indexer(

--- a/pandas/core/indexes/multi.py
+++ b/pandas/core/indexes/multi.py
@@ -3326,8 +3326,11 @@ class MultiIndex(Index):
             codes.extend(
                 [self.codes[lev] for lev in range(len(self.levels)) if lev not in level]
             )
-        else:
+        elif level:
             sortorder = level[0]
+
+        if not codes:
+            return self.copy(), np.arange(len(self), dtype=np.intp)
 
         indexer = lexsort_indexer(
             codes, orders=ascending, na_position=na_position, codes_given=True

--- a/pandas/tests/frame/methods/test_sort_index.py
+++ b/pandas/tests/frame/methods/test_sort_index.py
@@ -813,6 +813,28 @@ class TestDataFrameSortIndex:
 
         tm.assert_frame_equal(result, expected)
 
+    @pytest.mark.parametrize("sort_remaining", [True, False])
+    @pytest.mark.parametrize("axis", [0, 1])
+    def test_sort_index_empty_level(self, sort_remaining, ascending, axis):
+        # GH#25831
+        df = pd.DataFrame(
+            {"c": [0, 0, 1]},
+            index=pd.MultiIndex.from_tuples([(0, 3), (2, 0), (1, 2)], names=["a", "b"]),
+        )
+        if sort_remaining:
+            positions = [0, 2, 1] if ascending else [1, 2, 0]
+            expected = df.iloc[positions]
+        else:
+            expected = df.copy()
+        if axis == 1:
+            df = df.T
+            expected = expected.T
+
+        result = df.sort_index(
+            level=[], axis=axis, ascending=ascending, sort_remaining=sort_remaining
+        )
+        tm.assert_frame_equal(result, expected)
+
     def test_sort_index_level_on_range_index(self):
         # GH#64383: sort_index with level= on a RangeIndex raised AssertionError
         df = pd.DataFrame({"a": [1, 2, 3]})

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -57,6 +57,20 @@ def test_sortlevel_empty_level(sort_remaining, empty, ascending):
     tm.assert_numpy_array_equal(indexer, expected_indexer)
 
 
+@pytest.mark.parametrize("sort_remaining", [True, False])
+@pytest.mark.parametrize("ascending", [True, False, []])
+def test_sortlevel_empty_level_invalid_na_position(sort_remaining, ascending):
+    # GH#25831
+    index = pd.MultiIndex.from_tuples([(0, 3), (2, 0), (1, 2)])
+    with pytest.raises(ValueError, match="invalid na_position: invalid"):
+        index.sortlevel(
+            level=[],
+            ascending=ascending,
+            sort_remaining=sort_remaining,
+            na_position="invalid",
+        )
+
+
 def test_sortlevel_deterministic():
     tuples = [
         ("bar", "one"),

--- a/pandas/tests/indexes/multi/test_sorting.py
+++ b/pandas/tests/indexes/multi/test_sorting.py
@@ -36,6 +36,27 @@ def test_sortlevel_not_sort_remaining():
     assert sorted_idx.equals(mi)
 
 
+@pytest.mark.parametrize("sort_remaining", [True, False])
+@pytest.mark.parametrize("empty", [True, False])
+def test_sortlevel_empty_level(sort_remaining, empty, ascending):
+    # GH#25831
+    index = pd.MultiIndex.from_tuples([(0, 3), (2, 0), (1, 2)], names=["a", "b"])
+    if empty:
+        index = index[:0]
+
+    result, indexer = index.sortlevel(
+        level=[], ascending=ascending, sort_remaining=sort_remaining
+    )
+
+    if sort_remaining and not empty:
+        positions = [0, 2, 1] if ascending else [1, 2, 0]
+        expected_indexer = np.array(positions, dtype=np.intp)
+    else:
+        expected_indexer = np.arange(len(index), dtype=np.intp)
+    tm.assert_index_equal(result, index.take(expected_indexer))
+    tm.assert_numpy_array_equal(indexer, expected_indexer)
+
+
 def test_sortlevel_deterministic():
     tuples = [
         ("bar", "one"),


### PR DESCRIPTION
Preserve the original order when `level=[]` and `sort_remaining=False`, instead of raising `IndexError`. Return an identity indexer when no sorting keys remain; `sort_remaining=True` and `level=0` retain their existing behavior. Add regressions for both directions, both DataFrame axes, and empty MultiIndexes.

Validation: the new regression tests gave 8 expected failures and 8 passes before the fix, then 16 passes afterward. The three affected sorting test modules plus 25 local acceptance cases passed (185 tests total). All standard pre-commit hooks passed for the four changed files. The full pandas suite, manual type-check hooks, and documentation build were not run.

- [x] closes #25831
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions. (No new production arguments or methods.)
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
