### PR TITLE
DOC: correct overstated Day/Timedelta bullet in the 3.0 whatsnew

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -747,7 +747,7 @@ small behavior differences as collateral:
 - :class:`Timedelta` no longer accepts :class:`.Day` objects as inputs
 - :meth:`tseries.frequencies.to_offset` on a :class:`Timedelta` object returns an :class:`.offsets.Hour` object in cases where it used to return a :class:`.Day` object.
 - Adding or subtracting a scalar from a timezone-aware :class:`DatetimeIndex` with a :class:`.Day` ``freq`` no longer preserves that ``freq`` attribute.
-- Adding or subtracting a :class:`.Day` with a :class:`Timedelta` is no longer supported.
+- Subtracting a :class:`Timedelta` from a :class:`.Day` is no longer supported.
 - Adding or subtracting a :class:`.Day` offset to a timezone-aware :class:`Timestamp` or datetime-like may lead to an ambiguous or non-existent time, which will raise.
 
 .. _whatsnew_300.api_breaking.nan_vs_na:


### PR DESCRIPTION
The ``offsets_day_not_a_tick`` section added by GH-61985 lists as collateral that
"Adding or subtracting a ``Day`` with a ``Timedelta`` is no longer supported". Only
subtraction in one direction actually changed:

| expression | 2.3.3 | 3.0.5 | main |
|---|---|---|---|
| `Day(1) + Timedelta("1h")` | works | works | works |
| `Timedelta("1h") + Day(1)` | works | works | works |
| `Timedelta("1h") - Day(1)` | works | works | works |
| `Day(1) - Timedelta("1h")` | `23:00:00` | raises | raises |

`Day - Timedelta` broke because `Day` stopped being a `Tick`, so `Timedelta.__rsub__` no
longer catches it while `BaseOffset.__sub__` handles same-type operands only. Narrowed the
bullet to say that.

The neighbouring bullet, ":class:`Timedelta` no longer accepts :class:`.Day` objects as
inputs", is correct for 3.0 and is left alone — it was reverted for 3.1 by GH-64306, which
records that in the 3.1 whatsnew. The other five bullets in the list were re-verified and
all hold.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which measured each
spelling against the released 2.3.3 and 3.0.5 wheels and main to establish which bullets
were accurate.