### PR TITLE
BUG: DataFrame.dtypes could be left permanently stale by a concurrent write

### DIFF
--- a/pandas/_libs/internals.pyx
+++ b/pandas/_libs/internals.pyx
@@ -889,6 +889,7 @@ cdef class BlockManager:
         self._is_consolidated = False
         self._known_consolidated = False
         self._interleaved_dtype = None
+        self._dtypes_cache = None
         self._rebuild_blknos_and_blklocs()
 
     # -------------------------------------------------------------------

--- a/pandas/core/internals/managers.py
+++ b/pandas/core/internals/managers.py
@@ -343,9 +343,13 @@ class BaseBlockManager(PandasObject):
     def get_dtypes(self) -> npt.NDArray[np.object_]:
         cache = self._dtypes_cache
         if cache is None:
-            dtypes = np.array([blk.dtype for blk in self.blocks], dtype=object)
+            blocks = self.blocks
+            dtypes = np.array([blk.dtype for blk in blocks], dtype=object)
             cache = dtypes.take(self.blknos)
-            self._dtypes_cache = cache
+            # An invalidating write that landed while we computed has already
+            # cleared the cache, so storing now would leave the stale array for good.
+            if blocks is self.blocks:
+                self._dtypes_cache = cache
         return cache.copy()
 
     @property
@@ -1435,8 +1439,8 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
                 self._blknos[unfit_idxr] = len(self.blocks)
                 self._blklocs[unfit_idxr] = np.arange(unfit_count)
 
-            # Invalidate cache before mutating blocks so that a concurrent
-            # reader never sees stale cache + new blocks.
+            # Invalidate the caches before swapping blocks; see get_dtypes
+            # for the window this ordering leaves open.
             self._interleaved_dtype = None
             self._dtypes_cache = None
             self._known_consolidated = False
@@ -1522,8 +1526,8 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
         nb = new_block_2d(value, placement=blk._mgr_locs, refs=refs)
         old_blocks = self.blocks
         new_blocks = (*old_blocks[:blkno], nb, *old_blocks[blkno + 1 :])
-        # Invalidate cache before mutating blocks so that a concurrent
-        # reader never sees stale cache + new blocks.
+        # Invalidate the caches before swapping blocks; see get_dtypes
+        # for the window this ordering leaves open.
         self._interleaved_dtype = None
         self._dtypes_cache = None
         self.blocks = new_blocks
@@ -1595,8 +1599,8 @@ class BlockManager(libinternals.BlockManager, BaseBlockManager):
             self._insert_update_blklocs_and_blknos(loc)
 
         self.axes[0] = new_axis
-        # Invalidate cache before mutating blocks so that a concurrent
-        # reader never sees stale cache + new blocks.
+        # Invalidate the caches before swapping blocks; see get_dtypes
+        # for the window this ordering leaves open.
         self._interleaved_dtype = None
         self._dtypes_cache = None
         self._known_consolidated = False

--- a/pandas/tests/internals/test_internals.py
+++ b/pandas/tests/internals/test_internals.py
@@ -944,6 +944,33 @@ class TestGetDtypesCache:
         tm.assert_series_equal(df.dtypes, expected)
         tm.assert_frame_equal(view, pd.DataFrame({"a": [1, 2], "b": [3, 4]}))
 
+    def test_stale_array_not_cached_when_blocks_replaced(self):
+        # GH#68446 get_dtypes must not cache an array it built from blocks that a
+        # write has replaced meanwhile: that write's invalidation already ran.
+        df = pd.DataFrame(
+            {"a": pd.array([1], dtype="Int64"), "b": pd.array([2], dtype="Int64")}
+        )
+        mgr = df._mgr
+        blocks = mgr.blocks
+
+        class WriteWhileReadingDtypes:
+            # stands in for a write landing while get_dtypes walks mgr.blocks
+            def __init__(self, block) -> None:
+                self.block = block
+
+            @property
+            def dtype(self):
+                mgr.blocks = blocks  # the write must not see this stand-in
+                df["b"] = np.array([1.5])
+                return self.block.dtype
+
+        mgr._dtypes_cache = None
+        mgr.blocks = (WriteWhileReadingDtypes(blocks[0]), *blocks[1:])
+        mgr.get_dtypes()
+
+        expected = pd.Series([pd.Int64Dtype(), np.dtype("float64")], index=["a", "b"])
+        tm.assert_series_equal(df.dtypes, expected)
+
 
 def _as_array(mgr):
     if mgr.ndim == 1:


### PR DESCRIPTION
Follow-up to GH-65479, which added a `_dtypes_cache` to `BlockManager`. `get_dtypes` reads `self.blocks`, builds the per-column dtypes array from it, and only then stores that array in the cache. A write landing in that window has already run its own invalidation, so the reader's late store installs an array nothing clears again: `df.dtypes` then disagrees with `df[col].dtype`, with the block, and with `select_dtypes` for the life of the frame. Before GH-65479 `get_dtypes` recomputed on every call, so a racing read could at worst return one bad array without leaving the frame damaged.

On a 200k-block frame at the default switch interval this reproduced in 6/6 trials; the pre-GH-65479 body was 0/4 under the identical race.

The store is now conditional on `self.blocks` still being the tuple the array was computed from. Every site that invalidates the cache rebinds `self.blocks` to a new tuple, so the identity check catches all of them. This narrows the permanent-staleness window to the gap between the check and the store rather than closing it — check-then-act is not atomic — but that gap is a single statement instead of an O(nblocks) computation. The warm path is untouched, so GH-65479's speedup is unaffected.

Also here:

- `BlockManager._post_setstate` now clears `_dtypes_cache` alongside the three sibling slots it already resets. Latent today, since `__reduce__` bypasses `__setstate__`.
- The three "a concurrent reader never sees stale cache + new blocks" comments overstate: a reader that fits entirely inside a writer's invalidate/swap gap still installs a stale cache. Reworded to state the ordering without the guarantee.

No whatsnew entry: GH-65479 is in no 3.0.x tag, so the regression never shipped.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the race, wrote the fix and test, and ran a multi-round review of the branch.