### PR TITLE
TST: cover eval/query issues verified fixed on main

### DIFF
--- a/pandas/tests/computation/test_eval.py
+++ b/pandas/tests/computation/test_eval.py
@@ -1958,6 +1958,14 @@ def test_eval_float_div_numexpr():
     assert result == expected
 
 
+def test_call_with_binop_argument():
+    # GH#24670 a compound call argument has no .value to read off, as the
+    #  unary case in test_unary_in_function
+    floor = np.floor  # noqa: F841
+    result = pd.eval("floor(1.5 + 2)")
+    assert result == 3.0
+
+
 def test_method_calls_on_binop():
     # GH 61175
     x = pd.Series([1, 2, 3, 5])

--- a/pandas/tests/frame/methods/test_set_index.py
+++ b/pandas/tests/frame/methods/test_set_index.py
@@ -419,6 +419,16 @@ class TestSetIndex:
         idf = idf.reset_index().set_index("B")
         tm.assert_index_equal(idf.index, ci)
 
+    def test_set_index_preserve_object_dtype_after_query(self):
+        # GH#30517 set_index must not re-infer a subset that happens to be numeric;
+        #  reset_index still does, so the round trip is not yet lossless
+        df = pd.DataFrame({"mixed": [1, 2, "abc", "def"], "ints": [100, 200, 300, 400]})
+
+        result = df.query("ints < 300").set_index("mixed").index
+        expected = pd.Index([1, 2], dtype=object, name="mixed")
+
+        tm.assert_index_equal(result, expected)
+
     def test_set_index_preserve_categorical_dtype(self):
         # GH#13743, GH#13854
         df = pd.DataFrame(

--- a/pandas/tests/frame/test_query_eval.py
+++ b/pandas/tests/frame/test_query_eval.py
@@ -222,6 +222,17 @@ class TestDataFrameEval:
 
         tm.assert_frame_equal(result, df.iloc[[1]])
 
+    @pytest.mark.parametrize("name", ["Timestamp", "datetime", "list", "tuple"])
+    def test_query_index_name_shadowing_default_global(self, name, engine, parser):
+        # GH#34958, GH#35595 an index level wins over the type-valued
+        #  DEFAULT_GLOBALS; test_eval.py::test_eval_no_support_column_name
+        #  covers the column side
+        df = pd.DataFrame({"b": [3, 4]}, index=pd.Index([1, 20], name=name))
+
+        result = df.query(f"{name} < 10", engine=engine, parser=parser)
+
+        tm.assert_frame_equal(result, df.iloc[[0]])
+
     def test_query_duplicate_column_name_cleaned_name_collision(self, engine, parser):
         # GH#65588 clean_column_name is not injective, so the recorder has to
         # ask which label the cleaned name actually resolves to (the last one
@@ -354,6 +365,16 @@ class TestDataFrameEval:
         res = df.eval("@np.floor(a)", engine=engine, parser=parser)
         expected = np.floor(df["a"])
         tm.assert_series_equal(expected, res)
+
+    def test_using_local_function_with_scalar_arg(self, engine, parser):
+        # GH#22649 the bare-name branch of visit_Call; test_using_numpy covers
+        #  the same fix through the attribute branch
+        skip_if_no_pandas_parser(parser)
+        around = np.around  # noqa: F841
+        df = pd.Series([1.12, 2.76], name="a").to_frame()
+        result = df.eval("@around(a, 1)", engine=engine, parser=parser)
+        expected = np.around(df["a"], 1)
+        tm.assert_series_equal(result, expected)
 
     def test_eval_simple(self, engine, parser):
         df = pd.Series([0.2, 1.5, 2.8], name="a").to_frame()
@@ -1249,6 +1270,42 @@ class TestDataFrameQueryStrings:
             res = df.query('["a", "b"] != strings', engine=engine, parser=parser)
             tm.assert_frame_equal(res, expect)
 
+    def test_query_str_accessor_method(self, parser, engine):
+        # GH#26549
+        df = pd.DataFrame({"colA": list("0123456789")})
+
+        result = df.query('colA.str.contains("0")', engine=engine, parser=parser)
+
+        tm.assert_frame_equal(result, df[df["colA"].str.contains("0")])
+
+    def test_query_str_contains_word_boundary(self, parser, engine):
+        # GH#32589 was a non-raw outer string, not a pandas bug; this pins that
+        #  _preparse leaves a backslash escape inside a string literal alone
+        df = pd.DataFrame({"A": ["A test case", "Another Testing Case"]})
+        pat = r"\btest\b"
+
+        result = df.query(
+            f"A.str.contains(r'{pat}', regex=True, case=False)",
+            engine=engine,
+            parser=parser,
+        )
+
+        expected = df[df["A"].str.contains(pat, regex=True, case=False)]
+        tm.assert_frame_equal(result, expected)
+
+    def test_query_str_slice_negative_index(self, parser, engine):
+        # GH#49905 visit_Call's unary argument, as in
+        #  test_eval.py::test_unary_in_function; the a.str[-1:] spelling in the
+        #  same issue still raises, see visit_Slice
+        df = pd.DataFrame({"a": ["example", "zzz"]})
+
+        result = df.query(
+            'a.str.slice(0, -1).str.contains("e")', engine=engine, parser=parser
+        )
+
+        expected = df[df["a"].str.slice(0, -1).str.contains("e")]
+        tm.assert_frame_equal(result, expected)
+
     def test_query_with_string_columns(self, parser, engine):
         df = pd.DataFrame(
             {
@@ -1785,6 +1842,22 @@ class TestDataFrameQueryBacktickQuoting:
         expected = pd.DataFrame({"a": [2]}, index=range(1, 2), dtype=dtype)
         tm.assert_frame_equal(result, expected)
 
+    def test_query_ea_dtype_scalar_comparison(self, any_numeric_ea_and_arrow_dtype):
+        # GH#25369
+        df = pd.DataFrame(
+            {"col_test": [4, None, 6]}, dtype=any_numeric_ea_and_arrow_dtype
+        )
+        warning = RuntimeWarning if NUMEXPR_INSTALLED else None
+        msg = (
+            "Engine has switched to 'python' because numexpr does not "
+            "support extension array dtypes. Please set your engine "
+            "to python manually."
+        )
+        with tm.assert_produces_warning(warning, match=msg):
+            result = df.query("col_test != 6")
+
+        tm.assert_frame_equal(result, df.iloc[:1])
+
     @pytest.mark.parametrize("engine", ["python", "numexpr"])
     @pytest.mark.parametrize("dtype", ["int64", "Int64", "int64[pyarrow]"])
     def test_query_ea_equality_comparison(self, dtype, engine):
@@ -1902,3 +1975,39 @@ class TestDataFrameQueryInWithColumnRefs:
         result = df.query("a in (2, 3)", engine=engine, parser=parser)
         expected = df[df["a"].isin([2, 3])]
         tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype, values",
+    [
+        ("datetime64[ns]", ["2020-01-01", "2020-01-02"]),
+        ("timedelta64[ns]", ["5 days", "3 days"]),
+        ("period[D]", ["2020-01-01", "2020-01-02"]),
+    ],
+)
+@pytest.mark.xfail(
+    reason="GH#23420, GH#35595 _rewrite_membership_op turns == into isin, "
+    "which does not parse the string"
+)
+def test_query_datetimelike_eq_string(dtype, values, engine, parser):
+    skip_if_no_pandas_parser(parser)
+    df = pd.DataFrame({"a": pd.array(values, dtype=dtype)})
+
+    result = df.query(f'a == "{values[0]}"', engine=engine, parser=parser)
+
+    tm.assert_frame_equal(result, df.iloc[[0]])
+
+
+@pytest.mark.parametrize(
+    "op, func",
+    [("<", operator.lt), ("<=", operator.le), (">", operator.gt), (">=", operator.ge)],
+)
+def test_query_timedelta_compared_to_string(op, func, engine, parser):
+    # GH#23420 the ordered comparisons raised ValueError on timedelta;
+    #  == is still wrong, see test_query_datetimelike_eq_string
+    df = pd.DataFrame({"dt": pd.to_timedelta(["5 days", "3 days"])})
+
+    result = df.query(f'dt {op} "4 days"', engine=engine, parser=parser)
+
+    expected = df[func(df["dt"], pd.Timedelta("4 days"))]
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #22649
closes #24670
closes #25369
closes #26549
closes #34958

I was handed a list claiming eleven old `expressions` issues were fixed on main. Re-running every
repro in each issue — including the ones in comment threads — the list was wrong about four of
them. This adds regression tests for the claims that hold up, and records the ones that don't.

Closed above, each now pinned by a test:

- GH-22649 — `@around(x, 1)` under numexpr (the bare-name branch of `visit_Call`).
- GH-24670 — `pd.eval("floor(1 + 2)")`, a compound call argument.
- GH-25369 — extension dtypes in `query`, which now fall back to the python engine with a warning.
- GH-26549 — the `.str` accessor inside `query`.
- GH-34958 — a column shadowing a `DEFAULT_GLOBALS` name. The column side was already covered by
  `test_eval_no_support_column_name`, so only the index-level case was missing.

Not closed, because only part of each is fixed. The still-live half is a repro from the issue's
own comment thread in the first two:

- GH-30517 — `set_index` no longer re-infers (pinned here), but `reset_index` still does, so the
  round trip stays lossy.
- GH-49905 — `a.str.slice(0, -1)` works (pinned here), but `a.str[-1:]` still raises
  `AttributeError: 'UnaryOp' object has no attribute 'value'` from `visit_Slice` — the same
  unguarded `.value` that #48511 repaired in `visit_Call`.
- GH-23420 — the reported `ValueError` on `<` is fixed (pinned here), but `==` against a string is
  now silently all-False.
- GH-35595 — an index or column named `datetime` resolves correctly (pinned here), but a
  datetime64-valued level compared with `==` returns an empty frame.

The last two share one cause: `_rewrite_membership_op` turns `col == "<str>"` into
`col.isin(["<str>"])`, so `convert_values` skips the string coercion because the operand is no
longer a scalar. `isin` does not parse the string, leaving `==` silently wrong for datetime64,
timedelta64 and Period while the ordered comparisons stay correct. `test_query_datetimelike_eq_string`
records that as a strict xfail so it cannot stay invisible; the fix belongs in its own PR.

Two need no test here:

- GH-54449 was a numexpr 2.8.5 regression. `compat/_optional.py` floors numexpr at 2.11.0, and
  `test_local_syntax` already drives the `@local` path under numexpr.
- GH-32589 is not a pandas bug: the reporter's outer Python string was not raw, so `\b` was a
  literal backspace before pandas saw it, and the raw spelling has always worked. I kept the test
  as a guard that `_preparse` leaves a backslash escape inside a string literal alone. Worth
  closing as invalid rather than fixed.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`) — it ran the issue repros, wrote
the tests, and reviewed the branch.
