### PR TITLE
BUG: assert_almost_equal on 2-D arrays ignores check_dtype

### DIFF
--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -163,6 +163,11 @@ cpdef assert_almost_equal(a, b,
                 ):
                     return True
 
+            # flatten so the loop compares values, not rows; see GH#68364 and
+            #  test_assert_almost_equal_2d_large_mixed_integer_float
+            a = a.ravel()
+            b = b.ravel()
+
         else:
             na, nb = len(a), len(b)
 
@@ -179,7 +184,9 @@ cpdef assert_almost_equal(a, b,
 
         for i in range(len(a)):
             try:
-                assert_almost_equal(a[i], b[i], rtol=rtol, atol=atol)
+                assert_almost_equal(
+                    a[i], b[i], check_dtype=check_dtype, rtol=rtol, atol=atol
+                )
             except AssertionError:
                 is_unequal = True
                 diff += 1

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -163,7 +163,7 @@ cpdef assert_almost_equal(a, b,
                 ):
                     return True
 
-            # flatten so the loop compares values, not rows; see GH#68364 and
+            # flatten so the loop compares values, not rows; see GH#68366 and
             #  test_assert_almost_equal_2d_large_mixed_integer_float
             a = a.ravel()
             b = b.ravel()

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -839,9 +839,10 @@ def assert_numpy_array_equal(
                 )
 
             diff = 0.0
-            for left_arr, right_arr in zip(left, right, strict=True):
+            # ravel so the count is over values, matching the `left.size` total
+            for left_val, right_val in zip(left.ravel(), right.ravel(), strict=True):
                 # count up differences
-                if not array_equivalent(left_arr, right_arr, strict_nan=strict_nan):
+                if not array_equivalent(left_val, right_val, strict_nan=strict_nan):
                     diff += 1
 
             diff = diff * 100.0 / left.size

--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -209,6 +209,25 @@ def test_assert_almost_equal_large_mixed_integer_float_message():
     )
 
 
