### PR TITLE
BUG: SparseArray.astype dropped a datetimelike fill_value (GH#49631)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1077,7 +1077,7 @@ Sparse
 - Bug in :meth:`Series.mean` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`Series.reindex` and alignment raising when extending a boolean :class:`SparseDtype`-backed :class:`Series`; missing entries now upcast to ``object`` to match the dense behavior (:issue:`32119`)
 - Bug in :meth:`Series.sum`, :meth:`Series.min`, and :meth:`Series.max` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
-- Bug in :meth:`SparseArray.astype` where converting a datetime64 :class:`SparseArray` with ``NaT`` fill value to ``"Sparse[int64]"`` silently replaced the fill value with ``0`` instead of ``iNaT`` (:issue:`49631`)
+- Bug in :meth:`SparseArray.astype` where converting a datetime64 or timedelta64 :class:`SparseArray` to an integer or boolean ``Sparse`` dtype silently replaced the fill value with the target's default (``0``/``False``) instead of converting it (:issue:`49631`)
 - Bug in :meth:`SparseArray.mean` raising a ``TypeError`` when called with the ``skipna`` argument (:issue:`65478`)
 - Bug in :meth:`SparseArray.sum` with ``skipna=False`` returning ``NA`` for a non-null ``fill_value`` and ignoring missing values under a null ``fill_value`` (:issue:`65478`)
 - Bug in ``np.prod`` and ``np.multiply.reduce`` on a :class:`SparseArray` silently returning the product of only the stored values, ignoring the entries equal to ``fill_value`` (:issue:`68194`)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1449,7 +1449,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             and self.dtype.subtype.kind in "mM"
             and dtype.fill_value == na_value_for_dtype(dtype.subtype)
         ):
-            # build from the source subtype so a boxed or unit-less fill converts
+            # build from the source subtype so a boxed fill value converts too
             fv_arr = ensure_wrapped_if_datetimelike(np.zeros(1, self.dtype.subtype))
             fv_arr[0] = self.fill_value
             converted_fv = np.asarray(astype_array(fv_arr, dtype.subtype))

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1441,21 +1441,17 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         dtype = self.dtype.update_dtype(dtype)
 
         # GH#49631: update_dtype resolves the target to the subtype's default
-        # fill_value (e.g. 0 for int64) rather than converting the source
-        # fill_value. For a datetimelike source with an NA (NaT) fill, casting to
-        # int is a view, so match the dense .astype and map NaT -> iNaT instead of
-        # silently using 0. Only fire when the target fill is the subtype default,
-        # so an explicitly-requested non-default fill_value is respected. Skip
-        # when fully dense, since the fill_value is unused.
+        # fill_value (e.g. 0 for int64) instead of converting the source
+        # fill_value. Only fire when the target fill is the subtype default, so
+        # an explicitly-requested non-default fill_value is respected.
         if (
-            self.dtype._is_na_fill_value
-            and not dtype._is_na_fill_value
+            not dtype._is_na_fill_value
             and self.dtype.subtype.kind in "mM"
             and dtype.fill_value == na_value_for_dtype(dtype.subtype)
-            and self.sp_index.npoints != len(self)
         ):
-            fv_arr = np.atleast_1d(np.array(self.fill_value))
-            fv_arr = ensure_wrapped_if_datetimelike(fv_arr)
+            # build from the source subtype so a boxed or unit-less fill converts
+            fv_arr = ensure_wrapped_if_datetimelike(np.zeros(1, self.dtype.subtype))
+            fv_arr[0] = self.fill_value
             converted_fv = np.asarray(astype_array(fv_arr, dtype.subtype))
             dtype = SparseDtype(dtype.subtype, fill_value=converted_fv[0])
 

--- a/pandas/core/dtypes/dtypes.py
+++ b/pandas/core/dtypes/dtypes.py
@@ -1832,6 +1832,10 @@ class SparseDtype(ExtensionDtype):
 
         if isinstance(other, type(self)):
             subtype = self.subtype == other.subtype
+            if not subtype:
+                # comparing fill values across subtypes cannot change the result
+                # and can warn, e.g. numpy deprecates timedelta64 == int
+                return False
             if self._is_na_fill_value or other._is_na_fill_value:
                 # this case is complicated by two things:
                 # SparseDtype(float, float(nan)) == SparseDtype(float, np.nan)

