### PR TITLE
TST: unskip and tighten the pivot int32-overflow warning test

### DIFF
--- a/pandas/tests/reshape/test_pivot.py
+++ b/pandas/tests/reshape/test_pivot.py
@@ -2330,12 +2330,11 @@ class TestPivotTable:
         expected = pivot_table(data, index="A", columns="B", aggfunc=f_numpy)
         tm.assert_frame_equal(result, expected)
 
-    @pytest.mark.slow
     def test_pivot_number_of_levels_larger_than_int32_warns(
         self, performance_warning, monkeypatch
     ):
-        # GH 20601
-        # GH 26314: Change ValueError to PerformanceWarning
+        # GH#20601
+        # GH#26314: Change ValueError to PerformanceWarning
         class MockUnstacker(reshape_lib._Unstacker):
             def __init__(self, *args, **kwargs) -> None:
                 # __init__ will raise the warning
@@ -2351,7 +2350,7 @@ class TestPivotTable:
                 {"ind1": np.arange(2**16), "ind2": np.arange(2**16), "count": 0}
             )
 
-            msg = "The following operation may generate"
+            msg = f"may generate {2**32} cells"
             with tm.assert_produces_warning(performance_warning, match=msg):
                 with pytest.raises(Exception, match="Don't compute final result."):
                     df.pivot_table(


### PR DESCRIPTION
`test_pivot_number_of_levels_larger_than_int32_warns` guards the GH-20601 `PerformanceWarning`. Two problems, both making it weaker than it looks:

- It carries `@pytest.mark.slow`, but `MockUnstacker` short-circuits before `_make_selectors`, so nothing near 2\*\*32 is ever allocated and the test runs in ~0.01s. No CI job selects `-m slow` — every reference in `unit-tests.yml` and `pyproject.toml` is a `not slow` exclusion — so the mark meant the test ran nowhere, including on the Windows jobs whose int32 overflow the warning exists for.
- The `match` was the bare prefix `"The following operation may generate"`, so it never checked the cell count. It passes unchanged against a warning reporting 65536 cells.

Pinning the count to `f"may generate {2**32} cells"` is verified load-bearing: the test fails if the emitted count changes.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which measured the runtime and the CI mark selection, wrote the change, and reviewed it.