### PR TITLE
DOC: Correct pull request reopening instructions

### DIFF
--- a/doc/source/development/contributing.rst
+++ b/doc/source/development/contributing.rst
@@ -131,8 +131,8 @@ description, for example ``closes #1234``.
 Your pull request must be linked to an issue that is **assigned to you**. If you
 open one linked to an issue you haven't claimed, the bot adds the
 ``Needs Issue Assignment`` label, closes the pull request, and comments with
-what to do next: comment ``/take`` on the issue to claim it, then reopen your
-pull request (you can reopen it yourself — nothing is lost).
+what to do next: comment ``/take`` on the issue to claim it, then create a new
+pull request.
 
 Review and staleness
 --------------------


### PR DESCRIPTION
…est reopening instructions

Update instructions for claiming an issue and reopening pull requests.

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)
Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [ ] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting — e.g. `claude opus 4.8 (xhigh)`, not just `claude`.
