### PR TITLE
ENH: Implement Series.__getitem__ with future.python_scalars

### DIFF
--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1507,7 +1507,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         >>> arr.map(pd.Series([10, 11, 12], index=[0, 1, 2]))
         <SparseArray>
         [10, 11, 12]
-        Length: 3, dtype: Sparse[int64, np.int64(10)]
+        Length: 3, dtype: Sparse[int64, 10]
         """
         is_map = isinstance(mapper, (abc.Mapping, ABCSeries))
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -4437,8 +4437,8 @@ class DataFrame(NDFrame, OpsMixin):
         `self.columns._index_as_unique`; Caller is responsible for checking.
         """
         if takeable:
-            series = self._ixs(col, axis=1)
-            return series._values[index]
+            values = self._get_column_array(col)
+            return maybe_unbox_numpy_scalar(values[index], object_with_dtype=values)
 
         series = self._get_item(col)
 
@@ -4447,7 +4447,7 @@ class DataFrame(NDFrame, OpsMixin):
             #  results if our categories are integers that dont match our codes
             # IntervalIndex: IntervalTree has no get_loc
             row = self.index.get_loc(index)
-            return series._values[row]
+            return series._ixs(row)
 
         # For MultiIndex going through engine effectively restricts us to
         #  same-length tuples; see test_get_set_value_no_partial_indexing
@@ -4457,7 +4457,7 @@ class DataFrame(NDFrame, OpsMixin):
             # e.g. partial string slicing on DatetimeIndex level;
             #  see GH#43395
             loc = self.index.get_loc(index)
