### PR TITLE
BUG: spurious select_dtypes deprecation warning when str columns are already named

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5911,17 +5911,26 @@ class DataFrame(NDFrame, OpsMixin):
             return True
 
         blk_dtypes = [blk.dtype for blk in self._mgr.blocks]
-        # ``str`` (the type) and ``StringDtype`` (from a "str"/"string" spec)
-        # both count as the user explicitly handling string columns.
-        string_specs = {str, StringDtype}
-        if (
-            np.object_ in include_set
-            and string_specs.isdisjoint(include_set)
-            and string_specs.isdisjoint(exclude_set)
-            and any(
-                isinstance(dtype, StringDtype) and dtype.na_value is np.nan
-                for dtype in blk_dtypes
-            )
+
+        def is_handled(dtype: StringDtype) -> bool:
+            # A spec other than ``object`` that matches this column decides
+            # its fate whether or not ``object`` keeps selecting str columns
+            # (GH#61916).
+            for spec in include_set | exclude_set:
+                if spec is str:
+                    return True
+                if isinstance(spec, type):
+                    if issubclass(spec, ExtensionDtype) and isinstance(dtype, spec):
+                        return True
+                elif dtype == spec:
+                    return True
+            return False
+
+        if np.object_ in include_set and any(
+            isinstance(dtype, StringDtype)
+            and dtype.na_value is np.nan
+            and not is_handled(dtype)
+            for dtype in blk_dtypes
         ):
             # GH#61916
             warnings.warn(

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -952,6 +952,79 @@ def test_select_dtypes_ea_class_string_with_object_no_warning():
     tm.assert_frame_equal(result, df[["a"]])
 
 
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({"include": object, "exclude": pd.StringDtype(na_value=np.nan)}, ["o"]),
+        ({"include": object, "exclude": ExtensionDtype}, ["o"]),
+        ({"include": [object, pd.StringDtype(na_value=np.nan)]}, ["s", "o"]),
+        ({"include": [object, ExtensionDtype]}, ["s", "o"]),
+    ],
+)
+def test_select_dtypes_str_dtype_named_by_instance_or_base_no_warning(kwargs, expected):
+    # GH#61916: a StringDtype instance or the ExtensionDtype base class names the
+    # str columns just as str and the StringDtype class do, so nothing to warn about
+    df = pd.DataFrame(
+        {
+            "s": pd.array(["x", "y"], dtype=pd.StringDtype(na_value=np.nan)),
+            "o": np.array([{"k": 1}, None], dtype=object),
+        }
+    )
+    with tm.assert_produces_warning(None):
+        result = df.select_dtypes(**kwargs)
+    tm.assert_frame_equal(result, df[expected])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        # the pd.NA flavor of StringDtype matches no column here
+        {"include": [object, pd.StringDtype()]},
+        # an extension dtype class, but not one the str column is an instance of
+        {"include": [object, pd.CategoricalDtype]},
+        {"include": object, "exclude": pd.CategoricalDtype},
+    ],
+)
+def test_select_dtypes_str_dtype_not_named_still_warns(kwargs):
+    # GH#61916: none of these specs match "s", so 'object' is still the only
+    # thing selecting it and the result will change
+    df = pd.DataFrame(
+        {
+            "s": pd.array(["x", "y"], dtype=pd.StringDtype(na_value=np.nan)),
+            "o": np.array([{"k": 1}, None], dtype=object),
+        }
+    )
+    msg = "For backward compatibility, 'str' dtypes are included"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = df.select_dtypes(**kwargs)
+    tm.assert_frame_equal(result, df)
+
+
+def test_select_dtypes_str_dtype_one_storage_named_still_warns():
+    # GH#61916: the spec names only the python-backed column, so "b" is still
+    # selected by 'object' alone and its fate does change
+    pytest.importorskip("pyarrow")
+    df = pd.DataFrame(
+        {
+            "a": pd.array(
+                ["x", "y"], dtype=pd.StringDtype(storage="python", na_value=np.nan)
+            ),
+            "b": pd.array(
+                ["x", "y"], dtype=pd.StringDtype(storage="pyarrow", na_value=np.nan)
+            ),
+        }
+    )
+    msg = "For backward compatibility, 'str' dtypes are included"
+    spec = pd.StringDtype(storage="python", na_value=np.nan)
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = df.select_dtypes(include=[object, spec])
+    tm.assert_frame_equal(result, df)
+
+    with tm.assert_produces_warning(None):
+        result = df.select_dtypes(include=[object, pd.StringDtype])
+    tm.assert_frame_equal(result, df)
+
+
 def test_select_dtypes_ea_base_class():
     # GH#65366: the ExtensionDtype base class matches all extension dtypes
     df = pd.DataFrame(


### PR DESCRIPTION
`DataFrame.select_dtypes` warns (GH-61916) that passing `object` to `include` also selects `str` columns and will stop doing so in a future version. The warning is suppressed when the user has already named the `str` columns, but the suppression was a membership test against `{str, StringDtype}`, so it recognized only the spellings `str` and the `StringDtype` class. A `StringDtype` instance and the `ExtensionDtype` base class were not recognized, even though each decides the `str` columns' fate on its own:

```python
df = pd.DataFrame({"s": ["x", "y"], "o": [{"k": 1}, None]})
df.select_dtypes(include=object, exclude=pd.StringDtype(na_value=np.nan))  # warns; ["o"]
df.select_dtypes(include=[object, pd.api.extensions.ExtensionDtype])       # warns; ["s", "o"]
```

Both calls already give the same answer before and after the deprecation lands, so the warning asks for something the user has done. Replaced with a per-column check: a `str` column is handled if any spec other than `object` matches it. Results are unchanged. A spec that does not match the column still warns — `pd.StringDtype()` (the `pd.NA` flavor), or a `StringDtype` naming one storage when the frame has both.

No whatsnew entry: neither spelling warned in any released version. `StringDtype` instances regressed in GH-66120, which stopped normalizing instance specs to `dtype.type`, and the `ExtensionDtype` base class only became a usable spec in GH-66118 — both unreleased. In 3.0.5 `infer_dtype_from_object` turned a `StringDtype` instance into `str`, satisfying the old `str not in include` guard.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and ran the reproducers and differential sweeps.
