### PR TITLE
DOC: document pandas.api.typing.Expression

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -434,6 +434,10 @@ numpydoc_validation_exclude = {
     r"pandas\.Period\.weekday$",
     r"pandas\.PeriodIndex\.weekday$",
     r"pandas\.Series\.dt\.weekday$",
+    # Relaxed-rules class page (GH#63084): not instantiated by users, so
+    # the constructor parameters are not documented (PR01) and no See Also
+    # section applies (SA01)
+    r"pandas\.api\.typing\.Expression$",
 }
 
 # matplotlib plot directive

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -435,8 +435,7 @@ numpydoc_validation_exclude = {
     r"pandas\.PeriodIndex\.weekday$",
     r"pandas\.Series\.dt\.weekday$",
     # Relaxed-rules class page (GH#63084): not instantiated by users, so
-    # the constructor parameters are not documented (PR01) and no See Also
-    # section applies (SA01)
+    # the constructor parameters are not documented (PR01)
     r"pandas\.api\.typing\.Expression$",
 }
 

--- a/doc/source/reference/general_functions.rst
+++ b/doc/source/reference/general_functions.rst
@@ -75,9 +75,13 @@ Top-level evaluation
    :toctree: api/
 
    col
-   api.typing.Expression
-   api.typing.Expression.case_when
    eval
+
+.. autosummary::
+   :toctree: api/
+   :template: autosummary/class_without_autosummary.rst
+
+   api.typing.Expression
 
 Datetime formats
 ~~~~~~~~~~~~~~~~

--- a/doc/source/reference/general_functions.rst
+++ b/doc/source/reference/general_functions.rst
@@ -75,6 +75,8 @@ Top-level evaluation
    :toctree: api/
 
    col
