### PR TITLE
TST: equal-direction coverage for the GH#66699 magnitude guard

### DIFF
--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pytest
 
@@ -196,17 +198,40 @@ def test_assert_almost_equal_large_mixed_integer_float_rtol():
     _assert_almost_equal_both(a, b, check_dtype=False, rtol=1 / 2**60, atol=0)
 
 
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        (
+            np.array([2**60], dtype="int64"),
+            np.array([float(2**60)], dtype="float64"),
+        ),
+        (
+            np.array([-(2**60)], dtype="int64"),
+            np.array([float(-(2**60))], dtype="float64"),
+        ),
+        (
+            np.array([2**64 - 2048], dtype="uint64"),  # 2048 = float64 ULP here
+            np.array([float(2**64 - 2048)], dtype="float64"),
+        ),
+    ],
+)
+def test_assert_almost_equal_large_mixed_integer_float_equal(left, right):
+    # GH#66699 magnitudes above 2**53 bypass the array_equivalent fast path, so
+    #  the equal case has to survive the elementwise comparison too.
+    _assert_almost_equal_both(left, right, check_dtype=False, rtol=0, atol=0)
+
+
 def test_assert_almost_equal_large_mixed_integer_float_message():
     integer = 2**60 + 1
     floating = float(2**60)
 
-    with pytest.raises(AssertionError) as exc_info:
-        tm.assert_almost_equal(integer, floating, rtol=0, atol=0.5)
-
-    assert str(exc_info.value) == (
+    msg = re.escape(
         "expected 1152921504606846976.00000 but got 1152921504606846977.00000, "
         "with rtol=0, atol=0.5"
     )
+    # \Z not $, so a trailing newline cannot slip past
+    with pytest.raises(AssertionError, match=rf"^{msg}\Z"):
+        tm.assert_almost_equal(integer, floating, rtol=0, atol=0.5)
 
 
 def test_assert_almost_equal_2d_large_mixed_integer_float():

--- a/pandas/tests/util/test_assert_index_equal.py
+++ b/pandas/tests/util/test_assert_index_equal.py
@@ -377,3 +377,22 @@ def test_assert_index_equal_check_freq_check_order_false(box, start):
     with tm.assert_produces_warning(None):
         tm.assert_index_equal(shuffled, idx, check_order=False)
         tm.assert_index_equal(shuffled, idx, check_order=False, check_freq=True)
+
+
+def test_assert_index_equal_large_mixed_integer_float():
+    # GH#66699 only exact=False reaches the magnitude guard; the default
+    #  "equiv" rejects an int64/float64 pair before it
+    left = pd.Index([2**60 + 1])
+    right = pd.Index([float(2**60)])
+
+    tm.assert_index_equal(left, right, exact=False, check_exact=False, rtol=0, atol=1)
+    msg = r"Index values are different \(100\.0 %\)"
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_index_equal(
+            left, right, exact=False, check_exact=False, rtol=0, atol=0.5
+        )
+
+    same = pd.Index([2**60])
+    tm.assert_index_equal(
+        same, pd.Index([float(2**60)]), exact=False, check_exact=False, rtol=0, atol=0
+    )

--- a/pandas/tests/util/test_assert_series_equal.py
+++ b/pandas/tests/util/test_assert_series_equal.py
@@ -613,6 +613,25 @@ def test_assert_series_equal_large_mixed_integer_float_rtol():
     )
 
 
+@pytest.mark.parametrize(
+    "left_values,right_values,left_dtype,right_dtype",
+    [
+        ([2**60], [float(2**60)], "int64", "float64"),
+        ([2**63], [float(2**63)], "uint64", "float64"),
+    ],
+)
+def test_assert_series_equal_large_mixed_integer_float_equal(
+    left_values, right_values, left_dtype, right_dtype
+):
+    # GH#66699 the same equal-direction guarantee, at Series level
+    left = pd.Series(left_values, dtype=left_dtype)
+    right = pd.Series(right_values, dtype=right_dtype)
+
+    _assert_series_equal_both(
+        left, right, check_dtype=False, check_exact=False, rtol=0, atol=0
+    )
+
+
 @pytest.mark.parametrize("dtype", ["int64", "Int64"])
 def test_assert_series_equal_large_int_atol(dtype):
     # GH#66400 an explicitly passed atol must be honored above 2**53 too;


### PR DESCRIPTION
GH-66722 made `assert_almost_equal` stop trusting `array_equivalent` for mixed integer/float arrays above float64's exactly-representable range, falling through to the elementwise loop instead. Every array test it shipped compares values that are *unequal*, so nothing pinned the other direction: that a pair which genuinely **is** equal still passes once the guard drops it into that loop. GH-68366 turned out to be exactly that failure mode, which is the argument for pinning it.

No `closes` line — GH-66699 was already fixed and closed by GH-66722. This only fills the coverage gap that PR left behind.

Adds the equal direction at three entry points:

- `assert_almost_equal` on ndarrays: int64 `2**60`, negative int64 (the only case reaching the guard's `min()` arm), and uint64 `2**64 - 2048` — a value above int64 max, which had no array-level coverage.
- `assert_series_equal`.
- `assert_index_equal`, which reaches the same guard via `exact=False` (the default `"equiv"` rejects an int64/float64 pair first) and had no coverage in *either* direction.

Worth being explicit about what these do and do not pin, since it is not obvious: the two equal-direction tests pass even if the guard is reverted to a bare `return True`, because `array_equivalent` returns `True` for their inputs. They are forward regression guards on the elementwise path, not guards on the guard. The `assert_index_equal` test is the only added test that actually fails if the guard is reverted.

Also converts GH-66722's message test from `assert str(exc_info.value) == (...)` to the file's `pytest.raises(match=...)` convention, anchored `^...\Z` so it stays exactly as strict as the `==` it replaces.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the tests and ran a multi-round blind review over the diff; every finding was verified against a local build before acting on it.