### PR TITLE
ENH: Implement positional results for future.python_scalars

### DIFF
--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -36,7 +36,10 @@ from pandas.errors import (
 from pandas.util._decorators import cache_readonly
 from pandas.util._exceptions import find_stack_level
 
-from pandas.core.dtypes.cast import can_hold_element
+from pandas.core.dtypes.cast import (
+    can_hold_element,
+    maybe_unbox_numpy_scalar,
+)
 from pandas.core.dtypes.common import (
     is_object_dtype,
     is_scalar,
@@ -858,12 +861,14 @@ class IndexOpsMixin(OpsMixin):
         skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
 
         if isinstance(delegate, ExtensionArray):
-            return delegate.argmax(skipna=skipna)
+            result = delegate.argmax(skipna=skipna)
         else:
-            result = nanops.nanargmax(delegate, skipna=skipna)
-            # error: Incompatible return value type (got "Union[int, ndarray]", expected
-            # "int")
-            return result  # type: ignore[return-value]
+            # error: Incompatible types in assignment (expression has type
+            # "int | ndarray", variable has type "int")
+            result = nanops.nanargmax(  # type: ignore[assignment]
+                delegate, skipna=skipna
+            )
+        return maybe_unbox_numpy_scalar(result)
 
     def argmin(
         self, axis: AxisInt | None = None, skipna: bool = True, *args, **kwargs
@@ -931,12 +936,14 @@ class IndexOpsMixin(OpsMixin):
         skipna = nv.validate_argmax_with_skipna(skipna, args, kwargs)
 
         if isinstance(delegate, ExtensionArray):
-            return delegate.argmin(skipna=skipna)
+            result = delegate.argmin(skipna=skipna)
         else:
-            result = nanops.nanargmin(delegate, skipna=skipna)
-            # error: Incompatible return value type (got "Union[int, ndarray]", expected
-            # "int")
-            return result  # type: ignore[return-value]
+            # error: Incompatible types in assignment (expression has type
+            # "int | ndarray", variable has type "int")
+            result = nanops.nanargmin(  # type: ignore[assignment]
+                delegate, skipna=skipna
+            )
+        return maybe_unbox_numpy_scalar(result)
 
     def tolist(self) -> list:
         """
@@ -1669,14 +1676,15 @@ class IndexOpsMixin(OpsMixin):
         values = self._values
         if not isinstance(values, np.ndarray):
             # Going through EA.searchsorted directly improves performance GH#38083
-            return values.searchsorted(value, side=side, sorter=sorter)
-
-        return algorithms.searchsorted(
-            values,
-            value,
-            side=side,
-            sorter=sorter,
-        )
+            result = values.searchsorted(value, side=side, sorter=sorter)
+        else:
+            result = algorithms.searchsorted(
+                values,
+                value,
+                side=side,
+                sorter=sorter,
+            )
+        return maybe_unbox_numpy_scalar(result)
 
     def drop_duplicates(self, *, keep: DropKeep = "first") -> Self:
         duplicated = self._duplicated(keep=keep)

--- a/pandas/core/base.py
+++ b/pandas/core/base.py
@@ -848,9 +848,9 @@ class IndexOpsMixin(OpsMixin):
         dtype: float64
 
         >>> s.argmax()
-        np.int64(2)
+        2
         >>> s.argmin()
-        np.int64(0)
+        0
 
         The maximum cereal calories is the third element and
         the minimum cereal calories is the first element,
@@ -923,9 +923,9 @@ class IndexOpsMixin(OpsMixin):
         dtype: float64
 
         >>> s.argmax()
-        np.int64(2)
+        2
         >>> s.argmin()
-        np.int64(0)
+        0
 
         The maximum cereal calories is the third element and
         the minimum cereal calories is the first element,
@@ -1619,7 +1619,7 @@ class IndexOpsMixin(OpsMixin):
         dtype: int64
 
         >>> ser.searchsorted(4)
-        np.int64(3)
+        3
 
         >>> ser.searchsorted([0, 4])
         array([0, 3])
@@ -1638,7 +1638,7 @@ class IndexOpsMixin(OpsMixin):
         dtype: datetime64[us]
 
         >>> ser.searchsorted("3/14/2000")
-        np.int64(3)
+        3
 
         >>> ser = pd.Categorical(
         ...     ["apple", "bread", "bread", "cheese", "milk"], ordered=True

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -7970,9 +7970,9 @@ class Index(IndexOpsMixin, PandasObject):
         Index([100.0, 110.0, 120.0, 110.0], dtype='float64')
 
         >>> idx.argmax()
-        np.int64(2)
+        2
         >>> idx.argmin()
-        np.int64(0)
+        0
 
         The maximum cereal calories is the third element and
         the minimum cereal calories is the first element,
@@ -8034,9 +8034,9 @@ class Index(IndexOpsMixin, PandasObject):
         Index([100.0, 110.0, 120.0, 110.0], dtype='float64')
 
         >>> idx.argmax()
-        np.int64(2)
+        2
         >>> idx.argmin()
-        np.int64(0)
+        0
 
         The maximum cereal calories is the third element and
         the minimum cereal calories is the first element,

--- a/pandas/core/indexes/category.py
+++ b/pandas/core/indexes/category.py
@@ -64,7 +64,6 @@ if TYPE_CHECKING:
         "categories",
         "ordered",
         "_reverse_indexer",
-        "searchsorted",
         "min",
         "max",
     ],

--- a/pandas/core/indexes/range.py
+++ b/pandas/core/indexes/range.py
@@ -35,6 +35,7 @@ from pandas.util._decorators import (
 from pandas.util._exceptions import find_stack_level
 
 from pandas.core.dtypes.base import ExtensionDtype
+from pandas.core.dtypes.cast import maybe_unbox_numpy_scalar
 from pandas.core.dtypes.common import (
     ensure_platform_int,
     ensure_python_int,
@@ -1691,5 +1692,5 @@ class RangeIndex(Index):
             result = len(self) - result
         result = np.maximum(np.minimum(result, len(self)), 0)
         if was_scalar:
-            return np.intp(result.item())
+            return maybe_unbox_numpy_scalar(np.intp(result.item()))
         return result.astype(np.intp, copy=False)

--- a/pandas/core/series.py
+++ b/pandas/core/series.py
@@ -3524,7 +3524,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         2    3
         dtype: int64
         >>> ser.searchsorted(4)
-        np.int64(3)
+        3
         >>> ser.searchsorted([0, 4])
         array([0, 3])
         >>> ser.searchsorted([1, 3], side="left")
@@ -3538,7 +3538,7 @@ class Series(base.IndexOpsMixin, NDFrame):  # type: ignore[misc]
         2   2000-03-13
         dtype: datetime64[us]
         >>> ser.searchsorted("3/14/2000")
-        np.int64(3)
+        3
         >>> ser = pd.Categorical(
         ...     ["apple", "bread", "bread", "cheese", "milk"], ordered=True
         ... )

--- a/pandas/tests/base/test_misc.py
+++ b/pandas/tests/base/test_misc.py
@@ -10,6 +10,7 @@ from pandas.core.dtypes.common import (
 )
 
 import pandas as pd
+import pandas._testing as tm
 
 
 def test_isnull_notnull_docstrings():
@@ -159,6 +160,25 @@ def test_searchsorted(request, index_or_series_obj_orderable):
 
     index = np.searchsorted(obj, max_obj, sorter=range(len(obj)))
     assert 0 <= index <= len(obj)
+
+
+@pytest.mark.parametrize(
+    "dtype", ["int64", "float64", "Int64", "category", "datetime64[ns]", "object"]
+)
+def test_searchsorted_scalar_python_scalars(
+    index_or_series, dtype, using_python_scalars
+):
+    # GH#64266
+    obj = index_or_series([1, 2, 3], dtype=dtype)
+    result = obj.searchsorted(obj[1])
+    assert result == 1
+    if using_python_scalars:
+        assert type(result) is int
+    else:
+        assert isinstance(result, np.integer)
+
+    result = obj.searchsorted(obj[[1]])
+    tm.assert_numpy_array_equal(result, np.array([1], dtype=np.intp))
 
 
 def test_access_by_position(index_flat):

--- a/pandas/tests/indexes/ranges/test_range.py
+++ b/pandas/tests/indexes/ranges/test_range.py
@@ -951,11 +951,16 @@ def test_value_counts(sort, dropna, ascending, normalize, rng):
 
 @pytest.mark.parametrize("side", ["left", "right"])
 @pytest.mark.parametrize("value", [0, -5, 5, -3, np.array([-5, -3, 0, 5])])
-def test_searchsorted(side, value):
+def test_searchsorted(side, value, using_python_scalars):
     ri = pd.RangeIndex(-3, 3, 2)
     result = ri.searchsorted(value=value, side=side)
     expected = pd.Index(list(ri)).searchsorted(value=value, side=side)
     if isinstance(value, int):
         assert result == expected
+        # GH#64266
+        if using_python_scalars:
+            assert type(result) is int
+        else:
+            assert isinstance(result, np.integer)
     else:
         tm.assert_numpy_array_equal(result, expected)

--- a/pandas/tests/reductions/test_reductions.py
+++ b/pandas/tests/reductions/test_reductions.py
@@ -207,6 +207,22 @@ class TestReductions:
         with pytest.raises(ValueError, match="Encountered an NA value"):
             obj.argmax(skipna=False)
 
+    @pytest.mark.parametrize(
+        "dtype", ["int64", "float64", "Int64", "category", "datetime64[ns]", "object"]
+    )
+    @pytest.mark.parametrize("op", ["argmin", "argmax"])
+    def test_argminmax_python_scalars(
+        self, index_or_series, dtype, op, using_python_scalars
+    ):
+        # GH#64266
+        obj = index_or_series([1, 3, 2], dtype=dtype)
+        result = getattr(obj, op)()
+        assert result == (0 if op == "argmin" else 1)
+        if using_python_scalars:
+            assert type(result) is int
+        else:
+            assert isinstance(result, np.integer)
+
     @pytest.mark.parametrize("op, expected_col", [["max", "a"], ["min", "b"]])
     def test_same_tz_min_max_axis_1(self, op, expected_col):
         # GH 10390


### PR DESCRIPTION
Written with Claude Fable 5.1.

Part of https://github.com/pandas-dev/pandas/issues/64266

Handles:
- Series.searchsorted
- RangeIndex.searchsorted
- CategoricalIndex.searchsorted
- IndexOpsMixin.searchsorted
- Index.argmax
- Index.argmin
- IndexOpsMixin.argmax
- IndexOpsMixin.argmin