### PR TITLE
BUG: nanvar/nanstd honored an explicit mask only in the denominator under skipna=False (GH#65373)

### DIFF
--- a/pandas/core/nanops.py
+++ b/pandas/core/nanops.py
@@ -226,19 +226,14 @@ def _maybe_get_mask(
     """
     Compute a mask if and only if necessary.
 
-    This function will compute a mask iff it is necessary. Otherwise,
-    return the provided mask (potentially None) when a mask does not need to be
-    computed.
+    An explicit `mask` is returned unchanged; the values it marks need not be
+    NaN (a masked array stores fill values there).  Otherwise one is computed
+    with isna(), but only where it is needed: never for boolean or integer
+    values, which cannot store NaN, and under skipna=False only for
+    datetime64/timedelta64, whose NaT stops being detectable once `_get_values`
+    views it as i8 (GH#37392).
 
-    A mask is never necessary if the values array is of boolean or integer
-    dtypes, as these are incapable of storing NaNs. If passing a NaN-capable
-    dtype that is interpretable as either boolean or integer data (eg,
-    timedelta64), a mask must be provided.
-
-    If the skipna parameter is False, a new mask will not be computed.
-
-    The mask is computed using isna() by default. Setting invert=True selects
-    notna() as the masking function.
+    A caller that already holds that i8 view must pass its own mask.
 
     Parameters
     ----------
@@ -1206,7 +1201,7 @@ def nanstd(
         Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
         where N represents the number of elements.
     mask : ndarray[bool], optional
-        nan-mask if known
+        NA-mask if known
 
     Returns
     -------
@@ -1259,7 +1254,7 @@ def nanvar(
         Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
         where N represents the number of elements.
     mask : ndarray[bool], optional
-        nan-mask if known
+        NA-mask if known
 
     Returns
     -------
@@ -1279,10 +1274,9 @@ def nanvar(
         return cast("float", _na_for_min_count(values, axis))
     dtype = values.dtype
     mask = _maybe_get_mask(values, skipna, mask)
-    if dtype.kind in "iu":
+    if dtype.kind in "biu":
+        # bool: the np.nan putmask below would write True into a bool array
         values = values.astype("f8")
-        if mask is not None:
-            values[mask] = np.nan
     elif dtype.kind == "c":
         # https://en.wikipedia.org/wiki/Complex_random_variable#Variance_and_pseudo-variance
         # The variance is equal to the sum of
@@ -1296,9 +1290,10 @@ def nanvar(
     else:
         count, d = _get_counts_nanvar(values.shape, mask, axis, ddof)
 
-    if skipna and mask is not None:
+    if mask is not None:
         values = values.copy()
-        np.putmask(values, mask, 0)
+        # GH#65373 an explicit mask marks NA, so skipna=False propagates
+        np.putmask(values, mask, 0 if skipna else np.nan)
 
     # xref GH10242
     # Compute variance via two-pass algorithm, which is stable against
@@ -1349,7 +1344,7 @@ def nansem(
         Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
         where N represents the number of elements.
     mask : ndarray[bool], optional
-        nan-mask if known
+        NA-mask if known
 
     Returns
     -------
@@ -1372,12 +1367,6 @@ def nansem(
     # Convert to bottleneck return a float
     if values.dtype.kind not in "fc":
         values = values.astype("f8")
-
-    if not skipna and mask is not None:
-        # For masked arrays, the values underneath `mask` are fill values
-        # rather than NaN, so NaN would not otherwise propagate. GH#65373
-        values = values.copy()
-        np.putmask(values, mask, np.nan)
 
     dtype_count = np.dtype(np.float64)
     if values.dtype.kind == "f":

--- a/pandas/tests/test_nanops.py
+++ b/pandas/tests/test_nanops.py
@@ -1456,17 +1456,55 @@ def test_nanops_reductions_dont_skip_nan_with_mask(nanops_operation, skipna, axi
     tm.assert_equal(result, expected)
 
 
-def test_nansem_partial_mask_no_skipna_is_per_slice():
+@pytest.mark.parametrize("axis", [0, 1])
+@pytest.mark.parametrize("nanops_operation", ["nanvar", "nanstd", "nansem"])
+def test_partial_mask_no_skipna_is_per_slice(nanops_operation, axis):
     # GH#65373 masked entries propagate NaN only into the slices containing them
     values = np.arange(25, dtype=np.float64).reshape(5, 5)
     mask = np.zeros((5, 5), dtype=bool)
     mask[0, 0] = True
 
-    result = nanops.nansem(values, mask=mask, skipna=False, axis=0)
-    expected = nanops.nanskew(values, mask=mask, skipna=False, axis=0)
+    result = getattr(nanops, nanops_operation)(
+        values, mask=mask, skipna=False, axis=axis
+    )
+    expected = nanops.nanskew(values, mask=mask, skipna=False, axis=axis)
     tm.assert_numpy_array_equal(np.isnan(result), np.isnan(expected))
     assert np.isnan(result[0])
     assert not np.isnan(result[1:]).any()
+
+
+@pytest.mark.parametrize("axis", [None, 0])
+@pytest.mark.parametrize("dtype", ["f8", "f4", "i8", "u8", "bool", "c16", "O"])
+@pytest.mark.parametrize("nanops_operation", ["nanvar", "nanstd", "nansem"])
+def test_masked_non_nan_value_no_skipna_propagates(nanops_operation, dtype, axis):
+    # GH#65373 the entry under an explicit mask is a fill value; skipna=False
+    #  propagates NaN, and only into the slice holding it
+    values = np.array([[1, 1], [5, 2], [3, 0]], dtype=dtype)
+    mask = np.array([[False, False], [True, False], [False, False]])
+
+    operation = getattr(nanops, nanops_operation)
+    result = operation(values, mask=mask, skipna=False, axis=axis)
+    if axis is None:
+        assert np.isnan(result)
+    else:
+        assert np.isnan(result[0])
+        assert not np.isnan(result[1])
+
+
+@pytest.mark.parametrize("axis", [None, 0])
+@pytest.mark.parametrize("dtype", ["f8", "f4", "i8", "u8", "bool", "c16", "O"])
+@pytest.mark.parametrize("nanops_operation", ["nanvar", "nanstd", "nansem"])
+def test_masked_non_nan_value_skipna_is_excluded(nanops_operation, dtype, axis):
+    # GH#65373 with skipna=True the masked entry drops out of both the numerator
+    #  and the denominator
+    values = np.array([[1, 1], [5, 2], [3, 0]], dtype=dtype)
+    mask = np.array([[False, False], [True, True], [False, False]])
+
+    result = getattr(nanops, nanops_operation)(
+        values, mask=mask, skipna=True, axis=axis
+    )
+    expected = getattr(nanops, nanops_operation)(values[[0, 2]], skipna=True, axis=axis)
+    tm.assert_almost_equal(result, expected)
 
 
 @pytest.mark.parametrize("min_count", [-1, 0])


### PR DESCRIPTION
Follow-up to GH-67068, which fixed the `nansem` half of GH-65373 and settled the semantics: an explicit `mask` marks NA, so `skipna=False` propagates.

`nanvar` (and `nanstd`, which delegates to it) honored the mask only in the denominator — the masked position was dropped from `count`/`d` and zeroed out of the squared-deviation sum, but its value still entered the mean, so the result matched neither reading of the mask:

```python
values = np.array([[1.0, 1.0], [np.nan, 2.0], [3.0, 3.0]])
mask = np.array([[False, False], [True, True], [False, False]])

nanops.nanvar(values, axis=0, skipna=False, mask=mask)  # [nan, 4.0]
# NA-propagation says nan; mask-exclusion says var([1, 3]) == 2
```

`nanvar` now fills masked positions with NaN under `skipna=False` (with 0 under `skipna=True`, as before), and `bool` input joins the `i`/`u` cast to f8 since `np.nan` is truthy and would otherwise putmask `True`. The now-redundant fill in `nansem` is deleted, since it inherits the behavior from `nanvar`.

No whatsnew note: the only public-API path reaching `nanvar` with a non-None mask and `skipna=False` is `nansem` (`pd.Series([1, None, 3], dtype="Int64").sem(skipna=False)`), whose result is unchanged at `<NA>`; masked EAs route `var`/`std` through `masked_reductions` instead.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and ran the test suite under my review.
