### PR TITLE
BUG: SparseArray constructor raised on object data holding pd.NA

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1088,6 +1088,7 @@ Sparse
 - Bug in ``np.std`` and ``np.var`` on a :class:`SparseArray` returning ``NaN`` when the array held missing values, inconsistently with ``np.sum`` and ``np.mean``, which skip them (:issue:`68194`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
 - Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a differently-indexed :class:`Series` raising an uninformative error instead of aligning and returning the expected result (:issue:`32119`)
+- Bug in the :class:`SparseArray` constructor raising ``TypeError: boolean value of NA is ambiguous`` for object-dtype data holding ``pd.NA`` unless the fill value was itself missing (:issue:`68439`)
 - Bug in the repr of a datetime64 or timedelta64 :class:`SparseDtype`-backed :class:`Series`, and in casting such an array to ``object`` dtype, showing raw integers such as ``1577836800000000000`` instead of :class:`Timestamp`/:class:`Timedelta` values (:issue:`68073`)
 
 ExtensionArray

--- a/pandas/_libs/sparse.pyx
+++ b/pandas/_libs/sparse.pyx
@@ -747,7 +747,9 @@ def make_mask_object_ndarray(ndarray[object, ndim=1] arr, object fill_value):
 
     for i in range(new_length):
         value = arr[i]
-        if value == fill_value and type(value) is type(fill_value):
+        # the type check must come first: comparing e.g. pd.NA to a non-NA
+        # fill value gives a non-boolean result, see GH#68439
+        if type(value) is type(fill_value) and value == fill_value:
             mask[i] = 0
 
     return mask.view(dtype=bool)

--- a/pandas/tests/arrays/sparse/test_constructors.py
+++ b/pandas/tests/arrays/sparse/test_constructors.py
@@ -245,6 +245,20 @@ class TestConstructors:
         assert dense.dtype == bool
         tm.assert_numpy_array_equal(dense, data)
 
+    @pytest.mark.parametrize("fill_value", [0, "A", False])
+    def test_constructor_object_dtype_na_stored(self, fill_value):
+        # GH#68439 gap detection compared pd.NA against the fill value and took
+        # the truth of the result, raising "boolean value of NA is ambiguous"
+        data = np.array([1, pd.NA], dtype=object)
+
+        arr = SparseArray(data, fill_value=fill_value)
+        assert arr.dtype == pd.SparseDtype(object, fill_value)
+        tm.assert_numpy_array_equal(
+            arr.sp_index.indices, np.array([0, 1], dtype=np.int32)
+        )
+        tm.assert_numpy_array_equal(np.asarray(arr), data)
+        tm.assert_numpy_array_equal(np.asarray(arr.isna()), np.array([False, True]))
+
     def test_constructor_bool_fill_value(self):
         arr = SparseArray([True, False, True], dtype=None)
         assert arr.dtype == pd.SparseDtype(np.bool_)


### PR DESCRIPTION
The gap-detection mask in `make_mask_object_ndarray` evaluated `value == fill_value` before the type check, so object-dtype data holding `pd.NA` could only be sparsified when the fill value was itself NA. Any other fill value made the comparison return `pd.NA`, and the enclosing `if` then raised:

```python
data = np.array([1, pd.NA], dtype=object)

SparseArray(data, fill_value=pd.NA)              # Sparse[object, <NA>] -- fine
SparseArray(data, fill_value=0)                  # TypeError: boolean value of NA is ambiguous
SparseArray(data, dtype=SparseDtype(object, 0))  # same
```

`None` and `np.nan` in the same position always worked, which is what isolates it to `pd.NA`.

Reordering the conjunction so the type check short-circuits fixes it, and is strictly cheaper: the types have to match for the comparison's result to be used at all. `pd.NA` now sparsifies as an ordinary stored value and `isna()` reports it as missing. The 0 / 0.0 / `False` type-discrimination that the check exists for (GH-17574) is unchanged.

There is no GitHub issue for this one; it was found while sweeping `SparseDtype` subtypes for an unrelated fix.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the short-circuit order, wrote the fix and the regression test, and ran the sparse test suite.
