### PR TITLE
DOC: use Series links in Series.dt.tz_convert See Also

### DIFF
--- a/pandas/core/indexes/accessors.py
+++ b/pandas/core/indexes/accessors.py
@@ -317,6 +317,79 @@ class DatetimeProperties(Properties):
     Raises TypeError if the Series does not contain datetimelike values.
     """
 
+    def tz_convert(self, tz) -> Series:
+        """
+        Convert tz-aware Datetime Array/Index from one time zone to another.
+
+        This method converts datetime values from their current timezone to a
+        different timezone. The underlying UTC time remains the same, only the
+        local time representation changes to reflect the target timezone.
+
+        Parameters
+        ----------
+        tz : str, zoneinfo.ZoneInfo, pytz.timezone, dateutil.tz.tzfile, datetime.tzinfo or None
+            Time zone for time. Corresponding timestamps would be converted
+            to this time zone of the Datetime Array/Index. A `tz` of None will
+            convert to UTC and remove the timezone information.
+
+        Returns
+        -------
+        Array or Index
+            Datetime Array/Index with target `tz`.
+
+        Raises
+        ------
+        TypeError
+            If Datetime Array/Index is tz-naive.
+
+        See Also
+        --------
+        Series.dt.tz : A timezone that has a variable offset from UTC.
+        Series.dt.tz_localize : Localize tz-naive Series datetimes to a given
+            time zone, or remove timezone from tz-aware Series datetimes.
+
+        Examples
+        --------
+        With the `tz` parameter, we can change the DatetimeIndex
+        to other time zones:
+
+        >>> dti = pd.date_range(
+        ...     start="2014-08-01 09:00", freq="h", periods=3, tz="Europe/Berlin"
+        ... )
+
+        >>> dti
+        DatetimeIndex(['2014-08-01 09:00:00+02:00',
+                       '2014-08-01 10:00:00+02:00',
+                       '2014-08-01 11:00:00+02:00'],
+                      dtype='datetime64[us, Europe/Berlin]', freq='h')
+
+        >>> dti.tz_convert("US/Central")
+        DatetimeIndex(['2014-08-01 02:00:00-05:00',
+                       '2014-08-01 03:00:00-05:00',
+                       '2014-08-01 04:00:00-05:00'],
+                      dtype='datetime64[us, US/Central]', freq='h')
+
+        With the ``tz=None``, we can remove the timezone (after converting
+        to UTC if necessary):
+
+        >>> dti = pd.date_range(
+        ...     start="2014-08-01 09:00", freq="h", periods=3, tz="Europe/Berlin"
+        ... )
+
+        >>> dti
+        DatetimeIndex(['2014-08-01 09:00:00+02:00',
+                       '2014-08-01 10:00:00+02:00',
+                       '2014-08-01 11:00:00+02:00'],
+                        dtype='datetime64[us, Europe/Berlin]', freq='h')
+
+        >>> dti.tz_convert(None)
+        DatetimeIndex(['2014-08-01 07:00:00',
+                       '2014-08-01 08:00:00',
+                       '2014-08-01 09:00:00'],
+                        dtype='datetime64[us]', freq='h')
+        """  # noqa: E501
+        return self._delegate_method("tz_convert", tz)
+
     def to_pydatetime(self) -> Series:
         """
         Return the data as a Series of :class:`datetime.datetime` objects.


### PR DESCRIPTION
- [x] closes #49297
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.

`pandas.Series.dt.tz_convert` inherits its docstring from `DatetimeArray`, so the See also box on the Series page pointed at `DatetimeIndex.tz` / `DatetimeIndex.tz_localize`. Following those links, it is easy to call `Series.tz_localize` instead of `Series.dt.tz_localize`.

#66397 added Series accessor links next to the DatetimeIndex ones on the shared docstring and left this issue open, since the preferred fix is to inline the Series method (as `DatetimeIndex.tz_convert` already does).

This inlines `tz_convert` on `DatetimeProperties` and points See also at `Series.dt.tz` and `Series.dt.tz_localize`. The method still delegates to the existing implementation; behavior is unchanged.

Verification: `ruff==0.16.6` check/format, isort, codespell, `py_compile`, and `git diff --check` on the changed file. The pandas test suite and Sphinx doc build were not run here because this checkout does not have compiled C extensions.

AI use: xAI Grok 4.6 in Grok Build. I prompted it to follow AGENTS.md. The reasoning-effort setting is not exposed by this tool.