### PR TITLE
DOC: update slack invite link

### DIFF
--- a/doc/source/development/community.rst
+++ b/doc/source/development/community.rst
@@ -114,7 +114,7 @@ people who are hesitant to bring up their questions or ideas on a large public
 mailing list or GitHub.
 
 If this sounds like the right place for you, you are welcome to join using
-`this link <https://join.slack.com/t/pandas-dev-community/shared_invite/zt-3813u5fme-hmp5izpbeFl9G8~smrkE~A>`_!
+`this link <https://join.slack.com/t/pandas-dev-community/shared_invite/zt-49d16eik3-HmDn2YhetUE~iAKTodI8kA>`_!
 Please remember to follow our `Code of Conduct <https://pandas.pydata.org/community/coc.html>`_,
 and be aware that our admins are monitoring for irrelevant messages and will remove folks who use
 our


### PR DESCRIPTION
Apparently the current link was no longer working ("This link is no longer active", maybe reached its max invitations?), so updating with a new one