-        return series._values[loc]
+        return series._ixs(loc)
 
     def isetitem(self, loc, value) -> None:
         """

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -1346,7 +1346,7 @@ class DataFrame(NDFrame, OpsMixin):
         int      1.0
         float    1.5
         Name: 0, dtype: float64
-        >>> print(row["int"].dtype)
+        >>> print(row.dtype)
         float64
         >>> print(df["int"].dtype)
         int64
@@ -4447,7 +4447,8 @@ class DataFrame(NDFrame, OpsMixin):
             #  results if our categories are integers that dont match our codes
             # IntervalIndex: IntervalTree has no get_loc
             row = self.index.get_loc(index)
-            return series._ixs(row)
+            values = series._values
+            return maybe_unbox_numpy_scalar(values[row], object_with_dtype=values)
 
         # For MultiIndex going through engine effectively restricts us to
         #  same-length tuples; see test_get_set_value_no_partial_indexing

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -4283,7 +4283,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
                 # if we encounter an array-like and we only have 1 dim
                 # that means that their are list/ndarrays inside the Series!
                 # so just return them (GH 6394)
-                return self._values[loc]
+                return self._ixs(loc, axis=0)
 
             if not drop_level and isinstance(index, MultiIndex):
                 # GH#6507 - honor drop_level=False for fully specified keys

--- a/pandas/core/generic.py
+++ b/pandas/core/generic.py
@@ -885,7 +885,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         dtype: int64
 
         >>> even_primes.squeeze()
-        np.int64(2)
+        2
 
         Squeezing objects with more than one value in every axis does nothing:
 
@@ -943,7 +943,7 @@ class NDFrame(PandasObject, indexing.IndexingMixin):
         Squeezing all axes will project directly into a scalar:
 
         >>> df_0a.squeeze()
-        np.int64(1)
+        1
         """
         axes = range(self._AXIS_LEN) if axis is None else (self._get_axis_number(axis),)
         result = self.iloc[

--- a/pandas/core/indexing.py
+++ b/pandas/core/indexing.py
@@ -305,7 +305,7 @@ class IndexingMixin:
         With scalar integers.
 
         >>> df.iloc[0, 1]
-        np.int64(2)
+        2
 
         With lists of integers.
 
@@ -433,7 +433,7 @@ class IndexingMixin:
         Single label for row and column
 
         >>> df.loc["cobra", "shield"]
-        np.int64(2)
+        2
 
         Slice with labels for row and single label for column. As mentioned
         above, note that both the start and stop of the slice are included.
@@ -651,7 +651,7 @@ class IndexingMixin:
         Single tuple for the index with a single label for the column
 
         >>> df.loc[("cobra", "mark i"), "shield"]
-        np.int64(2)
+        2
 
         Slice from index tuple to single label
 
@@ -748,18 +748,18 @@ class IndexingMixin:
         Get value at specified row/column pair
 
         >>> df.at[4, "B"]
-        np.int64(2)
+        2
 
         Set value at specified row/column pair
 
         >>> df.at[4, "B"] = 10
         >>> df.at[4, "B"]
-        np.int64(10)
+        10
 
         Get value within a Series
 
         >>> df.loc[5].at["B"]
-        np.int64(4)
+        4
         """
         return _AtIndexer("at", self)
 
@@ -797,18 +797,18 @@ class IndexingMixin:
         Get value at specified row/column pair
 
         >>> df.iat[1, 2]
-        np.int64(1)
+        1
 
         Set value at specified row/column pair
 
         >>> df.iat[1, 2] = 10
         >>> df.iat[1, 2]
-        np.int64(10)
+        10
 
         Get value within a series
 
         >>> df.loc[0].iat[1]
-        np.int64(2)
+        2
         """
         return _iAtIndexer("iat", self)
 
@@ -1453,7 +1453,7 @@ class _LocIndexer(_LocationIndexer):
     Single label for row and column
 
     >>> df.loc["cobra", "shield"]
-    np.int64(2)
+    2
 
     Slice with labels for row and single label for column. As mentioned
     above, note that both the start and stop of the slice are included.
@@ -1653,7 +1653,7 @@ class _LocIndexer(_LocationIndexer):
     Single tuple for the index with a single label for the column
 
     >>> df.loc[("cobra", "mark i"), "shield"]
-    np.int64(2)
+    2
 
     Slice from index tuple to single label
 
@@ -2206,7 +2206,7 @@ class _iLocIndexer(_LocationIndexer):
     With scalar integers.
 
     >>> df.iloc[0, 1]
-    np.int64(2)
+    2
 
     With lists of integers.
 
@@ -3370,18 +3370,18 @@ class _AtIndexer(_ScalarAccessIndexer):
     Get value at specified row/column pair
 
     >>> df.at[4, "B"]
-    np.int64(2)
+    2
 
     Set value at specified row/column pair
 
     >>> df.at[4, "B"] = 10
     >>> df.at[4, "B"]
-    np.int64(10)
+    10
 
     Get value within a Series
 
     >>> df.loc[5].at["B"]
-    np.int64(4)
+    4
     """
 
     _takeable = False
@@ -3504,18 +3504,18 @@ class _iAtIndexer(_ScalarAccessIndexer):
     Get value at specified row/column pair
 
     >>> df.iat[1, 2]
-    np.int64(1)
+    1
 
     Set value at specified row/column pair
 
     >>> df.iat[1, 2] = 10
     >>> df.iat[1, 2]
-    np.int64(10)
+    10
 
     Get value within a series
 
     >>> df.loc[0].iat[1]
-    np.int64(2)
+    2
     """
 
     _takeable = True

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1035,7 +1035,8 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         -------
         scalar
         """
-        return self._values[i]
+        values = self._values
+        return maybe_unbox_numpy_scalar(values[i], object_with_dtype=values)
 
     def _slice(
         self, slobj: slice, axis: AxisInt = 0, new_index: Index | None = None
@@ -1145,20 +1146,22 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         scalar value
         """
         if takeable:
-            return self._values[label]
+            return self._ixs(label)
 
         # Similar to Index.get_value, but we do not fall back to positional
         loc = self.index.get_loc(label)
 
         if is_integer(loc):
-            return self._values[loc]
+            return self._ixs(loc)
 
         if isinstance(self.index, MultiIndex):
             mi = self.index
             new_values = self._values[loc]
             if len(new_values) == 1 and mi.nlevels == 1:
                 # If more than one level left, we can not return a scalar
-                return new_values[0]
+                return maybe_unbox_numpy_scalar(
+                    new_values[0], object_with_dtype=new_values
+                )
 
             new_index = mi[loc]
             new_index = maybe_droplevels(new_index, label)
@@ -2990,7 +2993,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
             return self._constructor(result, index=idx, name=self.name)
         else:
             # scalar
-            return maybe_unbox_numpy_scalar(result.iloc[0], object_with_dtype=self)
+            return result.iloc[0]
 
     def corr(
         self,
@@ -6387,7 +6390,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         2    3
         dtype: int64
         """
-        return maybe_unbox_numpy_scalar(super().pop(item=item), object_with_dtype=self)
+        return super().pop(item=item)
 
     def info(
         self,

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -1023,7 +1023,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
     # ----------------------------------------------------------------------
     # Indexing Methods
 
-    def _ixs(self, i: int, axis: AxisInt = 0) -> Any:
+    def _ixs(self, i: int | np.integer, axis: AxisInt = 0) -> Any:
         """
         Return the i-th value or values in the Series by location.
 

--- a/pandas/tests/apply/test_series_apply.py
+++ b/pandas/tests/apply/test_series_apply.py
@@ -246,7 +246,7 @@ def test_apply_empty_integer_series_with_datetime_index(by_row):
     tm.assert_series_equal(result, s)
 
 
-def test_apply_dataframe_iloc():
+def test_apply_dataframe_iloc(using_python_scalars):
     uintDF = pd.DataFrame(np.uint64([1, 2, 3, 4, 5]), columns=["Numbers"])
     indexDF = pd.DataFrame([2, 3, 2, 1, 2], columns=["Indices"])
 
@@ -255,7 +255,10 @@ def test_apply_dataframe_iloc():
         return val
 
     result = indexDF["Indices"].apply(retrieve, args=(uintDF,))
-    expected = pd.Series([3, 4, 3, 2, 3], name="Indices", dtype="uint64")
+    # iloc in retrieve returns Python scalars with future.python_scalars,
+    # which infer as int64
+    expected_dtype = "int64" if using_python_scalars else "uint64"
+    expected = pd.Series([3, 4, 3, 2, 3], name="Indices", dtype=expected_dtype)
     tm.assert_series_equal(result, expected)
 
 

--- a/pandas/tests/arrays/integer/test_function.py
+++ b/pandas/tests/arrays/integer/test_function.py
@@ -214,12 +214,13 @@ def test_integer_array_numpy_sum(values, expected):
 
 
 @pytest.mark.parametrize("op", ["sum", "prod", "min", "max"])
-def test_dataframe_reductions(op):
+def test_dataframe_reductions(op, using_python_scalars):
     # https://github.com/pandas-dev/pandas/pull/32867
     # ensure the integers are not cast to float during reductions
     df = pd.DataFrame({"a": pd.array([1, 2], dtype="Int64")})
     result = df.max()
-    assert isinstance(result["a"], np.int64)
+    expected_type = int if using_python_scalars else np.int64
+    assert type(result["a"]) is expected_type
 
 
 # TODO(jreback) - these need testing / are broken

--- a/pandas/tests/extension/base/getitem.py
+++ b/pandas/tests/extension/base/getitem.py
@@ -113,12 +113,15 @@ class BaseGetitemTests:
         result = df.iloc[-1]
         tm.assert_series_equal(result, expected)
 
-    def test_getitem_scalar(self, data):
+    def test_getitem_scalar(self, data, using_python_scalars):
         result = data[0]
         assert isinstance(result, data.dtype.type)
 
         result = pd.Series(data)[0]
-        assert isinstance(result, data.dtype.type)
+        if using_python_scalars and isinstance(data[0], np.generic):
+            assert type(result) is type(data[0].item())
+        else:
+            assert isinstance(result, data.dtype.type)
 
     def test_getitem_invalid(self, data):
         # TODO: box over scalar, [scalar], (scalar,)?

--- a/pandas/tests/extension/base/ops.py
+++ b/pandas/tests/extension/base/ops.py
@@ -191,7 +191,7 @@ class BaseArithmeticOpsTests(BaseOpsUtil):
         # ndarray & other series
         op_name = all_arithmetic_operators
         ser = pd.Series(data)
-        self.check_opname(ser, op_name, pd.Series([ser.iloc[0]] * len(ser)))
+        self.check_opname(ser, op_name, pd.Series([data[0]] * len(ser)))
 
     def test_divmod(self, data):
         ser = pd.Series(data)

--- a/pandas/tests/extension/conftest.py
+++ b/pandas/tests/extension/conftest.py
@@ -273,3 +273,8 @@ def comparison_op(request):
 def using_nan_is_na(request):
     with pd.option_context("future.distinguish_nan_and_na", not request.param):
         yield request.param
+
+
+@pytest.fixture
+def using_python_scalars() -> bool:
+    return pd.options.future.python_scalars is True

--- a/pandas/tests/extension/test_numpy.py
+++ b/pandas/tests/extension/test_numpy.py
@@ -200,9 +200,9 @@ class TestNumpyExtensionArray(base.ExtensionTests):
             super().test_is_not_object_type(dtype)
 
     @skip_nested
-    def test_getitem_scalar(self, data):
+    def test_getitem_scalar(self, data, using_python_scalars):
         # AssertionError
-        super().test_getitem_scalar(data)
+        super().test_getitem_scalar(data, using_python_scalars)
 
     @skip_nested
     def test_shift_fill_value(self, data):

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -441,17 +441,18 @@ class TestFrameFlexComparisons:
         df = pd.DataFrame([pd.NaT])
 
         result = df == pd.NaT
-        # result.iloc[0, 0] is an np.bool_ object
-        assert result.iloc[0, 0].item() is False
+        expected = pd.DataFrame([False])
+        tm.assert_frame_equal(result, expected)
 
         result = df.eq(pd.NaT)
-        assert result.iloc[0, 0].item() is False
+        tm.assert_frame_equal(result, expected)
 
         result = df != pd.NaT
-        assert result.iloc[0, 0].item() is True
+        expected = pd.DataFrame([True])
+        tm.assert_frame_equal(result, expected)
 
         result = df.ne(pd.NaT)
-        assert result.iloc[0, 0].item() is True
+        tm.assert_frame_equal(result, expected)
 
     def test_df_flex_cmp_constant_return_types(self, comparison_op):
         # GH 15077, non-empty DataFrame

--- a/pandas/tests/groupby/aggregate/test_aggregate.py
+++ b/pandas/tests/groupby/aggregate/test_aggregate.py
@@ -560,7 +560,7 @@ def test_bool_agg_dtype(op):
 )
 @pytest.mark.parametrize("method", ["apply", "aggregate", "transform"])
 def test_callable_result_dtype_frame(
-    keys, agg_index, input_dtype, result_dtype, method
+    keys, agg_index, input_dtype, result_dtype, method, using_python_scalars
 ):
     # GH 21240
     df = pd.DataFrame({"a": [1], "b": [2], "c": [True]})
@@ -569,12 +569,20 @@ def test_callable_result_dtype_frame(
     result = op(lambda x: x.astype(result_dtype).iloc[0])
     expected_index = pd.RangeIndex(0, 1) if method == "transform" else agg_index
 
-    if method == "aggregate":
-        # _cast_pointwise_result retains the input's dtype where feasible
-        if input_dtype == "float32" and result_dtype == "float64":
-            result_dtype = "float32"
-        if input_dtype == "int32" and result_dtype == "int64":
-            result_dtype = "int32"
+    if method != "apply":
+        if using_python_scalars:
+            # iloc in the callable returns Python scalars, which infer at
+            # the default width
+            if result_dtype in ("int32", "int64"):
+                result_dtype = "int64"
+            elif result_dtype in ("float32", "float64"):
+                result_dtype = "float64"
+        if method == "aggregate":
+            # _cast_pointwise_result retains the input's dtype where feasible
+            if input_dtype == "float32" and result_dtype == "float64":
+                result_dtype = "float32"
+            if input_dtype == "int32" and result_dtype == "int64":
+                result_dtype = "int32"
 
     expected = pd.DataFrame({"c": [df["c"].iloc[0]]}, index=expected_index).astype(
         result_dtype

--- a/pandas/tests/indexes/datetimes/test_partial_slicing.py
+++ b/pandas/tests/indexes/datetimes/test_partial_slicing.py
@@ -294,7 +294,7 @@ class TestSlicing:
         with pytest.raises(KeyError, match="2005-1-1 00:00:00"):
             s["2005-1-1 00:00:00"]
 
-    def test_partial_slicing_dataframe(self):
+    def test_partial_slicing_dataframe(self, using_python_scalars):
         # GH14856
         # Test various combinations of string slicing resolution vs.
         # index resolution
@@ -311,6 +311,7 @@ class TestSlicing:
             "%Y-%m-%d %H:%M:%S",
         ]
         resolutions = ["year", "month", "day", "hour", "minute", "second"]
+        expected_type = int if using_python_scalars else np.int64
         for rnum, resolution in enumerate(resolutions[2:], 2):
             # we check only 'day', 'hour', 'minute' and 'second'
             unit = pd.Timedelta("1 " + resolution)
@@ -327,7 +328,7 @@ class TestSlicing:
                 ts_string = timestamp.strftime(formats[rnum])
                 # make ts_string as precise as index
                 result = df["a"][ts_string]
-                assert isinstance(result, np.int64)
+                assert type(result) is expected_type
                 assert result == expected
                 msg = rf"^'{ts_string}'$"
                 with pytest.raises(KeyError, match=msg):
@@ -355,7 +356,7 @@ class TestSlicing:
             for fmt in formats[rnum + 1 :]:
                 ts_string = index[1].strftime(fmt)
                 result = df["a"][ts_string]
-                assert isinstance(result, np.int64)
+                assert type(result) is expected_type
                 assert result == 2
                 msg = rf"^'{ts_string}'$"
                 with pytest.raises(KeyError, match=msg):

--- a/pandas/tests/indexing/multiindex/test_loc.py
+++ b/pandas/tests/indexing/multiindex/test_loc.py
@@ -991,18 +991,19 @@ def test_mi_add_cell_missing_row_non_unique():
     tm.assert_frame_equal(result, expected)
 
 
-def test_loc_get_scalar_casting_to_float():
+def test_loc_get_scalar_casting_to_float(using_python_scalars):
     # GH#41369
     df = pd.DataFrame(
         {"a": 1.0, "b": 2},
         index=pd.MultiIndex.from_arrays([[3], [4]], names=["c", "d"]),
     )
+    expected_type = int if using_python_scalars else np.int64
     result = df.loc[(3, 4), "b"]
     assert result == 2
-    assert isinstance(result, np.int64)
+    assert type(result) is expected_type
     result = df.loc[[(3, 4)], "b"].iloc[0]
     assert result == 2
-    assert isinstance(result, np.int64)
+    assert type(result) is expected_type
 
 
 def test_loc_empty_single_selector_with_names():

--- a/pandas/tests/indexing/test_loc.py
+++ b/pandas/tests/indexing/test_loc.py
@@ -245,7 +245,7 @@ class TestLoc:
                 pd.IndexSlice[:, False],
                 pd.Series([1], name=False),
             ),
-            (pd.Series([1], index=pd.Index([False])), False, [1]),
+            (pd.Series([1], index=pd.Index([False])), False, 1),
             (
                 pd.DataFrame([[1]], index=pd.Index([False])),
                 False,

--- a/pandas/tests/io/parser/common/test_chunksize.py
+++ b/pandas/tests/io/parser/common/test_chunksize.py
@@ -211,7 +211,9 @@ def test_chunk_begins_with_newline_whitespace(all_parsers):
 
 
 @pytest.mark.slow
-def test_chunks_have_consistent_numerical_type(all_parsers, monkeypatch):
+def test_chunks_have_consistent_numerical_type(
+    all_parsers, monkeypatch, using_python_scalars
+):
     # mainly an issue with the C parser
     heuristic = 2**3
     parser = all_parsers
@@ -223,7 +225,8 @@ def test_chunks_have_consistent_numerical_type(all_parsers, monkeypatch):
         m.setattr(libparsers, "DEFAULT_BUFFER_HEURISTIC", heuristic)
         result = parser.read_csv(StringIO(data))
 
-    assert type(result.a[0]) is np.float64
+    expected_type = float if using_python_scalars else np.float64
+    assert type(result.a[0]) is expected_type
     assert result.a.dtype == float
 
 

--- a/pandas/tests/series/indexing/test_getitem.py
+++ b/pandas/tests/series/indexing/test_getitem.py
@@ -690,6 +690,48 @@ def test_duplicated_index_getitem_positional_indexer(index_vals):
         s[3]
 
 
+@pytest.mark.parametrize("indexer", [tm.getitem, tm.loc, tm.iloc, tm.at, tm.iat])
+def test_getitem_scalar_key(indexer, using_python_scalars):
+    # GH#20791
+    ser = pd.Series([1, 2, 3])
+    expected_type = int if using_python_scalars else np.int64
+    result = indexer(ser)[1]
+    assert result == 2
+    assert type(result) is expected_type
+
+
+@pytest.mark.parametrize("indexer", [tm.getitem, tm.loc, tm.at])
+def test_getitem_multiindex_scalar_key(indexer, using_python_scalars):
+    # GH#20791
+    mi = pd.MultiIndex.from_tuples([("a", 1), ("b", 2)])
+    ser = pd.Series([1.5, 2.5], index=mi)
+    expected_type = float if using_python_scalars else np.float64
+    result = indexer(ser)[("a", 1)]
+    assert result == 1.5
+    assert type(result) is expected_type
+
+
+def test_getitem_multiindex_single_level(using_python_scalars):
+    # GH#20791
+    # _get_value path where get_loc returns a slice of length one
+    mi = pd.MultiIndex.from_arrays([["a", "b"]])
+    ser = pd.Series([1.5, 2.5], index=mi)
+    expected_type = float if using_python_scalars else np.float64
+    result = ser["a"]
+    assert result == 1.5
+    assert type(result) is expected_type
+
+
+@pytest.mark.parametrize("indexer", [tm.getitem, tm.loc, tm.iloc, tm.at, tm.iat])
+def test_getitem_object_dtype_preserves_numpy_scalars(indexer):
+    # GH#64266
+    value = np.int8(1)
+    ser = pd.Series([value, np.int8(2)], dtype=object)
+    with pd.option_context("future.python_scalars", True):
+        result = indexer(ser)[0]
+    assert result is value
+
+
 class TestGetitemDeprecatedIndexers:
     @pytest.mark.parametrize("key", [{1}, {1: 1}])
     def test_getitem_dict_and_set_deprecated(self, key):

--- a/pandas/tests/series/test_arithmetic.py
+++ b/pandas/tests/series/test_arithmetic.py
@@ -120,6 +120,11 @@ class TestSeriesFlexArithmetic:
             amask = pd.isna(a)
             bmask = pd.isna(b)
 
+            # Use to_numpy to work with NumPy scalars so that op has NumPy semantics
+            # like the flex methods.
+            avals = a.to_numpy()
+            bvals = b.to_numpy()
+
             exp_values = []
             for i in range(len(exp_index)):
                 with np.errstate(all="ignore"):
@@ -127,14 +132,14 @@ class TestSeriesFlexArithmetic:
                         if bmask[i]:
                             exp_values.append(np.nan)
                             continue
-                        exp_values.append(op(fill_value, b[i]))
+                        exp_values.append(op(fill_value, bvals[i]))
                     elif bmask[i]:
                         if amask[i]:
                             exp_values.append(np.nan)
                             continue
-                        exp_values.append(op(a[i], fill_value))
+                        exp_values.append(op(avals[i], fill_value))
                     else:
-                        exp_values.append(op(a[i], b[i]))
+                        exp_values.append(op(avals[i], bvals[i]))
 
             result = meth(a, b, fill_value=fill_value)
             expected = pd.Series(exp_values, exp_index)

--- a/pandas/tests/series/test_constructors.py
+++ b/pandas/tests/series/test_constructors.py
@@ -800,12 +800,16 @@ class TestSeriesConstructors:
             [np.uint64(1)],
         ],
     )
-    def test_constructor_numpy_uints(self, values):
+    def test_constructor_numpy_uints(self, values, using_python_scalars):
         # GH#47294
         value = values[0]
         result = pd.Series(values)
 
-        assert result[0].dtype == value.dtype
+        assert result.dtype == value.dtype
+        if using_python_scalars:
+            assert type(result[0]) is int
+        else:
+            assert result[0].dtype == value.dtype
         assert result[0] == value
 
     def test_constructor_unsigned_dtype_overflow(self, any_unsigned_int_numpy_dtype):


### PR DESCRIPTION
Written with Claude Fable 5.1.

Part of https://github.com/pandas-dev/pandas/issues/64266

Also handles:
- `NDFrame.squeeze`
- `NDFrame.xs`
- `NDFrame.get`

One thing I'd like to punt to another PR is EAs with object dtype (e.g. categorical, sparse). Right now these get unboxed but shouldn't be.