### PR TITLE
CLN: skip the pyarrow pytz timezone normalization on pyarrow >= 25

### DIFF
--- a/pandas/io/_util.py
+++ b/pandas/io/_util.py
@@ -17,6 +17,7 @@ from pandas._libs.tslibs import timezones
 from pandas.compat import (
     pa_version_under18p0,
     pa_version_under19p0,
+    pa_version_under25p0,
 )
 from pandas.compat._optional import import_optional_dependency
 
@@ -332,13 +333,13 @@ def _normalize_timezone_index(index: pd.Index) -> pd.Index:
 
 def _normalize_timezone_dtypes(df: pd.DataFrame) -> pd.DataFrame:
     """
-    PyArrow uses pytz by default for timezones, but pandas uses
+    PyArrow below version 25 uses pytz by default for timezones, but pandas uses
     zoneinfo / datetime.timezone since pandas 3.0.
 
-    TODO: Starting with pyarrow 25, it will use zoneinfo by default, and then
-    this normalization can be skipped (https://github.com/apache/arrow/pull/49694).
+    Can be dropped once the minimum supported pyarrow is 25, which uses zoneinfo
+    itself (https://github.com/apache/arrow/pull/49694).
     """
-    if pytz is not None:
+    if pytz is not None and pa_version_under25p0:
         # Convert any pytz timezones to zoneinfo / fixed offset timezones
         if any(
             isinstance(dtype, pd.DatetimeTZDtype)


### PR DESCRIPTION
Follow-up to GH-65134, which added `_normalize_timezone_dtypes` to convert pyarrow's pytz timezones to zoneinfo / `datetime.timezone` after a pyarrow-backed read, plus a TODO to skip the conversion once pyarrow 25 shipped.

pyarrow 25 boxes timezones via `string_to_tzinfo(..., prefer_zoneinfo=_pandas_api.is_ge_v3())` (apache/arrow#49694), so pandas 3.x now gets zoneinfo for named zones and `datetime.timezone` for fixed offsets — nothing is left to normalize. This gates the helper on `pa_version_under25p0` and replaces the TODO with the condition that retires it.

Verified on pyarrow 25.0.1 / pytz 2026.1.post1: 14 named zones plus 3 fixed offsets x 3 dtype backends, covering column / index / columns-axis timezones, pytz-typed input round-tripped through arrow metadata, a two-zone MultiIndex, and naive and empty frames — identical output with and without the gate. The `< 25` arm stays exercised by the pyarrow 16 minimum-versions job.

No whatsnew, since behavior is unchanged on every supported pyarrow — with one narrow exception, which is an improvement rather than a regression. `_normalize_timezone_dtypes` runs *after* `_post_convert_dtypes`, so on `main` it also rewrites a dtype the caller explicitly asked for:

```python
dtype = pd.DatetimeTZDtype(tz=pytz.timezone("US/Eastern"))
pd.read_csv(io.StringIO("a\n2024-01-01T00:00:00+00:00\n"),
            engine="pyarrow", dtype={"a": dtype})["a"].dtype.tz
# main:                   zoneinfo.ZoneInfo(key='US/Eastern')
# here, on pyarrow >= 25: <DstTzInfo 'US/Eastern' LMT-1 day, 19:04:00 STD>
```

The requested dtype survives now. Only a deliberately pytz-constructed `DatetimeTZDtype` reaches this (`"datetime64[ns, US/Eastern]"` resolves to zoneinfo well before), and only the pyarrow CSV engine routes `dtype` through this helper. Fixing the ordering itself — normalizing before `_post_convert_dtypes` rather than after — is separate and not done here.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which verified the pyarrow 25 behavior change, wrote the gate, and ran the before/after matrix.