--- a/pandas/tests/arrays/sparse/test_astype.py
+++ b/pandas/tests/arrays/sparse/test_astype.py
@@ -197,22 +197,12 @@ class TestAstype:
         result = pd.Series(arr).astype(dtype)
         tm.assert_sp_array_equal(result.array, expected)
 
-    @pytest.mark.parametrize(
-        "unit_dtype, na_fill_value",
-        [
-            ("M8[ns]", pd.NaT),
-            ("M8[ns]", np.datetime64("NaT")),
-            ("m8[ns]", pd.NaT),
-            ("m8[ns]", np.timedelta64("NaT")),
-        ],
-    )
-    def test_astype_datetimelike_nat_fill_value_spelling(
-        self, unit_dtype, na_fill_value
-    ):
-        # GH#49631 a NaT fill value spelled as a pandas scalar or without a unit
-        # must convert like np.datetime64("NaT", "ns"), not raise
+    @pytest.mark.parametrize("unit_dtype", ["M8[ns]", "m8[ns]"])
+    def test_astype_datetimelike_nat_fill_value_spelling(self, unit_dtype):
+        # GH#49631 a NaT fill value spelled as a pandas scalar must convert like
+        # the numpy spelling, not raise
         values = np.array(["NaT", 1, 2], dtype=unit_dtype)
