### PR TITLE
DOC: document pandas.api.typing.Expression

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -434,6 +434,10 @@ numpydoc_validation_exclude = {
     r"pandas\.Period\.weekday$",
     r"pandas\.PeriodIndex\.weekday$",
     r"pandas\.Series\.dt\.weekday$",
+    # Relaxed-rules class page (GH#63084): not instantiated by users, so
+    # the constructor parameters are not documented (PR01) and no See Also
+    # section applies (SA01)
+    r"pandas\.api\.typing\.Expression$",
 }
 
 # matplotlib plot directive

--- a/doc/source/reference/general_functions.rst
+++ b/doc/source/reference/general_functions.rst
@@ -75,6 +75,8 @@ Top-level evaluation
    :toctree: api/
 
    col
+   api.typing.Expression
+   api.typing.Expression.case_when
    eval
 
 Datetime formats

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -80,9 +80,34 @@ def _pretty_print_args_kwargs(*args: Any, **kwargs: Any) -> str:
 @set_module("pandas.api.typing")
 class Expression:
     """
-    Class representing a deferred column.
+    Class representing a deferred expression evaluated against a DataFrame.
+
+    Expressions are initially created via ``pd.col`` and can be composed
+    using arithmetic, comparison, and any method or attribute that the
+    underlying object supports. This includes NumPy ufuncs, indexing, and
+    the logical operators ``&``, ``|``, and ``~``.
+
+    Expressions are solely intended for use in expression-based APIs, such
+    as :meth:`DataFrame.assign <pandas.DataFrame.assign>` and
+    :meth:`DataFrame.loc <pandas.DataFrame.loc>`, where they are
+    evaluated against the DataFrame they are passed to.
 
     This is not meant to be instantiated directly. Instead, use :meth:`pandas.col`.
+
+    Notes
+    -----
+    The attributes that are available depend on the expression and where it
+    is used. Attribute access is itself deferred: it is applied to the
+    result of evaluating the expression, so an attribute that is not
+    supported by that result raises when the expression is evaluated.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    >>> df.assign(c=pd.col("a") + pd.col("b"))
+       a  b  c
+    0  1  3  4
+    1  2  4  6
     """
 
     def __init__(
@@ -324,14 +349,39 @@ class Expression:
 
     def case_when(self, caselist: Sequence[tuple[Any, Any]]) -> Expression:
         """
-        Create an expression that evaluates :meth:`Series.case_when` in a DataFrame
-        context.
+        Evaluate :meth:`Series.case_when <pandas.Series.case_when>`.
 
-        This is intended to enable patterns like::
+        This enables patterns like::
 
             df.assign(result=pd.col("a").case_when([(pd.col("b") > 0, 1)]))
 
-        where conditions/replacements may reference other columns via ``pd.col``.
+        where conditions and replacements may reference other columns via
+        ``pd.col``.
+
+        Parameters
+        ----------
+        caselist : list of tuple
+            List of ``(condition, replacement)`` pairs. Conditions and
+            replacements may themselves be expressions.
+
+        Returns
+        -------
+        :class:`pandas.api.typing.Expression`
+            A deferred expression that evaluates
+            :meth:`Series.case_when <pandas.Series.case_when>` on
+            the column when applied to a DataFrame.
+
+        See Also
+        --------
+        Series.case_when : Replace values where the conditions are True.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({"a": [1, 2], "b": [-1, 3]})
+        >>> df.assign(c=pd.col("a").case_when([(pd.col("b") > 0, pd.col("b"))]))
+           a  b  c
+        0  1 -1  1
+        1  2  3  3
         """
 
         def func(df: DataFrame) -> Any:
@@ -384,7 +434,7 @@ def col(col_name: Hashable) -> Expression:
 
     Returns
     -------
-    `pandas.api.typing.Expression`
+    :class:`pandas.api.typing.Expression`
         A deferred object representing a column of a DataFrame.
 
     See Also


### PR DESCRIPTION
Closes #63084

`pd.col` returns a deferred expression, but nothing in the docs says what you can do with one, and the type shown in the Returns section doesn't link anywhere.

This adds a page for `pandas.api.typing.Expression`, generated from the class docstring. The docstring covers how expressions start from `pd.col`, how they compose (operators, ufuncs, indexing, deferred attribute access), and notes that the attributes available depend on the expression and where it is evaluated, per the discussion in the issue. No constructor docs and no attribute enumeration, following the relaxed rules agreed on there. `case_when` gets a proper docstring since it gets its own page.

Both entries go after `col` under "Top-level evaluation" in `general_functions.rst`, and `Expression` is excluded from numpydoc validation since users never instantiate it. `pd.col`'s Returns type is now a `:class:` reference, so it links to the page.

Verified with a full docs build with warnings as errors, same as CI: the Returns section links to the page, both pages show up in the sidebar, and the examples match real output.
