### PR TITLE
PERF: read_csv converts numeric columns in the batched row-blocked sweep

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -407,6 +407,7 @@ Performance improvements
 - Performance improvement in :class:`.DataFrameGroupBy` aggregations (``sum``, ``mean``, ``min``, ``max``, ``prod``) when the grouping keys are already sorted (:issue:`65103`)
 - Performance improvement in :class:`.DataFrameGroupBy` and :class:`.SeriesGroupBy` reductions for :class:`ArrowDtype` decimal columns (``sum``, ``prod``, ``min``, ``max``, ``mean``, ``var``) and for Arrow-backed string columns (``min``, ``max``), i.e. :class:`ArrowDtype` and :class:`StringDtype` with ``storage="pyarrow"``, by dispatching to PyArrow's native ``group_by`` instead of a slower fallback (:issue:`63416`)
 - Performance improvement in :class:`.DataFrameGroupBy` and :class:`.SeriesGroupBy` with ``sort=True``, as well as :func:`factorize` and :func:`merge` with ``sort=True``, when the keys are integers with many unique values (:issue:`66129`)
+- Performance improvement in :func:`read_csv` with the C engine for files with many string columns or many columns overall, and for parallel reads generally: columns are now converted a cache-sized block of rows at a time instead of one full pass per column (:issue:`68380`)
 - Performance improvement in casting integer and boolean dtypes to ``string[pyarrow]`` by using PyArrow's native cast instead of element-wise conversion (:issue:`56505`)
 - Performance improvement in :meth:`DataFrame.__getitem__` when selecting a
   single column by label on a :class:`DataFrame` with duplicate column names.

--- a/pandas/_libs/parsers.pyi
+++ b/pandas/_libs/parsers.pyi
@@ -41,6 +41,7 @@ class TextReader:
     leading_cols: int  # int64_t
     header: list[list[int]]  # non-negative integers
     defer_pa_wrap: bool