-        arr = SparseArray(values, dtype=pd.SparseDtype(unit_dtype, na_fill_value))
+        arr = SparseArray(values, dtype=pd.SparseDtype(unit_dtype, pd.NaT))
         expected = SparseArray(
             values.astype("int64"),
             dtype=pd.SparseDtype("int64", fill_value=np.iinfo(np.int64).min),

--- a/pandas/tests/arrays/sparse/test_astype.py
+++ b/pandas/tests/arrays/sparse/test_astype.py
@@ -166,6 +166,86 @@ class TestAstype:
         result = pd.Series(arr).astype(dtype)
         tm.assert_sp_array_equal(result.array, expected)
 
+    @pytest.mark.parametrize("dtype", ["Sparse[int64]", pd.SparseDtype("int64")])
+    @pytest.mark.parametrize(
+        "unit_dtype, fill_type",
+        [
+            ("M8[ns]", np.datetime64),
+            ("M8[ns]", pd.Timestamp),
+            ("M8[us]", pd.Timestamp),
+            ("m8[ns]", np.timedelta64),
+            ("m8[ns]", pd.Timedelta),
+            ("m8[s]", np.timedelta64),
+        ],
+    )
+    def test_astype_datetimelike_to_sparse_int64_non_na_fill_value(
+        self, dtype, unit_dtype, fill_type
+    ):
+        # GH#49631 a non-NA datetimelike fill_value must be converted too, not
+        # silently replaced with 0; the boxed pandas spelling of that fill value
+        # must work as well as the numpy one
+        values = np.array([1, 1, 2], dtype=unit_dtype)
+        arr = SparseArray(values, fill_value=fill_type(values[0]))
+        expected = SparseArray(
+            values.astype("int64"),
+            dtype=pd.SparseDtype("int64", fill_value=values[0].astype("int64")),
+        )
+
+        result = arr.astype(dtype)
+        tm.assert_sp_array_equal(result, expected)
+
+        result = pd.Series(arr).astype(dtype)
+        tm.assert_sp_array_equal(result.array, expected)
+
+    @pytest.mark.parametrize(
+        "unit_dtype, na_fill_value",
+        [
+            ("M8[ns]", pd.NaT),
+            ("M8[ns]", np.datetime64("NaT")),
+            ("m8[ns]", pd.NaT),
+            ("m8[ns]", np.timedelta64("NaT")),
+        ],
+    )
+    def test_astype_datetimelike_nat_fill_value_spelling(
+        self, unit_dtype, na_fill_value
+    ):
+        # GH#49631 a NaT fill value spelled as a pandas scalar or without a unit
+        # must convert like np.datetime64("NaT", "ns"), not raise
+        values = np.array(["NaT", 1, 2], dtype=unit_dtype)
+        arr = SparseArray(values, dtype=pd.SparseDtype(unit_dtype, na_fill_value))
+        expected = SparseArray(
+            values.astype("int64"),
+            dtype=pd.SparseDtype("int64", fill_value=np.iinfo(np.int64).min),
+        )
+
+        result = arr.astype("Sparse[int64]")
+        tm.assert_sp_array_equal(result, expected)
+
+    @pytest.mark.parametrize(
+        "unit_dtype, fill_type", [("M8[ns]", np.datetime64), ("m8[ns]", np.timedelta64)]
+    )
+    def test_astype_datetimelike_fully_dense_fill_value(self, unit_dtype, fill_type):
+        # GH#49631 the fill_value belongs to the dtype whether or not it happens
+        # to occur in the data, so a fully dense array converts it too
+        values = np.array([1, 2, 3], dtype=unit_dtype)
+        arr = SparseArray(values, fill_value=fill_type(5, "ns"))
+        assert arr.sp_index.npoints == len(arr)  # fill_value absent from the data
+
+        result = arr.astype("Sparse[int64]")
+        assert result.dtype == pd.SparseDtype("int64", fill_value=5)
+        tm.assert_numpy_array_equal(result.to_dense(), values.astype("int64"))
+
+    @pytest.mark.parametrize("unit_dtype", ["M8[ns]", "m8[ns]"])
+    def test_astype_datetimelike_to_sparse_bool_fill_value(self, unit_dtype):
+        # GH#49631 the fill_value conversion is not int-specific: a bool target
+        # must get the fill value's truthiness rather than False
+        values = np.array([1, 1, 2], dtype=unit_dtype)
+        arr = SparseArray(values, fill_value=values[0])
+
+        result = arr.astype("Sparse[bool]")
+        assert result.dtype == pd.SparseDtype(bool, fill_value=True)
+        tm.assert_numpy_array_equal(result.to_dense(), values.astype(bool))
+
     def test_astype_fully_dense_na_fill_to_int_no_raise(self):
         # GH#49631 a fully dense float SparseArray whose (unused) NaN fill_value
         # cannot be represented as an integer must not raise on astype to int


### PR DESCRIPTION
closes #49631

Casting a datetime64/timedelta64 `SparseArray` to an integer or boolean `Sparse` dtype resolved the target to the subtype's default `fill_value` (`0`/`False`) instead of converting the source one, so every unstored position densified to the wrong value:

```python
vals = np.array(["2016-01-02", "2016-01-02", "2016-01-03"], dtype="M8[ns]")
arr = SparseArray(vals, fill_value=pd.Timestamp("2016-01-02"))

arr.astype("Sparse[int64]").to_dense()
# [                  0                   0 1451779200000000000]
arr.to_dense().astype("int64")
# [1451692800000000000 1451692800000000000 1451779200000000000]
```

GH-66175 fixed this for an NA (`NaT`) fill by gating on `self.dtype._is_na_fill_value`; that gate is dropped here so any datetimelike fill is converted. A second clause, `sp_index.npoints != len(self)`, is dropped too: it was added for a fully-stored *float* `NaN` fill, which the `subtype.kind in "mM"` test already excludes, and its only remaining effect was to make the resulting public `fill_value` depend on whether the fill happened to occur in the data.

The one-element fill array is now built from the source subtype and assigned into, rather than built from the fill scalar. `np.array(fill_value)` is object-dtype for a boxed `Timestamp`/`Timedelta`/`pd.NaT`, so those spellings raised `TypeError` where `np.datetime64("NaT", "ns")` worked. Note `np.array([fill_value], dtype=subtype)` is not a valid simplification — numpy routes a `Timestamp` through `datetime.datetime` and silently drops the nanosecond.

Casts to an NA-default target (another datetimelike unit, or `object`) still take the target's NA and are left alone here: `SparseDtype` cannot distinguish an unspecified fill from one explicitly set to the subtype default, so that is the same design question as the documented `Sparse[int64, 0] -> SparseDtype(float64)` -> `nan` example in `SparseArray.astype`'s docstring.

`SparseDtype.__eq__` also no longer compares fill values when the subtypes differ. That comparison could never change the result, and on newer numpy it warns (`timedelta64 == int` hits the deprecated generic timedelta unit), which failed the new timedelta tests on CI.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which investigated the bug, wrote the fix and tests, and reviewed the branch across several blind review rounds.

