### PR TITLE
BUG: respect explicit na_rep for missing values in DataFrame.to_html

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -813,7 +813,7 @@ MultiIndex
 
 I/O
 ^^^
-- Bug in :meth:`DataFrame.to_html` ignoring an explicitly provided ``na_rep`` for ``pd.NA`` values (:issue:`33950`)
+- Bug in :meth:`DataFrame.to_html` ignoring an explicitly provided ``na_rep`` for some missing values (:issue:`33950`)
 - :func:`read_csv` and :func:`read_table` now raise an informative ``ValueError`` for ``sep="\r"`` or ``delimiter="\r"``, which were silently mis-parsed into a frame of one column plus all-NaN padding, matching the error already raised for ``"\n"``; the error message no longer misattributes the failure to the ``python`` engine (:issue:`43528`, :issue:`51801`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``EmptyDataError`` (matching the ``c`` and ``python`` engines) instead of a cryptic ``ParserError`` reporting ``Empty CSV file or block`` when no columns can be parsed from the input (:issue:`66065`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``ValueError`` for the unsupported ``na_filter=False`` instead of silently ignoring it (:issue:`66053`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -813,6 +813,7 @@ MultiIndex
 
 I/O
 ^^^
+- Bug in :meth:`DataFrame.to_html` ignoring an explicitly provided ``na_rep`` for ``pd.NA`` values (:issue:`33950`)
 - :func:`read_csv` and :func:`read_table` now raise an informative ``ValueError`` for ``sep="\r"`` or ``delimiter="\r"``, which were silently mis-parsed into a frame of one column plus all-NaN padding, matching the error already raised for ``"\n"``; the error message no longer misattributes the failure to the ``python`` engine (:issue:`43528`, :issue:`51801`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``EmptyDataError`` (matching the ``c`` and ``python`` engines) instead of a cryptic ``ParserError`` reporting ``Empty CSV file or block`` when no columns can be parsed from the input (:issue:`66065`)
 - :func:`read_csv` with ``engine="pyarrow"`` now raises ``ValueError`` for the unsupported ``na_filter=False`` instead of silently ignoring it (:issue:`66053`)

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3228,8 +3228,8 @@ class DataFrame(NDFrame, OpsMixin):
         index : bool, optional, default True
             Whether to print index (row) labels.
         na_rep : str, optional, default 'NaN'
-            String representation of ``NaN`` and ``pd.NA`` to use.
-            If not specified, ``pd.NA`` is displayed as ``<NA>``.
+            String representation of missing values to use. If not specified,
+            each type of missing value uses its default representation.
         formatters : list, tuple or dict of one-param. functions, optional
             Formatter functions to apply to columns' elements by position or
             name.
@@ -3379,7 +3379,7 @@ class DataFrame(NDFrame, OpsMixin):
             columns=columns,
             col_space=col_space,
             na_rep="NaN" if na_rep is lib.no_default else na_rep,
-            pd_na_rep=None if na_rep is lib.no_default else na_rep,
+            missing_rep=None if na_rep is lib.no_default else na_rep,
             header=header,
             index=index,
             formatters=formatters,

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -3188,7 +3188,7 @@ class DataFrame(NDFrame, OpsMixin):
         col_space: ColspaceArgType | None = None,
         header: bool = True,
         index: bool = True,
-        na_rep: str = "NaN",
+        na_rep: str | lib.NoDefault = lib.no_default,
         formatters: FormattersType | None = None,
         float_format: FloatFormatType | None = None,
         sparsify: bool | None = None,
@@ -3228,7 +3228,8 @@ class DataFrame(NDFrame, OpsMixin):
         index : bool, optional, default True
             Whether to print index (row) labels.
         na_rep : str, optional, default 'NaN'
-            String representation of ``NaN`` to use.
+            String representation of ``NaN`` and ``pd.NA`` to use.
+            If not specified, ``pd.NA`` is displayed as ``<NA>``.
         formatters : list, tuple or dict of one-param. functions, optional
             Formatter functions to apply to columns' elements by position or
             name.
@@ -3377,7 +3378,8 @@ class DataFrame(NDFrame, OpsMixin):
             self,
             columns=columns,
             col_space=col_space,
-            na_rep=na_rep,
+            na_rep="NaN" if na_rep is lib.no_default else na_rep,
+            pd_na_rep=None if na_rep is lib.no_default else na_rep,
             header=header,
             index=index,
             formatters=formatters,

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -418,6 +418,8 @@ class DataFrameFormatter:
         Display DataFrame dimensions (number of rows by number of columns).
     decimal : str, default '.'
         Character recognized as decimal separator, e.g. ',' in Europe.
+    pd_na_rep : str or None, default None
+        String representation of pd.NA. If None, use "<NA>".
 
     Returns
     -------
@@ -446,6 +448,7 @@ class DataFrameFormatter:
         decimal: str = ".",
         bold_rows: bool = False,
         escape: bool = True,
+        pd_na_rep: str | None = None,
     ) -> None:
         self.frame = frame
         self.columns = self._initialize_columns(columns)
@@ -453,6 +456,7 @@ class DataFrameFormatter:
         self.header = header
         self.index = index
         self.na_rep = na_rep
+        self.pd_na_rep = pd_na_rep
         self.formatters = self._initialize_formatters(formatters)
         self.justify = self._initialize_justify(justify)
         self.float_format = self._validate_float_format(float_format)
@@ -759,6 +763,7 @@ class DataFrameFormatter:
             formatter,
             float_format=self.float_format,
             na_rep=self.na_rep,
+            pd_na_rep=self.pd_na_rep,
             space=self.col_space.get(frame.columns[i]),
             decimal=self.decimal,
             leading_space=self.index,
@@ -1102,6 +1107,7 @@ def format_array(
     leading_space: bool | None = True,
     quoting: int | None = None,
     fallback_formatter: Callable | None = None,
+    pd_na_rep: str | None = None,
 ) -> list[str]:
     """
     Format an array for printing.
@@ -1125,6 +1131,8 @@ def format_array(
         (e.g. IntervalIndex._get_values_for_csv), we don't want the
         leading space since it should be left-aligned.
     fallback_formatter
+    pd_na_rep : str or None, default None
+        String representation of pd.NA. If None, use "<NA>".
 
     Returns
     -------
@@ -1163,6 +1171,7 @@ def format_array(
         values,
         digits=digits,
         na_rep=na_rep,
+        pd_na_rep=pd_na_rep,
         float_format=float_format,
         formatter=formatter,
         space=space,
@@ -1191,10 +1200,12 @@ class _GenericArrayFormatter:
         fixed_width: bool = True,
         leading_space: bool | None = True,
         fallback_formatter: Callable | None = None,
+        pd_na_rep: str | None = None,
     ) -> None:
         self.values = values
         self.digits = digits
         self.na_rep = na_rep
+        self.pd_na_rep = pd_na_rep
         self.space = space
         self.formatter = formatter
         self.float_format = float_format
@@ -1238,7 +1249,7 @@ class _GenericArrayFormatter:
                 if x is None:
                     return "None"
                 elif x is NA:
-                    return str(NA)
+                    return str(NA) if self.pd_na_rep is None else self.pd_na_rep
                 elif x is NaT or isinstance(x, (np.datetime64, np.timedelta64)):
                     return "NaT"
                 return self.na_rep
@@ -1544,6 +1555,7 @@ class _ExtensionArrayFormatter(_GenericArrayFormatter):
             float_format=self.float_format,
             na_rep=self.na_rep,
             digits=self.digits,
+            pd_na_rep=self.pd_na_rep,
             space=self.space,
             justify=self.justify,
             decimal=self.decimal,

--- a/pandas/io/formats/format.py
+++ b/pandas/io/formats/format.py
@@ -418,8 +418,9 @@ class DataFrameFormatter:
         Display DataFrame dimensions (number of rows by number of columns).
     decimal : str, default '.'
         Character recognized as decimal separator, e.g. ',' in Europe.
-    pd_na_rep : str or None, default None
-        String representation of pd.NA. If None, use "<NA>".
+    missing_rep : str or None, default None
+        String representation of missing values. If None, use the default
+        representation for each missing value type.
 
     Returns
     -------
@@ -448,7 +449,7 @@ class DataFrameFormatter:
         decimal: str = ".",
         bold_rows: bool = False,
         escape: bool = True,
-        pd_na_rep: str | None = None,
+        missing_rep: str | None = None,
     ) -> None:
         self.frame = frame
         self.columns = self._initialize_columns(columns)
@@ -456,7 +457,7 @@ class DataFrameFormatter:
         self.header = header
         self.index = index
         self.na_rep = na_rep
-        self.pd_na_rep = pd_na_rep
+        self.missing_rep = missing_rep
         self.formatters = self._initialize_formatters(formatters)
         self.justify = self._initialize_justify(justify)
         self.float_format = self._validate_float_format(float_format)
@@ -763,7 +764,7 @@ class DataFrameFormatter:
             formatter,
             float_format=self.float_format,
             na_rep=self.na_rep,
-            pd_na_rep=self.pd_na_rep,
+            missing_rep=self.missing_rep,
             space=self.col_space.get(frame.columns[i]),
             decimal=self.decimal,
             leading_space=self.index,
@@ -1107,7 +1108,7 @@ def format_array(
     leading_space: bool | None = True,
     quoting: int | None = None,
     fallback_formatter: Callable | None = None,
-    pd_na_rep: str | None = None,
+    missing_rep: str | None = None,
 ) -> list[str]:
     """
     Format an array for printing.
@@ -1131,8 +1132,9 @@ def format_array(
         (e.g. IntervalIndex._get_values_for_csv), we don't want the
         leading space since it should be left-aligned.
     fallback_formatter
-    pd_na_rep : str or None, default None
-        String representation of pd.NA. If None, use "<NA>".
+    missing_rep : str or None, default None
+        String representation of missing values. If None, use the default
+        representation for each missing value type.
 
     Returns
     -------
@@ -1142,12 +1144,12 @@ def format_array(
     if lib.is_np_dtype(values.dtype, "M") or isinstance(values.dtype, DatetimeTZDtype):
         fmt_klass = _Datetime64Formatter
         values = cast("DatetimeArray", values)
-        if na_rep == "NaN":
+        if na_rep == "NaN" and missing_rep is None:
             na_rep = "NaT"
     elif lib.is_np_dtype(values.dtype, "m"):
         fmt_klass = _Timedelta64Formatter
         values = cast("TimedeltaArray", values)
-        if na_rep == "NaN":
+        if na_rep == "NaN" and missing_rep is None:
             na_rep = "NaT"
     elif isinstance(values.dtype, ExtensionDtype):
         fmt_klass = _ExtensionArrayFormatter
@@ -1171,7 +1173,7 @@ def format_array(
         values,
         digits=digits,
         na_rep=na_rep,
-        pd_na_rep=pd_na_rep,
+        missing_rep=missing_rep,
         float_format=float_format,
         formatter=formatter,
         space=space,
@@ -1200,12 +1202,12 @@ class _GenericArrayFormatter:
         fixed_width: bool = True,
         leading_space: bool | None = True,
         fallback_formatter: Callable | None = None,
-        pd_na_rep: str | None = None,
+        missing_rep: str | None = None,
     ) -> None:
         self.values = values
         self.digits = digits
         self.na_rep = na_rep
-        self.pd_na_rep = pd_na_rep
+        self.missing_rep = missing_rep
         self.space = space
         self.formatter = formatter
         self.float_format = float_format
@@ -1246,10 +1248,12 @@ class _GenericArrayFormatter:
 
         def _format(x):
             if self.na_rep is not None and is_scalar(x) and isna(x):
-                if x is None:
+                if self.missing_rep is not None:
+                    return self.missing_rep
+                elif x is None:
                     return "None"
                 elif x is NA:
-                    return str(NA) if self.pd_na_rep is None else self.pd_na_rep
+                    return str(NA)
                 elif x is NaT or isinstance(x, (np.datetime64, np.timedelta64)):
                     return "NaT"
                 return self.na_rep
@@ -1555,7 +1559,7 @@ class _ExtensionArrayFormatter(_GenericArrayFormatter):
             float_format=self.float_format,
             na_rep=self.na_rep,
             digits=self.digits,
-            pd_na_rep=self.pd_na_rep,
+            missing_rep=self.missing_rep,
             space=self.space,
             justify=self.justify,
             decimal=self.decimal,

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1091,6 +1091,65 @@ def test_to_html_na_rep_pd_na(dtype, na_rep, notebook):
     assert re.findall(r"<td>(.*?)</td>", result) == expected
 
 
+@pytest.mark.parametrize("na_rep", ["zzzz", "NaN", ""])
+@pytest.mark.parametrize("notebook", [True, False])
+def test_to_html_na_rep_missing_scalars(na_rep, notebook):
+    # GH#33950
+    df = pd.DataFrame(
+        {"a": [float("nan"), pd.NA, pd.NaT, None]},
+        dtype=object,
+    )
+
+    result = df.to_html(na_rep=na_rep, notebook=notebook)
+
+    assert re.findall(r"<td>(.*?)</td>", result) == [na_rep] * 4
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "datetime64[ns]",
+        "timedelta64[ns]",
+        "datetime64[ns, UTC]",
+        "timestamp[ns][pyarrow]",
+    ],
+)
+@pytest.mark.parametrize("na_rep", ["zzzz", "NaN", ""])
+def test_to_html_na_rep_temporal_missing(dtype, na_rep):
+    if "pyarrow" in dtype:
+        pytest.importorskip("pyarrow")
+    df = pd.DataFrame({"a": pd.Series([pd.NaT], dtype=dtype)})
+
+    result = df.to_html(na_rep=na_rep)
+
+    assert re.findall(r"<td>(.*?)</td>", result) == [na_rep]
+
+
+@pytest.mark.parametrize("notebook", [True, False])
+def test_to_html_missing_scalars_default(notebook):
+    df = pd.DataFrame(
+        {"a": [float("nan"), pd.NA, pd.NaT, None]},
+        dtype=object,
+    )
+
+    result = df.to_html(notebook=notebook)
+
+    expected = ["NaN", "&lt;NA&gt;", "NaT", "None"]
+    assert re.findall(r"<td>(.*?)</td>", result) == expected
+
+
+def test_repr_html_missing_scalars_default():
+    df = pd.DataFrame(
+        {"a": [float("nan"), pd.NA, pd.NaT, None]},
+        dtype=object,
+    )
+
+    result = df._repr_html_()
+
+    expected = ["NaN", "&lt;NA&gt;", "NaT", "None"]
+    assert re.findall(r"<td>(.*?)</td>", result) == expected
+
+
 @pytest.mark.parametrize(
     "dtype",
     [
@@ -1114,17 +1173,37 @@ def test_to_html_pd_na_default(dtype, notebook):
 
 
 @pytest.mark.parametrize("escape_html", [True, False])
-@pytest.mark.parametrize("formatter", [None, lambda x: "<NA>"])
+@pytest.mark.parametrize("use_formatter", [True, False])
+@pytest.mark.parametrize("rendered_text", ["<NA>", "NaT", "None", "NaN"])
 @pytest.mark.parametrize("literal_first", [True, False])
 @pytest.mark.parametrize("na_rep", ["zzzz", "缺💡<&>"])
-def test_to_html_na_rep_pd_na_literal_and_formatter(
-    escape_html, formatter, literal_first, na_rep
+@pytest.mark.parametrize(
+    "missing_value",
+    [
+        float("nan"),
+        pd.NA,
+        pd.NaT,
+        np.datetime64("NaT", "ns"),
+        np.timedelta64("NaT", "ns"),
+        None,
+    ],
+    ids=["nan", "pd_na", "pd_nat", "np_datetime_nat", "np_timedelta_nat", "none"],
+)
+def test_to_html_na_rep_literal_and_formatter(
+    escape_html, use_formatter, rendered_text, literal_first, na_rep, missing_value
 ):
     # GH#33950: replace the missing scalar, not text or formatter output.
-    first, last = ("<NA>", "value") if literal_first else ("value", "<NA>")
-    df = pd.DataFrame({"a": [first, pd.NA, last]}, dtype=object)
+    formatter = (lambda value: rendered_text) if use_formatter else None
+    first, last = (
+        (rendered_text, "value") if literal_first else ("value", rendered_text)
+    )
+    df = pd.DataFrame({"a": [first, missing_value, last]}, dtype=object)
     result = df.to_html(na_rep=na_rep, formatters={"a": formatter}, escape=escape_html)
-    expected = ["<NA>", na_rep, "<NA>"] if formatter else [first, na_rep, last]
+    expected = (
+        [rendered_text, na_rep, rendered_text]
+        if use_formatter
+        else [first, na_rep, last]
+    )
     if escape_html:
         expected = [escape(value, quote=False) for value in expected]
     assert re.findall(r"<td>(.*?)</td>", result) == expected

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1071,7 +1071,7 @@ def test_to_html_multilevel(multiindex_year_month_day_dataframe_random_data):
         "int64[pyarrow]",
     ],
 )
-@pytest.mark.parametrize("na_rep", ["zzzz", "NaN", "", "<missing&>"])
+@pytest.mark.parametrize("na_rep", ["zzzz", "NaN", "", "<missing&>", "缺💡<&>"])
 @pytest.mark.parametrize("notebook", [True, False])
 def test_to_html_na_rep_pd_na(dtype, na_rep, notebook):
     # GH#33950
@@ -1081,31 +1081,53 @@ def test_to_html_na_rep_pd_na(dtype, na_rep, notebook):
     df = pd.DataFrame({"a": pd.Series(values, dtype=dtype)})
 
     result = df.to_html(na_rep=na_rep, notebook=notebook)
-    escaped = escape(na_rep, quote=False)
-    expected = df.to_html(notebook=notebook).replace(
-        "<td>&lt;NA&gt;</td>", f"<td>{escaped}</td>"
-    )
-    assert result == expected
+    if dtype == "boolean":
+        first, last = "True", "False"
+    elif dtype == "Float64":
+        first, last = "1.0", "2.0"
+    else:
+        first, last = "1", "2"
+    expected = [first, escape(na_rep, quote=False), last]
+    assert re.findall(r"<td>(.*?)</td>", result) == expected
 
 
-@pytest.mark.parametrize("dtype", ["object", "Int64", "Float64", "string", "boolean"])
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "object",
+        "Int64",
+        "Float64",
+        "string",
+        "boolean",
+        "string[pyarrow]",
+        "int64[pyarrow]",
+    ],
+)
 @pytest.mark.parametrize("notebook", [True, False])
 def test_to_html_pd_na_default(dtype, notebook):
     # GH#33950: omitting na_rep must preserve the usual pd.NA representation.
+    if "pyarrow" in dtype:
+        pytest.importorskip("pyarrow")
     df = pd.DataFrame({"a": pd.Series([pd.NA], dtype=dtype)})
     result = df.to_html(notebook=notebook)
-    assert "<td>&lt;NA&gt;</td>" in result
+    assert re.findall(r"<td>(.*?)</td>", result) == ["&lt;NA&gt;"]
 
 
 @pytest.mark.parametrize("escape_html", [True, False])
 @pytest.mark.parametrize("formatter", [None, lambda x: "<NA>"])
-def test_to_html_na_rep_pd_na_literal_and_formatter(escape_html, formatter):
+@pytest.mark.parametrize("literal_first", [True, False])
+@pytest.mark.parametrize("na_rep", ["zzzz", "缺💡<&>"])
+def test_to_html_na_rep_pd_na_literal_and_formatter(
+    escape_html, formatter, literal_first, na_rep
+):
     # GH#33950: replace the missing scalar, not text or formatter output.
-    df = pd.DataFrame({"a": [pd.NA, "<NA>", "value"]}, dtype=object)
-    result = df.to_html(na_rep="zzzz", formatters={"a": formatter}, escape=escape_html)
-    assert result.count("<td>zzzz</td>") == 1
-    expected = "&lt;NA&gt;" if escape_html else "<NA>"
-    assert result.count(f"<td>{expected}</td>") == (2 if formatter else 1)
+    first, last = ("<NA>", "value") if literal_first else ("value", "<NA>")
+    df = pd.DataFrame({"a": [first, pd.NA, last]}, dtype=object)
+    result = df.to_html(na_rep=na_rep, formatters={"a": formatter}, escape=escape_html)
+    expected = ["<NA>", na_rep, "<NA>"] if formatter else [first, na_rep, last]
+    if escape_html:
+        expected = [escape(value, quote=False) for value in expected]
+    assert re.findall(r"<td>(.*?)</td>", result) == expected
 
 
 @pytest.mark.parametrize("na_rep", ["NaN", "Ted"])

--- a/pandas/tests/io/formats/test_to_html.py
+++ b/pandas/tests/io/formats/test_to_html.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from html import escape
 from io import StringIO
 import itertools
 import re
@@ -1056,6 +1057,55 @@ def test_to_html_multilevel(multiindex_year_month_day_dataframe_random_data):
     ymd.columns.name = "foo"
     ymd.to_html()
     ymd.T.to_html()
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "object",
+        "Int64",
+        "Float64",
+        "boolean",
+        "string[python]",
+        "string[pyarrow]",
+        "int64[pyarrow]",
+    ],
+)
+@pytest.mark.parametrize("na_rep", ["zzzz", "NaN", "", "<missing&>"])
+@pytest.mark.parametrize("notebook", [True, False])
+def test_to_html_na_rep_pd_na(dtype, na_rep, notebook):
+    # GH#33950
+    if "pyarrow" in dtype:
+        pytest.importorskip("pyarrow")
+    values = [True, pd.NA, False] if dtype == "boolean" else [1, pd.NA, 2]
+    df = pd.DataFrame({"a": pd.Series(values, dtype=dtype)})
+
+    result = df.to_html(na_rep=na_rep, notebook=notebook)
+    escaped = escape(na_rep, quote=False)
+    expected = df.to_html(notebook=notebook).replace(
+        "<td>&lt;NA&gt;</td>", f"<td>{escaped}</td>"
+    )
+    assert result == expected
+
+
+@pytest.mark.parametrize("dtype", ["object", "Int64", "Float64", "string", "boolean"])
+@pytest.mark.parametrize("notebook", [True, False])
+def test_to_html_pd_na_default(dtype, notebook):
+    # GH#33950: omitting na_rep must preserve the usual pd.NA representation.
+    df = pd.DataFrame({"a": pd.Series([pd.NA], dtype=dtype)})
+    result = df.to_html(notebook=notebook)
+    assert "<td>&lt;NA&gt;</td>" in result
+
+
+@pytest.mark.parametrize("escape_html", [True, False])
+@pytest.mark.parametrize("formatter", [None, lambda x: "<NA>"])
+def test_to_html_na_rep_pd_na_literal_and_formatter(escape_html, formatter):
+    # GH#33950: replace the missing scalar, not text or formatter output.
+    df = pd.DataFrame({"a": [pd.NA, "<NA>", "value"]}, dtype=object)
+    result = df.to_html(na_rep="zzzz", formatters={"a": formatter}, escape=escape_html)
+    assert result.count("<td>zzzz</td>") == 1
+    expected = "&lt;NA&gt;" if escape_html else "<NA>"
+    assert result.count(f"<td>{expected}</td>") == (2 if formatter else 1)
 
 
 @pytest.mark.parametrize("na_rep", ["NaN", "Ted"])


### PR DESCRIPTION
Make an explicitly supplied `DataFrame.to_html(na_rep=...)` marker apply consistently to missing values, including `pd.NA`, `NaT`, and `None` in object columns and missing values in nullable, Arrow, and temporal columns. Omitting `na_rep` preserves the existing defaults. Literal strings, custom formatter output, HTML escaping, and missing axis labels retain their behavior.

`lib.no_default` distinguishes omission from explicit `"NaN"` or an empty marker; the introspection default changes.

Validation: `test_to_html.py` and `test_format.py` passed with 1062 tests and 1 skip, including 384 literal/formatter cases. Applicable pre-commit hooks passed. The full suite and wheel build were not run; standalone docstring validation was unavailable because `docutils` is missing.

- [x] closes #33950
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [x] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
