### PR TITLE
DOC: document that assert_*_equal rtol/atol are numeric-only (GH#43913)

### DIFF
--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -75,9 +75,11 @@ cpdef assert_almost_equal(a, b,
     a : object
     b : object
     rtol : float, default 1e-5
-        Relative tolerance.
+        Relative tolerance. Only applied to numeric dtypes; values of other
+        dtypes, such as interval, are always compared exactly.
     atol : float, default 1e-8
-        Absolute tolerance.
+        Absolute tolerance. Only applied to numeric dtypes; values of other
+        dtypes, such as interval, are always compared exactly.
     check_dtype: bool, default True
         check dtype if both a and b are np.ndarray.
     obj : str, default None

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -101,9 +101,11 @@ def assert_almost_equal(
         then `RangeIndex` and `Index` with int64 dtype are also considered
         equivalent when doing type checking.
     rtol : float, default 1e-5
-        Relative tolerance.
+        Relative tolerance. Only applied to numeric dtypes; values of other
+        dtypes, such as interval, are always compared exactly.
     atol : float, default 1e-8
-        Absolute tolerance.
+        Absolute tolerance. Only applied to numeric dtypes; values of other
+        dtypes, such as interval, are always compared exactly.
     """
     if isinstance(left, Index):
         assert_index_equal(
@@ -259,9 +261,13 @@ def assert_index_equal(
         If True, both indexes must contain the same elements, in the same order.
         If False, both indexes must contain the same elements, but in any order.
     rtol : float, default 1e-5
-        Relative tolerance. Only used when check_exact is False.
+        Relative tolerance. Only used when check_exact is False, and only
+        applied to numeric dtypes; values of other dtypes, such as interval,
+        are always compared exactly.
     atol : float, default 1e-8
-        Absolute tolerance. Only used when check_exact is False.
+        Absolute tolerance. Only used when check_exact is False, and only
+        applied to numeric dtypes; values of other dtypes, such as interval,
+        are always compared exactly.
     obj : str, default 'Index' or 'MultiIndex'
         Specify object name being compared, internally used to show appropriate
         assertion message.
@@ -894,9 +900,13 @@ def assert_extension_array_equal(
             Defaults to True for integer dtypes if none of
             ``check_exact``, ``rtol`` and ``atol`` are specified.
     rtol : float, default 1e-5
-        Relative tolerance. Only used when check_exact is False.
+        Relative tolerance. Only used when check_exact is False, and only
+        applied to numeric dtypes; values of other dtypes, such as interval,
+        are always compared exactly.
     atol : float, default 1e-8
-        Absolute tolerance. Only used when check_exact is False.
+        Absolute tolerance. Only used when check_exact is False, and only
+        applied to numeric dtypes; values of other dtypes, such as interval,
+        are always compared exactly.
     obj : str, default 'ExtensionArray'
         Specify object name being compared, internally used to show appropriate
         assertion message.
@@ -1104,9 +1114,13 @@ def assert_series_equal(
     check_flags : bool, default True
         Whether to check the `flags` attribute.
     rtol : float, default 1e-5
-        Relative tolerance. Only used when check_exact is False.
+        Relative tolerance. Only used when check_exact is False, and only
+        applied to numeric dtypes; values of other dtypes, such as interval,
+        are always compared exactly.
     atol : float, default 1e-8
-        Absolute tolerance. Only used when check_exact is False.
+        Absolute tolerance. Only used when check_exact is False, and only
+        applied to numeric dtypes; values of other dtypes, such as interval,
+        are always compared exactly.
     obj : str, default 'Series'
         Specify object name being compared, internally used to show appropriate
         assertion message.
@@ -1432,9 +1446,13 @@ def assert_frame_equal(
     check_flags : bool, default True
         Whether to check the `flags` attribute.
     rtol : float, default 1e-5
-        Relative tolerance. Only used when check_exact is False.
+        Relative tolerance. Only used when check_exact is False, and only
+        applied to numeric dtypes; values of other dtypes, such as interval,
+        are always compared exactly.
     atol : float, default 1e-8
-        Absolute tolerance. Only used when check_exact is False.
+        Absolute tolerance. Only used when check_exact is False, and only
+        applied to numeric dtypes; values of other dtypes, such as interval,
+        are always compared exactly.
     obj : str, default 'DataFrame'
         Specify object name being compared, internally used to show appropriate
         assertion message.

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -631,6 +631,32 @@ def test_assert_series_equal_large_int_atol(dtype):
         )
 
 
+@pytest.mark.parametrize(
+    "left_values,right_values",
+    [
+        (
+            pd.arrays.IntervalArray.from_tuples([(1.0, 2.0)]),
+            pd.arrays.IntervalArray.from_tuples([(1.5, 2.0)]),
+        ),
+        (pd.to_datetime(["2020-01-01"]), pd.to_datetime(["2020-01-02"])),
+        (pd.to_timedelta([1], unit="D"), pd.to_timedelta([2], unit="D")),
+        (
+            pd.period_range("2020-01-01", periods=1, freq="D"),
+            pd.period_range("2020-01-02", periods=1, freq="D"),
+        ),
+        (pd.array(["a"], dtype="str"), pd.array(["b"], dtype="str")),
+    ],
+)
+def test_assert_series_equal_tolerance_numeric_only(left_values, right_values):
+    # GH#43913 rtol/atol are documented as numeric-only; non-numeric dtypes
+    #  compare exactly no matter how large the tolerance
+    left = pd.Series(left_values)
+    right = pd.Series(right_values)
+
+    with pytest.raises(AssertionError, match="are different"):
+        tm.assert_series_equal(left, right, check_exact=False, rtol=10, atol=10)
+
+
 def test_assert_series_equal_check_like_check_freq():
     # GH#51920 sorting a shuffled DatetimeIndex does not restore its freq, so
     #  the freq check is skipped with check_like=True


### PR DESCRIPTION
Follow-up to GH-43913, which I closed as no-action: `rtol`/`atol` are intended for floating-point wiggle room, and propagating them to interval opens the door to every other dtype (nested Arrow types being the worst case). Documenting the existing behavior instead, using the wording @rhshadrach proposed there.

Updates the `rtol`/`atol` parameter docs on `assert_almost_equal`, `assert_index_equal`, `assert_extension_array_equal`, `assert_series_equal`, `assert_frame_equal`, and the `_libs/testing.pyx` helper:

> Relative tolerance. Only used when check_exact is False, and only applied to numeric dtypes; values of other dtypes, such as interval, are always compared exactly.

Adds a test locking the rule in across the distinct dispatch branches — interval (`assert_interval_array_equal`), datetime64/timedelta64 (the `asi8` shortcut), Period (the EA object-cast fallback) and str (`_testing.assert_almost_equal`). Four of the five would pass at `rtol=10` if the tolerance were propagated.

Also relevant: GH-66844 is an open PR implementing the propagation, which this supersedes.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which confirmed empirically which dtypes honor the tolerances, wrote the docstring and test changes, and ran the checks.