+    block_workers: int
     trim_after_read: bool
     warning_sink: list[tuple[str, type[Warning]]] | None
     def __init__(

--- a/pandas/_libs/parsers.pyx
+++ b/pandas/_libs/parsers.pyx
@@ -67,6 +67,7 @@ from libc.stdint cimport (
     uintptr_t,
 )
 from libc.stdlib cimport (
+    calloc,
     free,
     malloc,
     realloc,
@@ -376,6 +377,44 @@ cdef void del_rd_source_wrapper(void *src) noexcept nogil:
     del_rd_source(src)
 
 
+# Row-blocked conversion (see TextReader._convert_batched): bytes of parser
+# state (tokens, word_ends, line_start) per block, so every column's pass
+# finds it cache-resident.  Flat from 16 KB to 128 KB, gone by 4 MB.  0 = off.
+_BLOCK_BYTES = 1 << 15
+
+cdef enum:
+    BLOCK_KIND_INT64 = 1
+    BLOCK_KIND_FLOAT64 = 2
+    BLOCK_KIND_BOOL = 3
+    BLOCK_KIND_STRING = 4
+
+
+cdef struct _BlockColState:
+    # Resumable per-column converter state for _convert_batched.
+    int64_t col
+    int kind
+    int failed
+    # nonzero: block 0 came from the probe, so the loop starts at block 1
+    int adopted
+    bint na_filter
+    kh_str_starts_t *na_hashset
+    int na_count
+    # numeric kinds: output buffers owned by ndarrays the caller keeps alive
+    void *data
+    uint8_t *na_mask
+    const kh_float64_t *na_fhashset
+    bint use_na_flist
+    # string kind: malloc'd buffers, handed to a _PendingStringColumn at the end
+    bint large
+    int64_t *offsets64
+    int32_t *offsets32
+    uint8_t *validity
+    char *sdata
+    Py_ssize_t data_cap
+    Py_ssize_t total_bytes
+    uint64_t ascii_acc
+
+
 cdef class TextReader:
     """
 
@@ -429,6 +468,11 @@ cdef class TextReader:
         # handles instead of ExtensionArrays; the c_parser_wrapper layer
         # materializes them once per column at the end of the read.
         public bint defer_pa_wrap
+        # worker count of the parallel read (0 = serial); numeric columns
+        # only batch once enough workers contend for bandwidth
+        public int block_workers
+        bint _probe_defer_all
+        dict _block_kind_cache
         # Set by _close, which frees the tokenizer's buffers.  Reading from a
         # closed reader would dereference those freed pointers (GH#66622).
         bint is_closed
@@ -589,6 +633,9 @@ cdef class TextReader:
         self.converters = converters
         self.na_filter = na_filter
         self.defer_pa_wrap = False
+        self.block_workers = 0
+        self._probe_defer_all = False
+        self._block_kind_cache = {}
         self._pa_target = None
         self.trim_after_read = True
         self.warning_sink = None
@@ -1195,6 +1242,10 @@ cdef class TextReader:
             int64_t num_cols
             dict results
             bint is_default_dict_dtype
+            list deferred = []
+            int64_t block_rows
+            int verdict
+            bint numeric_ok
 
         start = self.parser_start
 
@@ -1214,6 +1265,10 @@ cdef class TextReader:
         results = {}
         nused = 0
         is_default_dict_dtype = isinstance(self.dtype, defaultdict)
+        block_rows = self._block_rows(end - start)
+        # Numeric converters are compute-bound at low worker counts unless the
+        # frame is wide enough that each pass drags a long row through cache.
+        numeric_ok = self.block_workers >= 6 or self.table_width >= 16
 
         for i in range(self.table_width):
             if i < self.leading_cols:
@@ -1258,33 +1313,377 @@ cdef class TextReader:
             else:
                 na_filter = 0
 
+            if block_rows > 0 and col_dtype is None and i not in self.noconvert:
+                # Decided together once the loop knows how many there are
+                # (see _resolve_deferred).  Bools never qualify: per-token
+                # hash probes keep them compute-bound.
+                verdict = self._first_token_kind(
+                    i, start, start + block_rows, na_filter, na_hashset)
+                if verdict == BLOCK_KIND_STRING or (
+                    numeric_ok and verdict in (BLOCK_KIND_INT64,
+                                               BLOCK_KIND_FLOAT64)
+                ):
+                    deferred.append(
+                        (i, name, na_filter, <uintptr_t>na_hashset, na_fset,
+                         verdict)
+                    )
+                    continue
+
             # Attempt to parse tokens and infer dtype of the column.
             # Should return as the desired dtype (inferred or specified).
             col_res, na_count, na_mask = self._convert_tokens(
                 i, start, end, name, na_filter, na_hashset,
                 na_fset, col_dtype)
 
-            # don't try to upcast EAs
-            if (
-                na_count > 0 and not isinstance(col_dtype, ExtensionDtype)
-                or self.dtype_backend != "numpy"
-            ):
-                use_dtype_backend = self.dtype_backend != "numpy" and col_dtype is None
-                col_res = _maybe_upcast(
-                    col_res,
-                    use_dtype_backend=use_dtype_backend,
-                    dtype_backend=self.dtype_backend,
-                    na_mask=na_mask,
-                )
+            self._finish_column(i, col_dtype, col_res, na_count, na_mask, results)
 
-            if col_res is None:
-                raise ParserError(f"Unable to parse column {i}")
-
-            results[i] = col_res
+        if deferred:
+            self._resolve_deferred(deferred, start, end, block_rows, results)
+            results = dict(sorted(results.items()))
 
         self.parser_start += end - start
 
         return results
+
+    cdef _resolve_deferred(self, list deferred, int64_t start, int64_t end,
+                           int64_t block_rows, dict results):
+        """
+        Convert the candidate columns: row-blocked together when there are
+        enough of them for a block to be reused across passes, else one at a
+        time down the ordinary path.
+        """
+        cdef:
+            list batch = []
+            bint block = len(deferred) >= 3
+            int kind, verdict
+            bint na_filter
+            uintptr_t hs_addr
+            kh_str_starts_t *na_hashset
+
+        for i, name, na_filter, hs_addr, na_fset, verdict in deferred:
+            na_hashset = <kh_str_starts_t *>hs_addr
+            kind = 0
+            probe = None
+            if block:
+                # A clean earlier chunk's kind is reused when this chunk's
+                # first token agrees (the cascade's own verdict); later
+                # blocks catch any disagreement.
+                kind = self._block_kind_cache.get(i, 0)
+                if kind == 0 or kind != verdict:
+                    kind, probe = self._probe_block_kind(
+                        i, start, start + block_rows, name, na_filter,
+                        na_hashset, na_fset)
+                    if kind == BLOCK_KIND_BOOL:
+                        kind = 0
+            if kind != 0:
+                batch.append(
+                    (i, name, kind, na_filter, hs_addr, na_fset, probe)
+                )
+                continue
+            col_res, na_count, na_mask = self._convert_tokens(
+                i, start, end, name, na_filter, na_hashset, na_fset, None)
+            self._finish_column(i, None, col_res, na_count, na_mask, results)
+
+        if batch:
+            self._convert_batched(batch, start, end, block_rows, results)
+
+    cdef _finish_column(self, Py_ssize_t i, object col_dtype, object col_res,
+                        object na_count, object na_mask, dict results):
+        # don't try to upcast EAs
+        if (
+            na_count > 0 and not isinstance(col_dtype, ExtensionDtype)
+            or self.dtype_backend != "numpy"
+        ):
+            use_dtype_backend = self.dtype_backend != "numpy" and col_dtype is None
+            col_res = _maybe_upcast(
+                col_res,
+                use_dtype_backend=use_dtype_backend,
+                dtype_backend=self.dtype_backend,
+                na_mask=na_mask,
+            )
+
+        if col_res is None:
+            raise ParserError(f"Unable to parse column {i}")
+
+        results[i] = col_res
+
+    cdef int64_t _block_rows(self, int64_t lines):
+        """
+        Rows per conversion block, or 0 when row-blocked conversion does not
+        apply (disabled, or the rows already fit in one block).
+        """
+        cdef int64_t bytes_per_row, block_rows, block_bytes = _BLOCK_BYTES
+        if block_bytes <= 0 or self.parser.lines == 0 or lines <= 0:
+            return 0
+        # per row: its tokens, one word_ends entry per field, one line_start
+        bytes_per_row = (
+            <int64_t>(self.parser.stream_len // self.parser.lines)
+            + 8 * self.table_width + 8
+        )
+        block_rows = block_bytes // bytes_per_row
+        if block_rows < 64:
+            block_rows = 64
+        # a chunk of only a few blocks is cache-resident already
+        if lines < 8 * block_rows:
+            return 0
+        return block_rows
+
+    cdef int _first_token_kind(self, Py_ssize_t i, int64_t start,
+                               int64_t end, bint na_filter,
+                               kh_str_starts_t *na_hashset):
+        """
+        The cascade's verdict from the first non-NA token alone: the kind it
+        would try first for this column, or 0 when none applies.
+        """
+        cdef:
+            bint try_int = self.dtype_cast_order[0].kind == "i"
+            int kind = 0
+        with nogil:
+            if try_int and _probe_int64(self.parser, i, start, end,
+                                        na_filter, na_hashset) == 0:
+                kind = BLOCK_KIND_INT64
+            elif _probe_double(self.parser, i, start, end,
+                               na_filter, na_hashset) == 0:
+                kind = BLOCK_KIND_FLOAT64
+            elif _probe_bool_flex(self.parser, i, start, end, na_filter,
+                                  na_hashset, self.true_set,
+                                  self.false_set) == 0:
+                kind = BLOCK_KIND_BOOL
+        if kind == 0 and self._resolve_pa_target():
+            kind = BLOCK_KIND_STRING
+        return kind
+
+    cdef tuple _probe_block_kind(self, Py_ssize_t i, int64_t start,
+                                 int64_t probe_end, object name,
+                                 bint na_filter, kh_str_starts_t *na_hashset,
+                                 set na_fset):
+        """
+        Run the inference cascade on the leading rows of column ``i`` and map
+        its result to a resumable block converter kind; 0 means the column
+        takes the whole-column path.  Returns (kind, (col_res, na_count,
+        na_mask)) so the batch can adopt the probed rows' result.
+        """
+        cdef int kind = 0
+        if self.na_left_literal:
+            return 0, None
+        # a non-ASCII block 0 still comes back pending; the batch validates
+        # the whole column at the end (see _wrap_pending_string)
+        self._probe_defer_all = True
+        try:
+            probe = self._convert_tokens(
+                i, start, probe_end, name, na_filter, na_hashset, na_fset, None)
+        finally:
+            self._probe_defer_all = False
+        col_res = probe[0]
+        if self.na_left_literal:
+            # the cascade ended in the na_filter=0 string fallback
+            return 0, None
+        if isinstance(col_res, (_PendingStringColumn, ArrowStringArray,
+                                ArrowExtensionArray)):
+            if self._pa_target:
+                kind = BLOCK_KIND_STRING
+        elif isinstance(col_res, np.ndarray):
+            if col_res.dtype == np.int64:
+                kind = BLOCK_KIND_INT64
+            elif col_res.dtype == np.float64:
+                kind = BLOCK_KIND_FLOAT64
+            elif col_res.dtype == np.bool_:
+                kind = BLOCK_KIND_BOOL
+        if kind == 0:
+            return 0, None
+        return kind, probe
+
+    cdef _convert_batched(self, list batch, int64_t start, int64_t end,
+                          int64_t block_rows, dict results):
+        """
+        Convert the batched columns together, one row block at a time, so a
+        block's tokens and word_ends are read from cache by every column's
+        pass instead of from memory once per column.  A column whose block
+        converter fails past the probed block is re-converted whole.
+        """
+        cdef:
+            Py_ssize_t lines = end - start
+            Py_ssize_t n = len(batch), k, off
+            _BlockColState *states
+            _BlockColState *st
+            int64_t blk, blk_end
+            float64_t NA_f = na_values[np.float64]
+            int64_t NA_i = na_values[np.int64]
+            uint8_t NA_b = na_values[np.bool_]
+            list keep = [None] * n
+            ndarray arr, mask, probe_arr, probe_mask
+            int kind
+            uintptr_t hs_addr
+            bint na_filter
+            parser_t *parser = self.parser
+            str target = self._pa_target
+            _PendingStringColumn pending
+            char *grown
+            Py_ssize_t probe_rows = block_rows
+            Py_ssize_t probe_bytes
+            int64_t data_est
+
+        states = <_BlockColState *>calloc(n, sizeof(_BlockColState))
+        if states == NULL:
+            raise MemoryError()
+        try:
+            for k in range(n):
+                i, name, kind, na_filter, hs_addr, na_fset, probe = batch[k]
+                if probe is None:
+                    # cached kind: no probed rows to adopt
+                    probe_res, probe_na_count, probe_na_mask = None, 0, None
+                else:
+                    probe_res, probe_na_count, probe_na_mask = probe
+                st = &states[k]
+                st.col = i
+                st.kind = kind
+                st.na_filter = na_filter
+                st.na_hashset = <kh_str_starts_t *>hs_addr
+                if kind == BLOCK_KIND_STRING:
+                    st.large = target == "str_nan"
+                    if isinstance(probe_res, _PendingStringColumn):
+                        # take over the probe's buffers, resized for the
+                        # whole column
+                        pending = probe_res
+                        probe_bytes = pending.total_bytes
+                        data_est = <int64_t>lines * (
+                            probe_bytes // probe_rows + 1)
+                        data_est += (data_est >> 2) + 64
+                        st.data_cap = _clamp_data_cap(data_est, parser,
+                                                      st.large)
+                        if st.data_cap < probe_bytes:
+                            st.data_cap = probe_bytes
+                        grown = <char *>realloc(pending.data_ptr,
+                                                st.data_cap + WILDCOPY_SLACK)
+                        if grown == NULL:
+                            raise MemoryError()
+                        pending.data_ptr = NULL
+                        st.sdata = grown
+                        st.total_bytes = probe_bytes
+                        if st.large:
+                            st.offsets64 = <int64_t *>realloc(
+                                pending.offsets64_ptr,
+                                (lines + 1) * sizeof(int64_t))
+                            if st.offsets64 == NULL:
+                                raise MemoryError()
+                            pending.offsets64_ptr = NULL
+                        else:
+                            st.offsets32 = <int32_t *>realloc(
+                                pending.offsets32_ptr,
+                                (lines + 1) * sizeof(int32_t))
+                            if st.offsets32 == NULL:
+                                raise MemoryError()
+                            pending.offsets32_ptr = NULL
+                        if na_filter:
+                            # padding bits past the probe rows are still set,
+                            # so only the bytes added here need filling
+                            st.validity = <uint8_t *>realloc(
+                                pending.validity_ptr, (lines + 7) // 8)
+                            if st.validity == NULL:
+                                raise MemoryError()
+                            pending.validity_ptr = NULL
+                            memset(st.validity + (probe_rows + 7) // 8, 0xFF,
+                                   (lines + 7) // 8 - (probe_rows + 7) // 8)
+                        st.na_count = pending.na_count
+                        if pending.non_ascii:
+                            st.ascii_acc = 0x80
+                        st.adopted = 1
+                    continue
+
+                if kind == BLOCK_KIND_INT64:
+                    arr = np.empty(lines, dtype=np.int64)
+                    mask = np.zeros(lines, dtype=np.bool_)
+                    st.na_mask = <uint8_t *>mask.data
+                    keep[k] = (arr, mask)
+                elif kind == BLOCK_KIND_FLOAT64:
+                    arr = np.empty(lines, dtype=np.float64)
+                    mask = np.zeros(lines, dtype=np.bool_)
+                    st.na_mask = <uint8_t *>mask.data
+                    st.use_na_flist = len(na_fset) > 0
+                    st.na_fhashset = kset_float64_from_set(na_fset)
+                    keep[k] = (arr, mask)
+                else:
+                    arr = np.empty(lines, dtype=np.uint8)
+                    mask = None
+                    keep[k] = (arr, None)
+                st.data = <void *>arr.data
+                if probe is None or (mask is not None and probe_na_mask is None):
+                    # no mask to adopt; the block loop redoes the probed rows
+                    continue
+                # adopt the probe's rows
+                probe_arr = probe_res
+                if kind == BLOCK_KIND_BOOL:
+                    probe_arr = probe_arr.view(np.uint8)
+                memcpy(st.data, <void *>probe_arr.data,
+                       probe_rows * probe_arr.dtype.itemsize)
+                if mask is not None:
+                    probe_mask = probe_na_mask
+                    memcpy(st.na_mask, <void *>probe_mask.data, probe_rows)
+                st.na_count = probe_na_count
+                st.adopted = 1
+
+            with nogil:
+                for k in range(n):
+                    st = &states[k]
+                    if st.kind == BLOCK_KIND_STRING and not st.adopted:
+                        if _string_block_init(parser, st, start, lines) != 0:
+                            st.failed = 1
+                blk = start
+                while blk < end:
+                    blk_end = blk + block_rows
+                    if blk_end > end:
+                        blk_end = end
+                    off = blk - start
+                    for k in range(n):
+                        st = &states[k]
+                        if st.failed or (st.adopted and off == 0):
+                            continue
+                        if _convert_block(parser, st, blk, blk_end, off,
+                                          NA_f, NA_i, NA_b,
+                                          self.true_set, self.false_set) != 0:
+                            st.failed = 1
+                    blk = blk_end
+                for k in range(n):
+                    st = &states[k]
+                    if st.kind == BLOCK_KIND_STRING and not st.failed:
+                        _string_block_trim(st)
+
+            for k in range(n):
+                i, name, kind, na_filter, hs_addr, na_fset, probe = batch[k]
+                st = &states[k]
+                na_mask = None
+                if st.failed:
+                    self._block_kind_cache.pop(i, None)
+                    _free_block_string(st)
+                    col_res, na_count, na_mask = self._convert_tokens(
+                        i, start, end, name, na_filter, st.na_hashset,
+                        na_fset, None)
+                    self._finish_column(i, None, col_res, na_count, na_mask,
+                                        results)
+                    continue
+                self._block_kind_cache[i] = kind
+                if kind == BLOCK_KIND_STRING:
+                    pending = _pending_from_state(st, lines)
+                    col_res, na_count = _wrap_pending_string(
+                        parser, i, start, end, na_filter, st.na_hashset,
+                        target, self.defer_pa_wrap, pending,
+                        pending.non_ascii)
+                else:
+                    arr, mask = keep[k]
+                    na_count = st.na_count
+                    if kind == BLOCK_KIND_BOOL:
+                        col_res = arr.view(np.bool_)
+                    else:
+                        col_res = arr
+                        na_mask = mask
+                self._finish_column(i, None, col_res, na_count, na_mask, results)
+        finally:
+            for k in range(n):
+                st = &states[k]
+                _free_block_string(st)
+                if st.na_fhashset != NULL:
+                    kh_destroy_float64(<kh_float64_t *>st.na_fhashset)
+            free(states)
 
     # -> tuple["ArrayLike", int, np.ndarray | None]:
     cdef _convert_tokens(self, Py_ssize_t i, int64_t start,
@@ -1598,44 +1997,53 @@ cdef class TextReader:
         else:
             raise TypeError(f"the dtype {dtype} is not supported for parsing")
 
+    cdef str _resolve_pa_target(self):
+        """
+        Which pyarrow string fast path applies ("str_nan", "arrow", or "").
+
+        The option lookups behind the decision are not free and run under the
+        GIL, so resolve them once per reader rather than once per column
+        chunk.  This pins which path the parser takes at the first string
+        column considered, so changing the options mid-read (possible only
+        with chunksize / iterator=True) no longer moves one read on or off
+        the fast path partway through.  The object path still picks its
+        storage downstream, per chunk.
+        """
+        cdef str resolved
+        if self._pa_target is None:
+            # resolve into a local and publish once, so no observer can
+            # see the "" placeholder while the lookups below are running
+            resolved = ""
+            if HAS_PYARROW and self.encoding_errors == b"strict":
+                if self.dtype_backend == "pyarrow":
+                    resolved = "arrow"
+                elif (
+                    self.dtype_backend == "numpy"
+                    and using_string_dtype()
+                    # an ArrowStringArray result would be inconsistent
+                    # with mode.string_storage="python"
+                    and StringDtype(na_value=np.nan).storage == "pyarrow"
+                ):
+                    resolved = "str_nan"
+            self._pa_target = resolved
+        return self._pa_target
+
     # -> tuple[ArrayLike, int]
     cdef _string_convert(self, Py_ssize_t i, int64_t start, int64_t end,
                          bint na_filter, kh_str_starts_t *na_hashset,
                          bint allow_pyarrow=False):
 
         cdef str target = ""
-        cdef str resolved
         if allow_pyarrow:
-            # The option lookups behind the target decision are not free and
-            # run under the GIL, so resolve them once per reader rather than
-            # once per column chunk.  This pins which path the parser takes at
-            # the first string column converted, so changing the options
-            # mid-read (possible only with chunksize / iterator=True) no longer
-            # moves one read on or off the fast path partway through.  The
-            # object path still picks its storage downstream, per chunk.
-            if self._pa_target is None:
-                # resolve into a local and publish once, so no observer can
-                # see the "" placeholder while the lookups below are running
-                resolved = ""
-                if HAS_PYARROW and self.encoding_errors == b"strict":
-                    if self.dtype_backend == "pyarrow":
-                        resolved = "arrow"
-                    elif (
-                        self.dtype_backend == "numpy"
-                        and using_string_dtype()
-                        # an ArrowStringArray result would be inconsistent
-                        # with mode.string_storage="python"
-                        and StringDtype(na_value=np.nan).storage == "pyarrow"
-                    ):
-                        resolved = "str_nan"
-                self._pa_target = resolved
-            target = self._pa_target
+            target = self._resolve_pa_target()
 
         if target:
             try:
                 return _string_pyarrow_utf8(self.parser, i, start, end,
                                             na_filter, na_hashset, target,
-                                            self.defer_pa_wrap)
+                                            self.defer_pa_wrap
+                                            or self._probe_defer_all,
+                                            self._probe_defer_all)
             except OverflowError:
                 # >2GiB of string data does not fit the "arrow" target's
                 # int32 offsets; the object path below chunks as needed.
@@ -2218,6 +2626,8 @@ cdef class _PendingStringColumn:
         Py_ssize_t total_bytes
         int na_count
         bint large
+        # set only for a batched probe's result, which skips validation
+        bint non_ascii
 
     def __dealloc__(self):
         # Only owns whatever materialize() has not yet transferred.
@@ -2880,7 +3290,8 @@ cdef inline Py_ssize_t _clamp_data_cap(int64_t want, parser_t *parser,
 cdef _string_pyarrow_utf8(parser_t *parser, int64_t col,
                           int64_t line_start, int64_t line_end,
                           bint na_filter, kh_str_starts_t *na_hashset,
-                          str target, bint defer=False):
+                          str target, bint defer=False,
+                          bint defer_non_ascii=False):
     """
     Build a pyarrow-backed string ExtensionArray directly from the C parser
     buffers, bypassing the intermediate ``ndarray[object]`` and its associated
@@ -2899,210 +3310,61 @@ cdef _string_pyarrow_utf8(parser_t *parser, int64_t col,
     With ``defer=True``, pure-ASCII columns are returned as a raw
     `_PendingStringColumn` (no numpy/pyarrow objects created); the
     c_parser_wrapper layer materializes them into one ExtensionArray per
-    column at the end of the read.
+    column at the end of the read.  ``defer_non_ascii`` extends that to
+    non-ASCII columns for the batched probe, which validates at the end.
     """
     cdef:
-        int na_count = 0
-        Py_ssize_t i, lines
-        Py_ssize_t total_bytes = 0
-        Py_ssize_t data_cap = 0
-        int64_t data_est = 0
-        Py_ssize_t probe, probe_seen, probe_bytes = 0
-        int64_t wlen
-        c_int64_t token_idx = 0
-        coliter_t it, probe_it
-        const char *word = NULL
-        char *grown = NULL
-        int32_t *offsets32_ptr = NULL
-        int64_t *offsets64_ptr = NULL
-        uint8_t *validity_ptr = NULL
-        char *data_ptr = NULL
-        bint large = target == "str_nan"
-        bint track_validity = na_filter
-        bint overflow = False
-        bint malloc_failed = False
-        bint saw_non_ascii = False
-        uint64_t ascii_acc = 0
-        uint64_t HIGH_BITS = 0x8080808080808080
-        const uint64_t *data_words = NULL
-        Py_ssize_t nwords, block_start, block_end, jw
-        const char *wild_limit = (
-            parser.stream + parser.stream_cap - WILDCOPY_SLACK
-            if parser.stream_cap >= WILDCOPY_SLACK
-            else parser.stream
-        )
+        _BlockColState st
+        Py_ssize_t lines = line_end - line_start
+        int error = 0
         _PendingStringColumn pending
 
-    lines = line_end - line_start
+    memset(&st, 0, sizeof(_BlockColState))
+    st.col = col
+    st.kind = BLOCK_KIND_STRING
+    st.na_filter = na_filter
+    st.na_hashset = na_hashset
+    st.large = target == "str_nan"
 
-    # Single GIL-free region covering every allocation and the one pass that
-    # fills the offsets, validity and data buffers together.  No numpy or
-    # pyarrow objects are created here, so parallel workers spend almost no
-    # time holding the GIL.
-    #
-    # Sizing the data buffer exactly would need a prior sizing pass, but that
-    # pass is the expensive half of the work: a column's tokens are strided
-    # through `word_ends`, whose 8 bytes per token outweigh the token bytes
-    # themselves at CSV widths, so a second sweep roughly doubles the memory
-    # traffic of the read.  Estimate the size instead from the column's own
-    # leading tokens, and grow geometrically in the rare case that falls short.
-    coliter_setup(&it, parser, col, line_start)
+    # One GIL-free region for the allocations and the pass; the batched path
+    # runs the same loop a block at a time.
     with nogil:
-        if large:
-            offsets64_ptr = <int64_t *>malloc(
-                (lines + 1) * sizeof(int64_t)
+        error = _string_block_init(parser, &st, line_start, lines)
+        if error == 0:
+            error = _string_block_convert(parser, &st, line_start, line_end, 0)
+        if error == 0:
+            _string_block_trim(&st)
+
+    if error != 0:
+        _free_block_string(&st)
+        if error == 2:
+            raise OverflowError(
+                "String column exceeds 2GiB, which is the maximum supported "
+                "by pyarrow's 'string' type."
             )
-            malloc_failed = offsets64_ptr == NULL
-            if not malloc_failed:
-                offsets64_ptr[0] = 0
-        else:
-            offsets32_ptr = <int32_t *>malloc(
-                (lines + 1) * sizeof(int32_t)
-            )
-            malloc_failed = offsets32_ptr == NULL
-            if not malloc_failed:
-                offsets32_ptr[0] = 0
+        raise MemoryError()
 
-        if track_validity and not malloc_failed:
-            # Start all-valid and clear bits on NA rows, so the common
-            # no-NA case does no per-token bitmap work.  Padding bits in
-            # the last byte stay set, which Arrow permits (their value is
-            # unspecified).
-            validity_ptr = <uint8_t *>malloc(
-                (lines + 7) // 8 if lines else 1
-            )
-            malloc_failed = validity_ptr == NULL
-            if not malloc_failed:
-                memset(validity_ptr, 0xFF, (lines + 7) // 8)
+    pending = _pending_from_state(&st, lines)
+    if defer_non_ascii and pending.non_ascii:
+        # only the batched probe asks for this; it validates later
+        return pending, pending.na_count
 
-        if not malloc_failed:
-            # Size the data buffer from this column's own leading tokens; a
-            # chunk-wide mean would misjudge a column much wider than its
-            # neighbours, and that column would then grow repeatedly,
-            # re-copying everything it had already written.
-            probe = 16 if lines > 16 else lines
-            probe_seen = 0
-            coliter_setup(&probe_it, parser, col, line_start)
-            while probe_seen < probe:
-                coliter_next_with_idx(&probe_it, &token_idx)
-                probe_bytes += _token_len(parser, token_idx)
-                probe_seen += 1
-            # Unclamped this extrapolates the probe over every row, which a
-            # column whose leading rows are much wider than the rest turns into
-            # a reservation bounded by nothing in the file.
-            if probe:
-                data_est = <int64_t>lines * (probe_bytes // probe + 1)
-            data_est += (data_est >> 2) + 64
-            data_cap = _clamp_data_cap(data_est, parser, large)
-            data_ptr = <char *>malloc(data_cap + WILDCOPY_SLACK)
-            malloc_failed = data_ptr == NULL
+    return _wrap_pending_string(parser, col, line_start, line_end, na_filter,
+                                na_hashset, target, defer, pending,
+                                pending.non_ascii)
 
-        for i in range(lines if not malloc_failed else 0):
-            word = coliter_next_with_idx(&it, &token_idx)
 
-            # Not strlen: an embedded NUL is a data byte here, so strlen would
-            # truncate the field at it (GH#66415).
-            wlen = _token_len(parser, token_idx)
-
-            if na_filter and kh_get_str_starts_item(na_hashset, word,
-                                                    <size_t>wlen):
-                na_count += 1
-                validity_ptr[i >> 3] &= <uint8_t>(~(1 << (i & 7)))
-                if large:
-                    offsets64_ptr[i + 1] = <int64_t>total_bytes
-                else:
-                    offsets32_ptr[i + 1] = <int32_t>total_bytes
-                continue
-
-            if not large and total_bytes + wlen > <Py_ssize_t>INT32_MAX:
-                overflow = True
-                break
-
-            if total_bytes + wlen > data_cap:
-                # Same bounds as the initial reservation.  Neither clamp can
-                # undersize the buffer: total_bytes + wlen never exceeds
-                # stream_len, and for the int32 target the overflow break above
-                # has already fired if it exceeds INT32_MAX.
-                data_cap = _clamp_data_cap(
-                    <int64_t>data_cap * 2 + wlen, parser, large
-                )
-                grown = <char *>realloc(data_ptr, data_cap + WILDCOPY_SLACK)
-                if grown == NULL:
-                    malloc_failed = True
-                    break
-                data_ptr = grown
-
-            if wlen:
-                # A row short of this column yields the "" literal rather than
-                # a pointer into the stream, so it must not reach the
-                # overshooting copy.  Its length is 0, as is a genuinely empty
-                # field's, so one test covers both.
-                _copy_token(data_ptr + total_bytes, word, wlen, wild_limit)
-
-            total_bytes += wlen
-            if large:
-                offsets64_ptr[i + 1] = <int64_t>total_bytes
-            else:
-                offsets32_ptr[i + 1] = <int32_t>total_bytes
-
-        if not overflow and not malloc_failed:
-            if total_bytes < data_cap >> 1:
-                # Less than half the reservation was used, so the leading rows
-                # this column was sized from are far wider than the rest of it.
-                # Give the tail back: untouched pages cost no RSS, but in this
-                # case the reservation is bounded only by the chunk's whole
-                # stream length, and it outlives the read.  A normal column
-                # keeps its buffer -- one malloc per (column, chunk), no more
-                # heap traffic in a worker than the exact-size allocation this
-                # replaced.  Failure just means we keep the larger block.
-                grown = <char *>realloc(data_ptr,
-                                        total_bytes + WILDCOPY_SLACK)
-                if grown != NULL:
-                    data_ptr = grown
-
-            # ASCII probe: a clear high bit across the data buffer means
-            # the column is pure ASCII, which is valid UTF-8 by
-            # construction, so the validate(full=True) below can be
-            # skipped.  Scan in 32KiB blocks so multibyte data bails out
-            # after the first block.
-            nwords = total_bytes >> 3
-            data_words = <const uint64_t *>data_ptr
-            block_start = 0
-            while block_start < nwords and not saw_non_ascii:
-                block_end = block_start + 4096
-                if block_end > nwords:
-                    block_end = nwords
-                for jw in range(block_start, block_end):
-                    ascii_acc |= data_words[jw]
-                if ascii_acc & HIGH_BITS:
-                    saw_non_ascii = True
-                block_start = block_end
-            if not saw_non_ascii:
-                for jw in range(nwords << 3, total_bytes):
-                    ascii_acc |= <uint8_t>data_ptr[jw]
-                saw_non_ascii = (ascii_acc & HIGH_BITS) != 0
-
-    if overflow or malloc_failed:
-        free(offsets64_ptr)
-        free(offsets32_ptr)
-        free(validity_ptr)
-        free(data_ptr)
-        if malloc_failed:
-            raise MemoryError()
-        raise OverflowError(
-            "String column exceeds 2GiB, which is the maximum supported "
-            "by pyarrow's 'string' type."
-        )
-
-    pending = _PendingStringColumn.__new__(_PendingStringColumn)
-    pending.offsets64_ptr = offsets64_ptr
-    pending.offsets32_ptr = offsets32_ptr
-    pending.validity_ptr = validity_ptr
-    pending.data_ptr = data_ptr
-    pending.lines = lines
-    pending.total_bytes = total_bytes
-    pending.na_count = na_count
-    pending.large = large
+cdef _wrap_pending_string(parser_t *parser, int64_t col,
+                          int64_t line_start, int64_t line_end,
+                          bint na_filter, kh_str_starts_t *na_hashset,
+                          str target, bint defer,
+                          _PendingStringColumn pending, bint saw_non_ascii):
+    """
+    Tail of `_string_pyarrow_utf8`: hand back the pending column, or
+    materialize it (validating non-ASCII data, with the object path as the
+    fallback) into the ExtensionArray for ``target``.
+    """
+    cdef int na_count = pending.na_count
 
     if defer and not saw_non_ascii:
         # Caller materializes and wraps into one ExtensionArray per column
@@ -3140,6 +3402,235 @@ cdef _string_pyarrow_utf8(parser_t *parser, int64_t col,
     arr._pa_array = _pa_chunked_array([pa_arr])
     arr._cache = {}
     return arr, na_count
+
+
+cdef int _string_block_init(parser_t *parser, _BlockColState *st,
+                            int64_t line_start, Py_ssize_t lines) noexcept nogil:
+    """
+    Allocate the string block state's buffers, sized as
+    `_string_pyarrow_utf8` sizes them.  Returns nonzero on allocation failure.
+    """
+    cdef:
+        coliter_t probe_it
+        c_int64_t token_idx = 0
+        Py_ssize_t probe, probe_seen, probe_bytes = 0
+        int64_t data_est = 0
+
+    if st.large:
+        st.offsets64 = <int64_t *>malloc((lines + 1) * sizeof(int64_t))
+        if st.offsets64 == NULL:
+            return 1
+        st.offsets64[0] = 0
+    else:
+        st.offsets32 = <int32_t *>malloc((lines + 1) * sizeof(int32_t))
+        if st.offsets32 == NULL:
+            return 1
+        st.offsets32[0] = 0
+
+    if st.na_filter:
+        st.validity = <uint8_t *>malloc((lines + 7) // 8 if lines else 1)
+        if st.validity == NULL:
+            return 1
+        memset(st.validity, 0xFF, (lines + 7) // 8)
+
+    probe = 16 if lines > 16 else lines
+    probe_seen = 0
+    coliter_setup(&probe_it, parser, st.col, line_start)
+    while probe_seen < probe:
+        coliter_next_with_idx(&probe_it, &token_idx)
+        probe_bytes += _token_len(parser, token_idx)
+        probe_seen += 1
+    if probe:
+        data_est = <int64_t>lines * (probe_bytes // probe + 1)
+    data_est += (data_est >> 2) + 64
+    st.data_cap = _clamp_data_cap(data_est, parser, st.large)
+    st.sdata = <char *>malloc(st.data_cap + WILDCOPY_SLACK)
+    if st.sdata == NULL:
+        return 1
+    return 0
+
+
+cdef void _string_block_trim(_BlockColState *st) noexcept nogil:
+    """
+    Give back a mostly unused data reservation: the leading rows it was sized
+    from were far wider than the rest, and it outlives the read.  Failure just
+    keeps the larger block.
+    """
+    cdef char *grown
+    if st.total_bytes < st.data_cap >> 1:
+        grown = <char *>realloc(st.sdata, st.total_bytes + WILDCOPY_SLACK)
+        if grown != NULL:
+            st.sdata = grown
+
+
+cdef _PendingStringColumn _pending_from_state(_BlockColState *st,
+                                              Py_ssize_t lines):
+    """Move the string state's buffers into a _PendingStringColumn."""
+    cdef _PendingStringColumn pending
+    pending = _PendingStringColumn.__new__(_PendingStringColumn)
+    pending.offsets64_ptr = st.offsets64
+    pending.offsets32_ptr = st.offsets32
+    pending.validity_ptr = st.validity
+    pending.data_ptr = st.sdata
+    st.offsets64 = NULL
+    st.offsets32 = NULL
+    st.validity = NULL
+    st.sdata = NULL
+    pending.lines = lines
+    pending.total_bytes = st.total_bytes
+    pending.na_count = st.na_count
+    pending.large = st.large
+    pending.non_ascii = (st.ascii_acc & <uint64_t>0x8080808080808080) != 0
+    return pending
+
+
+cdef void _free_block_string(_BlockColState *st) noexcept nogil:
+    free(st.offsets64)
+    free(st.offsets32)
+    free(st.validity)
+    free(st.sdata)
+    st.offsets64 = NULL
+    st.offsets32 = NULL
+    st.validity = NULL
+    st.sdata = NULL
+
+
+cdef int _string_block_convert(parser_t *parser, _BlockColState *st,
+                               int64_t blk_start, int64_t blk_end,
+                               Py_ssize_t off) noexcept nogil:
+    """
+    Append rows [blk_start, blk_end) of the column to the string state; the
+    per-token body of `_string_pyarrow_utf8`, resumable.  Nonzero on failure
+    (allocation, or int32 offsets overflowing).
+    """
+    cdef:
+        coliter_t it
+        c_int64_t token_idx = 0
+        const char *word = NULL
+        char *grown = NULL
+        int64_t wlen
+        Py_ssize_t i, row, jw, nwords
+        Py_ssize_t total_bytes = st.total_bytes
+        Py_ssize_t prev_bytes = st.total_bytes
+        Py_ssize_t data_cap = st.data_cap
+        char *data_ptr = st.sdata
+        bint large = st.large
+        bint na_filter = st.na_filter
+        # hot loop: state fields in locals
+        int64_t *offsets64 = st.offsets64
+        int32_t *offsets32 = st.offsets32
+        uint8_t *validity = st.validity
+        const kh_str_starts_t *na_hashset = st.na_hashset
+        int na_count = st.na_count
+        uint64_t acc = 0
+        const uint64_t *data_words
+        const char *wild_limit = (
+            parser.stream + parser.stream_cap - WILDCOPY_SLACK
+            if parser.stream_cap >= WILDCOPY_SLACK
+            else parser.stream
+        )
+
+    coliter_setup(&it, parser, st.col, blk_start)
+    for i in range(blk_end - blk_start):
+        row = off + i
+        word = coliter_next_with_idx(&it, &token_idx)
+        wlen = _token_len(parser, token_idx)
+
+        if na_filter and kh_get_str_starts_item(na_hashset, word,
+                                                <size_t>wlen):
+            na_count += 1
+            validity[row >> 3] &= <uint8_t>(~(1 << (row & 7)))
+            if large:
+                offsets64[row + 1] = <int64_t>total_bytes
+            else:
+                offsets32[row + 1] = <int32_t>total_bytes
+            continue
+
+        if not large and total_bytes + wlen > <Py_ssize_t>INT32_MAX:
+            st.total_bytes = total_bytes
+            st.na_count = na_count
+            return 2
+
+        if total_bytes + wlen > data_cap:
+            data_cap = _clamp_data_cap(
+                <int64_t>data_cap * 2 + wlen, parser, large
+            )
+            grown = <char *>realloc(data_ptr, data_cap + WILDCOPY_SLACK)
+            if grown == NULL:
+                st.total_bytes = total_bytes
+                st.na_count = na_count
+                return 1
+            data_ptr = grown
+            st.sdata = data_ptr
+            st.data_cap = data_cap
+
+        if wlen:
+            _copy_token(data_ptr + total_bytes, word, wlen, wild_limit)
+
+        total_bytes += wlen
+        if large:
+            offsets64[row + 1] = <int64_t>total_bytes
+        else:
+            offsets32[row + 1] = <int32_t>total_bytes
+
+    st.total_bytes = total_bytes
+    st.na_count = na_count
+
+    # ASCII probe over the bytes this block appended, while they are still
+    # cached; nothing left to learn once a non-ASCII byte has been seen.
+    if st.ascii_acc & <uint64_t>0x8080808080808080:
+        return 0
+    jw = prev_bytes
+    while jw < total_bytes and (jw & 7):
+        acc |= <uint8_t>data_ptr[jw]
+        jw += 1
+    data_words = <const uint64_t *>(data_ptr + jw)
+    nwords = (total_bytes - jw) >> 3
+    for i in range(nwords):
+        acc |= data_words[i]
+    jw += nwords << 3
+    while jw < total_bytes:
+        acc |= <uint8_t>data_ptr[jw]
+        jw += 1
+    st.ascii_acc |= acc
+    return 0
+
+
+cdef int _convert_block(parser_t *parser, _BlockColState *st,
+                        int64_t blk_start, int64_t blk_end, Py_ssize_t off,
+                        float64_t NA_f, int64_t NA_i, uint8_t NA_b,
+                        const kh_str_starts_t *true_set,
+                        const kh_str_starts_t *false_set) nogil:
+    """
+    Convert rows [blk_start, blk_end) of one batched column into its output
+    at row offset ``off``; nonzero means the column's inferred kind does not
+    hold and it must be re-converted whole.
+    """
+    cdef:
+        int blk_na = 0
+        int error
+
+    if st.kind == BLOCK_KIND_INT64:
+        error = _try_int64_nogil(parser, st.col, blk_start, blk_end,
+                                 st.na_filter, st.na_hashset, NA_i,
+                                 <int64_t *>st.data + off, &blk_na,
+                                 st.na_mask + off)
+    elif st.kind == BLOCK_KIND_FLOAT64:
+        error = _try_double_nogil(parser, parser.double_converter, st.col,
+                                  blk_start, blk_end, st.na_filter,
+                                  st.na_hashset, st.use_na_flist,
+                                  st.na_fhashset, NA_f,
+                                  <float64_t *>st.data + off, &blk_na,
+                                  st.na_mask + off)
+    elif st.kind == BLOCK_KIND_BOOL:
+        error = _try_bool_flex_nogil(parser, st.col, blk_start, blk_end,
+                                     st.na_filter, st.na_hashset, true_set,
+                                     false_set, NA_b,
+                                     <uint8_t *>st.data + off, &blk_na)
+    else:
+        return _string_block_convert(parser, st, blk_start, blk_end, off)
+    st.na_count += blk_na
+    return error
 
 
 @cython.wraparound(False)

--- a/pandas/io/parsers/readers.py
+++ b/pandas/io/parsers/readers.py
@@ -915,6 +915,9 @@ def _read_csv_chunks(
         # GIL-held pyarrow wrap happens once per column rather than once per
         # chunk in every worker.
         reader._engine.wrap_deferred = False
+        # Row-blocked conversion of numeric columns pays off once enough
+        # workers contend for memory bandwidth (see TextReader.block_workers).
+        reader._engine._reader.block_workers = n_workers
         reader._engine._warning_sink = warning_sink
         reader._engine._reader.warning_sink = warning_sink
         workers_readers.append(reader)

--- a/pandas/tests/io/parser/test_parallel_read.py
+++ b/pandas/tests/io/parser/test_parallel_read.py
@@ -32,6 +32,8 @@ from pandas.errors import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+from pandas._libs import parsers as _parsers
+
 import pandas as pd
 import pandas._testing as tm
 
@@ -1799,3 +1801,59 @@ def test_parallel_huge_int_first_line_matches_serial(tmp_path, monkeypatch):
     result = _read_forced_parallel(path, monkeypatch, dtype_backend="pyarrow")
 
     tm.assert_frame_equal(result, pd.read_csv(io.BytesIO(raw), dtype_backend="pyarrow"))
+
+
+# ---------------------------------------------------------------------------
+# Row-blocked column conversion (TextReader._convert_batched)
+# ---------------------------------------------------------------------------
+
+
+def _blocked_frame(n_rows: int = 30_000) -> pd.DataFrame:
+    # >= 16 columns, so numeric columns qualify for row-blocked conversion at
+    # any worker count; the string columns qualify on their own
+    rng = np.random.default_rng(0)
+    data: dict[str, object] = {
+        f"i{k}": rng.integers(-1000, 1000, size=n_rows) for k in range(6)
+    }
+    data.update({f"f{k}": rng.random(n_rows) for k in range(6)})
+    data.update(
+        {f"s{k}": rng.choice(["id1", "id22", "id333"], size=n_rows) for k in range(6)}
+    )
+    data["b0"] = rng.integers(0, 2, size=n_rows).astype(bool)
+    return pd.DataFrame(data)
+
+
+@pytest.mark.parametrize("threads", [1, 6])
+def test_row_blocked_conversion_matches_python_engine(tmp_path, monkeypatch, threads):
+    path = tmp_path / "blocked.csv"
+    _blocked_frame().to_csv(path, index=False)
+    monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
+    # tiny blocks, so every chunk spans many of them
+    monkeypatch.setattr(_parsers, "_BLOCK_BYTES", 2048)
+
+    with pd.option_context("mode.max_threads", threads):
+        result = pd.read_csv(path)
+    expected = pd.read_csv(path, engine="python")
+    tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize("threads", [1, 6])
+def test_row_blocked_conversion_late_dtype_miss(tmp_path, monkeypatch, threads):
+    # A column whose leading block infers one kind but whose later rows do
+    # not must fall back to the whole-column inference cascade.
+    df = _blocked_frame().astype(object)
+    df.loc[25_000, "i0"] = 1.5  # int -> float
+    df.loc[25_000, "i1"] = 2**63 + 5  # int -> uint64
+    df.loc[25_000, "i2"] = "abc"  # int -> str
+    df.loc[25_000, "f0"] = "oops"  # float -> str
+    df.loc[25_000, "s0"] = "h\u00e9llo"  # ASCII -> non-ASCII
+    df.loc[25_100, "i3"] = np.nan  # NA past the leading block
+    path = tmp_path / "late.csv"
+    df.to_csv(path, index=False)
+    monkeypatch.setattr(_readers, "_PARALLEL_READ_MIN_BYTES", 1)
+    monkeypatch.setattr(_parsers, "_BLOCK_BYTES", 2048)
+
+    with pd.option_context("mode.max_threads", threads):
+        result = pd.read_csv(path)
+    expected = pd.read_csv(path, engine="python")
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
GH-68379 converts a chunk's pyarrow string columns together, a block of rows at a time, so a block's `word_ends` and tokens are read from memory once and consumed by every column from cache. Numeric columns still got one full pass over the chunk each, and on wide frames and high-worker parallel reads those passes are bandwidth-bound too (`wide20 [par]` re-reads the chunk twenty times).

This adds int64 and float64 columns to that sweep. A column joins when the cascade's own first verdict -- its first non-NA token parses as an int, else as a float -- says so, except that a token overflowing int64 gives no verdict, since the cascade would land on uint64 or object; the sweep then runs the existing nogil converters a block at a time, and a later token that breaks the verdict sends the column back through the whole cascade. Those converters fail at the first bad token, so a wrong verdict wastes at most a partial block, the same prefix the cascade re-scans anyway; results are identical by construction. Numeric columns join only where the pass is bandwidth-bound: 16 or more columns, or a parallel read with 6 or more workers, and a chunk spanning at least 8 blocks. Bools never join (the per-token hash probes keep them compute-bound). String columns keep GH-68379's queue and sweep body; one difference is that a string column that overflows the `"arrow"` target's int32 offsets now leaves the sweep alone rather than discarding the whole batch.

csvbench (paired, 99% CI, 1% floor), this branch vs main at e0730cf05ba (which includes GH-68379), same venv and Cython on both sides:

**32 significant wins, 1 significant regression, 22 neutral** over the core, strings, threads and widths packs (55 cases; the `[par]` cases run at the default 4 workers):

| case | speedup |
|---|---|
| wide20 (20 int/float cols) ``[par]`` | 1.82x |
| wide (20 cols x 2M rows) @12 | 1.74x |
| wide ``[par]`` | 1.61x |
| wide @6 / @2 | 1.58x / 1.40x |
| int @12 | 1.37x |
| wide 20-col / 100-col, serial | 1.28x / 1.26x |
| float @12 | 1.23x |
| mixed (int/float/str/bool) @12 | 1.17x |

Every string case is neutral (0.99-1.01x), as it should be: the string path is GH-68379's. The one regression is ``str @12`` at 0.98x, a 12-worker case on a 12-core box. The int/float serial wins of 1.10-1.17x are a clang inlining artifact of the second call site for the nogil converters (arm64 only; x86 measured neutral there in the previous revision).

Numbers are from an M3 Pro; the x86 run in the previous revision of this PR (Xeon 8488C, 8 cores) showed about half the magnitude, as its larger L3 keeps more of the chunk cached.

Tracks GH-66152 (parallel scaling).

AI disclosure: drafted with Claude Code (`claude fable 5.1`), which wrote the implementation and ran the measurements under my direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LydN3zyLvkyDoGzRyFQoRN

