### PR TITLE
BUG: select_dtypes raised on an array-like include/exclude spec

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5549,6 +5549,8 @@ class DataFrame(NDFrame, OpsMixin):
             include = (include,) if include is not None else ()
         if not is_list_like(exclude):
             exclude = (exclude,) if exclude is not None else ()
+        # GH#68448: see test_select_dtypes_listlike_spec_container
+        include, exclude = tuple(include), tuple(exclude)
 
         selection = (frozenset(include), frozenset(exclude))
 

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -1167,3 +1167,20 @@ def test_select_dtypes_none_in_listlike_deprecated(kwarg):
 
     expected = df[["c"]] if kwarg == "include" else df[["a", "b"]]
     tm.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "box",
+    [np.array, pd.Index, pd.Series, iter],
+    ids=["ndarray", "index", "series", "iterator"],
+)
+@pytest.mark.parametrize("kwarg", ["include", "exclude"])
+def test_select_dtypes_listlike_spec_container(box, kwarg):
+    # GH#68448: any list-like is accepted as the spec container. An ndarray/Index/
+    # Series has no usable truthiness for the guards in ``predicate``, and a one-shot
+    # iterator is consumed by the frozensets before ``to_callable`` iterates it.
+    df = pd.DataFrame({"a": [1, 2], "b": [1.0, 2.0], "c": ["x", "y"]})
+    result = df.select_dtypes(**{kwarg: box(["int64", "float64"])})
+
+    expected = df[["a", "b"]] if kwarg == "include" else df[["c"]]
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
`DataFrame.select_dtypes` raised `ValueError: The truth value of an array with more than one element is ambiguous` whenever `include`/`exclude` was given as an array-like container (numpy ndarray, `Index`, `Series`) rather than a list, even though the docstring documents the argument as "scalar or list-like".

Regression from GH-66112. Before that PR, `include` was rebound to a frozenset (`include = check_int_infer_dtype(include)`) before the `predicate` closure tested it, so `if include:` was frozenset truthiness and any list-like container worked. GH-66112 renamed the converted sets to `include_set`/`exclude_set` and left `include`/`exclude` bound to the raw user input, while `predicate` kept its bare `if include:` / `if exclude:` guards.

Normalizing the list-like to a tuple once, immediately after the existing scalar-wrapping, also repairs a one-shot iterator spec: that previously returned an empty frame for `include` and the whole frame for `exclude`, silently, because `frozenset(include)` consumed the iterator before `to_callable` iterated it again.

No whatsnew entry — GH-66112 is unreleased (3.1.0.dev), so the regression never reached users.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the regression against GH-66112's diff, wrote the fix and the regression test, and ran a multi-round blind review over the branch.