+def test_assert_almost_equal_2d_large_mixed_integer_float():
+    # GH#68364 the GH#66699 magnitude guard sends exactly-equal large integers
+    #  through the element loop, which must honour check_dtype like the 1-D case
+    big = np.array([[2**60, 1], [2, 3]], dtype="int64")
+
+    _assert_almost_equal_both(
+        big, big.astype("float64"), check_dtype=False, rtol=0, atol=0
+    )
+
+
+def test_assert_almost_equal_nested_arrays_check_dtype():
+    # GH#68364 the element loop forwards check_dtype, so nested arrays compare
+    #  by value rather than tripping on their dtypes
+    left = [np.array([1, 2]), np.array([3, 4])]
+    right = [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
+
+    _assert_almost_equal_both(left, right, check_dtype=False)
+
+
 @pytest.mark.parametrize(
     "a,b,rtol",
     [
@@ -512,6 +531,19 @@ numpy array values are different \\(25\\.0 %\\)
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_almost_equal(np.array([[1, 2], [3, 4]]), np.array([[1, 3], [3, 4]]))
+
+
+def test_assert_almost_equal_value_mismatch_2d_percentage():
+    # GH#68364 the percentage counts differing values, not differing rows
+    msg = """numpy array are different
+
+numpy array values are different \\(100\\.0 %\\)
+\\[left\\]:  \\[\\[1, 2\\], \\[3, 4\\]\\]
+\\[right\\]: \\[\\[9, 9\\], \\[9, 9\\]\\]
+At positional index 0, first diff: 1 != 9"""
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_almost_equal(np.array([[1, 2], [3, 4]]), np.array([[9, 9], [9, 9]]))
 
 
 def test_assert_almost_equal_shape_mismatch_override():

--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -210,7 +210,7 @@ def test_assert_almost_equal_large_mixed_integer_float_message():
 
 
 def test_assert_almost_equal_2d_large_mixed_integer_float():
-    # GH#68364 the GH#66699 magnitude guard sends exactly-equal large integers
+    # GH#68366 the GH#66699 magnitude guard sends exactly-equal large integers
     #  through the element loop, which must honour check_dtype like the 1-D case
     big = np.array([[2**60, 1], [2, 3]], dtype="int64")
 
@@ -220,7 +220,7 @@ def test_assert_almost_equal_2d_large_mixed_integer_float():
 
 
 def test_assert_almost_equal_nested_arrays_check_dtype():
-    # GH#68364 the element loop forwards check_dtype, so nested arrays compare
+    # GH#68366 the element loop forwards check_dtype, so nested arrays compare
     #  by value rather than tripping on their dtypes
     left = [np.array([1, 2]), np.array([3, 4])]
     right = [np.array([1.0, 2.0]), np.array([3.0, 4.0])]
@@ -534,7 +534,7 @@ numpy array values are different \\(25\\.0 %\\)
 
 
 def test_assert_almost_equal_value_mismatch_2d_percentage():
-    # GH#68364 the percentage counts differing values, not differing rows
+    # GH#68366 the percentage counts differing values, not differing rows
     msg = """numpy array are different
 
 numpy array values are different \\(100\\.0 %\\)

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -112,6 +112,20 @@ numpy array values are different \\(25\\.0 %\\)
         )
 
 
+def test_assert_numpy_array_equal_value_mismatch_2d_percentage():
+    # GH#68364 the percentage counts differing values, not differing rows
+    msg = """numpy array are different
+
+numpy array values are different \\(100\\.0 %\\)
+\\[left\\]:  \\[\\[1, 2\\], \\[3, 4\\]\\]
+\\[right\\]: \\[\\[9, 9\\], \\[9, 9\\]\\]"""
+
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_numpy_array_equal(
+            np.array([[1, 2], [3, 4]]), np.array([[9, 9], [9, 9]])
+        )
+
+
 def test_assert_numpy_array_equal_shape_mismatch_override():
     msg = """Index are different
 

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -113,7 +113,7 @@ numpy array values are different \\(25\\.0 %\\)
 
 
 def test_assert_numpy_array_equal_value_mismatch_2d_percentage():
-    # GH#68364 the percentage counts differing values, not differing rows
+    # GH#68366 the percentage counts differing values, not differing rows
     msg = """numpy array are different
 
 numpy array values are different \\(100\\.0 %\\)


### PR DESCRIPTION
The element loop in `assert_almost_equal` recursed as `assert_almost_equal(a[i], b[i], rtol=rtol, atol=atol)`, dropping `check_dtype`. For a 2-D ndarray each `a[i]` is a 1-D *row*, so the recursive call re-entered the array branch with `check_dtype` back at its `True` default and reported a dtype mismatch the caller had opted out of.

That was unreachable for *equal* arrays until GH-66722: the `array_equivalent` early return caught them first. Its magnitude guard now falls through to the loop whenever the integer values exceed float64's exact range, so an exactly-equal 2-D pair above `2**53` fails where the identical shape below `2**53` passes:

```python
import numpy as np
import pandas._testing as tm

big = np.array([[2**60, 1], [2, 3]], dtype="int64")
small = np.array([[10, 1], [2, 3]], dtype="int64")

tm.assert_almost_equal(small, small.astype("float64"), check_dtype=False, rtol=0, atol=0)
# passes

tm.assert_almost_equal(big, big.astype("float64"), check_dtype=False, rtol=0, atol=0)
# AssertionError: numpy array are different
# numpy array values are different (50.0 %)
```

Both pairs are exactly equal — `2**60` is representable in float64 — so both should pass.

Fixed by flattening a both-ndarray pair before the loop, so each `a[i]` is a value and never re-enters the array branch. `check_dtype` is forwarded as well, which is what matters for the non-array iterables the same loop serves (a list of arrays).

Flattening also fixes a second, pre-existing defect in the same loop: `diff` counted differing *rows* while the denominator `na` was `a.size`, so the repro above reports "50.0 %" for a 2-row / 4-element array with both rows differing. `assert_numpy_array_equal` held its own copy of that formula and gets the same `ravel()`. The three existing 2-D percentage tests are unchanged — they happen to have exactly one differing value per differing row, so the row and value counts coincide.

No whatsnew: neither `assert_almost_equal` nor `assert_numpy_array_equal` is exported from `pandas.testing`, and all four public entry points compare 1-D data, so no released public behaviour changes.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the dropped kwarg, wrote the fix and tests, and verified each new test fails on the unpatched build.