### PR TITLE
[backport 3.0.x] STYLE: fix typing in pandas/io/formats/printing.py

### DIFF
--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -261,12 +261,12 @@ def enable_data_resource_formatter(enable: bool) -> None:
     from IPython import get_ipython
 
     # error: Call to untyped function "get_ipython" in typed context
-    ip = get_ipython()  # type: ignore[no-untyped-call]
+    ip = get_ipython()
     if ip is None:
         # still not in IPython
         return
 
-    formatters = ip.display_formatter.formatters
+    formatters = ip.display_formatter.formatters  # type: ignore[union-attr]
     mimetype = "application/vnd.dataresource+json"
 
     if enable:

--- a/pandas/io/formats/printing.py
+++ b/pandas/io/formats/printing.py
@@ -266,7 +266,7 @@ def enable_data_resource_formatter(enable: bool) -> None:
         # still not in IPython
         return
 
-    formatters = ip.display_formatter.formatters  # type: ignore[union-attr]
+    formatters = ip.display_formatter.formatters
     mimetype = "application/vnd.dataresource+json"
 
     if enable:


### PR DESCRIPTION
(cherry picked from commit d77e7af6890b4287ebff0ae278487bc152a8165b)

Backporting typing changes from https://github.com/pandas-dev/pandas/pull/66598