+   api.typing.Expression
+   api.typing.Expression.case_when
    eval
 
 Datetime formats

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -80,9 +80,34 @@ def _pretty_print_args_kwargs(*args: Any, **kwargs: Any) -> str:
 @set_module("pandas.api.typing")
 class Expression:
     """
-    Class representing a deferred column.
+    Class representing a deferred expression evaluated against a DataFrame.
+
+    Expressions are initially created via ``pd.col`` and can be composed
+    using arithmetic, comparison, and any method or attribute that the
+    underlying object supports. This includes NumPy ufuncs, indexing, and
+    the logical operators ``&``, ``|``, and ``~``.
+
+    Expressions are solely intended for use in expression-based APIs, such
+    as :meth:`DataFrame.assign <pandas.DataFrame.assign>` and
+    :meth:`DataFrame.loc <pandas.DataFrame.loc>`, where they are
+    evaluated against the DataFrame they are passed to.
 
     This is not meant to be instantiated directly. Instead, use :meth:`pandas.col`.
+
+    Notes
+    -----
+    The attributes that are available depend on the expression and where it
+    is used. Attribute access is itself deferred: it is applied to the
+    result of evaluating the expression, so an attribute that is not
+    supported by that result raises when the expression is evaluated.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    >>> df.assign(c=pd.col("a") + pd.col("b"))
+       a  b  c
+    0  1  3  4
+    1  2  4  6
     """
 
     def __init__(
@@ -324,14 +349,39 @@ class Expression:
 
     def case_when(self, caselist: Sequence[tuple[Any, Any]]) -> Expression:
         """
-        Create an expression that evaluates :meth:`Series.case_when` in a DataFrame
-        context.
+        Evaluate :meth:`Series.case_when <pandas.Series.case_when>`.
 
-        This is intended to enable patterns like::
+        This enables patterns like::
 
             df.assign(result=pd.col("a").case_when([(pd.col("b") > 0, 1)]))
 
-        where conditions/replacements may reference other columns via ``pd.col``.
+        where conditions and replacements may reference other columns via
+        ``pd.col``.
+
+        Parameters
+        ----------
+        caselist : list of tuple
+            List of ``(condition, replacement)`` pairs. Conditions and
+            replacements may themselves be expressions.
+
+        Returns
+        -------
+        :class:`pandas.api.typing.Expression`
+            A deferred expression that evaluates
+            :meth:`Series.case_when <pandas.Series.case_when>` on
+            the column when applied to a DataFrame.
+
+        See Also
+        --------
+        Series.case_when : Replace values where the conditions are True.
+
+        Examples
+        --------
+        >>> df = pd.DataFrame({"a": [1, 2], "b": [-1, 3]})
+        >>> df.assign(c=pd.col("a").case_when([(pd.col("b") > 0, pd.col("b"))]))
+           a  b  c
+        0  1 -1  1
+        1  2  3  3
         """
 
         def func(df: DataFrame) -> Any:
@@ -384,7 +434,7 @@ def col(col_name: Hashable) -> Expression:
 
     Returns
     -------
-    `pandas.api.typing.Expression`
+    :class:`pandas.api.typing.Expression`
         A deferred object representing a column of a DataFrame.
 
     See Also

--- a/pandas/core/col.py
+++ b/pandas/core/col.py
@@ -85,7 +85,7 @@ class Expression:
     Expressions are initially created via ``pd.col`` and can be composed
     using arithmetic, comparison, and any method or attribute that the
     underlying object supports. This includes NumPy ufuncs, indexing, and
-    the logical operators ``&``, ``|``, and ``~``.
+    the boolean operators ``&``, ``|``, and ``~``.
 
     Expressions are solely intended for use in expression-based APIs, such
     as :meth:`DataFrame.assign <pandas.DataFrame.assign>` and
@@ -93,6 +93,10 @@ class Expression:
     evaluated against the DataFrame they are passed to.
 
     This is not meant to be instantiated directly. Instead, use :meth:`pandas.col`.
+
+    See Also
+    --------
+    pandas.col : Create a deferred column reference.
 
     Notes
     -----
@@ -349,39 +353,14 @@ class Expression:
 
     def case_when(self, caselist: Sequence[tuple[Any, Any]]) -> Expression:
         """
-        Evaluate :meth:`Series.case_when <pandas.Series.case_when>`.
+        Create an expression that evaluates :meth:`Series.case_when` in a DataFrame
+        context.
 
-        This enables patterns like::
+        This is intended to enable patterns like::
 
             df.assign(result=pd.col("a").case_when([(pd.col("b") > 0, 1)]))
 
-        where conditions and replacements may reference other columns via
-        ``pd.col``.
-
-        Parameters
-        ----------
-        caselist : list of tuple
-            List of ``(condition, replacement)`` pairs. Conditions and
-            replacements may themselves be expressions.
-
-        Returns
-        -------
-        :class:`pandas.api.typing.Expression`
-            A deferred expression that evaluates
-            :meth:`Series.case_when <pandas.Series.case_when>` on
-            the column when applied to a DataFrame.
-
-        See Also
-        --------
-        Series.case_when : Replace values where the conditions are True.
-
-        Examples
-        --------
-        >>> df = pd.DataFrame({"a": [1, 2], "b": [-1, 3]})
-        >>> df.assign(c=pd.col("a").case_when([(pd.col("b") > 0, pd.col("b"))]))
-           a  b  c
-        0  1 -1  1
-        1  2  3  3
+        where conditions/replacements may reference other columns via ``pd.col``.
         """
 
         def func(df: DataFrame) -> Any:


### PR DESCRIPTION
Closes #63084

Supersedes #68367, which was auto-closed while the issue claim was pending.

Document `pandas.api.typing.Expression` and link to it from `pd.col`'s Returns section. The class page explains deferred evaluation, composition, and attribute access, with an example and a See Also link to `pandas.col`.

Use the class template without a method list, so `case_when` is not presented as a special expression method. Its existing docstring is unchanged. Exclude the class from numpydoc validation because users do not instantiate it and its constructor parameters are intentionally undocumented.

Validation: documentation build with warnings treated as errors, generated-page link checks, the class example, and pre-commit checks for the changed files.

- [x] I used AI to develop this pull request. Review revisions used OpenAI Codex (GPT-6); the session did not expose a reasoning-effort setting.
