### PR TITLE
DOC: freeze the DataFrame.select whatsnew example

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -27,22 +27,34 @@ keyword arguments, with the keyword naming the resulting column. As with
 earlier in the same call
 (:issue:`61522`, :issue:`40322`).
 
-.. ipython:: python
+.. code-block:: pycon
 
-    df = pd.DataFrame(
-        {
-            "first_name": ["John", "Alice", "Bob"],
-            "last_name": ["Smith", "Cooper", "Marley"],
-            "age": [61, 22, 35],
-        }
-    )
-    df.select("first_name", "last_name")
-    df.select("first_name", pd.col("age"), age_months=pd.col("age") * 12)
-    df.select(
-        "first_name",
-        age_months=pd.col("age") * 12,
-        age_days=pd.col("age_months") * 30,
-    )
+   >>> df = pd.DataFrame(
+   ...     {
+   ...         "first_name": ["John", "Alice", "Bob"],
+   ...         "last_name": ["Smith", "Cooper", "Marley"],
+   ...         "age": [61, 22, 35],
+   ...     }
+   ... )
+   >>> df.select("first_name", "last_name")
+     first_name last_name
+   0       John     Smith
+   1      Alice    Cooper
+   2        Bob    Marley
+   >>> df.select("first_name", pd.col("age"), age_months=pd.col("age") * 12)
+     first_name  age  age_months
+   0       John   61         732
+   1      Alice   22         264
+   2        Bob   35         420
+   >>> df.select(
+   ...     "first_name",
+   ...     age_months=pd.col("age") * 12,
+   ...     age_days=pd.col("age_months") * 30,
+   ... )
+     first_name  age_months  age_days
+   0       John         732     21960
+   1      Alice         264      7920
+   2        Bob         420     12600
 
 .. _whatsnew_310.enhancements.enhancement2:
 


### PR DESCRIPTION
`main` is currently red on pre-commit for every open PR:

```
Whatsnew code examples must be static, not re-executed...........Failed
- hook id: no-executable-ipython-in-whatsnew
- exit code: 1
doc/source/whatsnew/v3.1.0.rst:30:.. ipython:: python
```

GH-67290 added that hook and converted the whatsnew directory's `.. ipython::` blocks to static `.. code-block:: pycon` sessions; it passed on the tree at the time, including the in-development `v3.1.0`. GH-66785 was last checked before the hook landed, so its `DataFrame.select` example merged green as a live `.. ipython::` block.

This freezes that block in the same style as the rest of the directory: `>>>`/`...` prompts, output pasted in. The output is what `e613083fc20` actually prints — I ran the three `df.select` calls against a build of that commit rather than transcribing them.

`git grep '^\s*\.\. ipython' -- doc/source/whatsnew/` now returns nothing, and `pre-commit run --files doc/source/whatsnew/v3.1.0.rst` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P821xNMBbL5gtv8DXp6mh8