### PR TITLE
BUG: SparseArray.density raised ZeroDivisionError on an empty array

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1125,7 +1125,7 @@ Reshaping
 
 Sparse
 ^^^^^^
-- Bug in :attr:`Series.sparse.density`, :attr:`DataFrame.sparse.density`, and :attr:`SparseArray.density` raising ``ZeroDivisionError`` on empty data instead of returning ``nan`` (:issue:`68422`)
+- Bug in :attr:`Series.sparse.density`, :attr:`DataFrame.sparse.density`, and :attr:`SparseArray.density` raising ``ZeroDivisionError`` on empty data instead of returning ``nan`` (:issue:`68468`)
 - Bug in :class:`SparseArray` with a datetime64 or timedelta64 subtype where a ``pd.NaT`` ``fill_value`` raised ``TypeError`` from :meth:`SparseArray.to_dense`, :meth:`SparseArray.unique`, :meth:`SparseArray.astype`, :meth:`SparseArray.take`, and arithmetic and comparison operations, and made ``np.asarray`` on a timedelta64 subtype return ``object`` dtype; all of these behaved correctly for an equivalent ``np.datetime64("NaT")`` fill value (:issue:`68449`)
 - Bug in :class:`SparseDtype` where two equal instances with an NA ``fill_value`` could hash differently, so a datetime64 or timedelta64 :class:`SparseDtype` could not be used as a dict key and identical sparse columns were counted separately by :meth:`Series.value_counts` on :attr:`DataFrame.dtypes` (:issue:`68449`)
 - Bug in :meth:`DataFrame.count`, :meth:`DataFrame.sum`, :meth:`DataFrame.mean`, :meth:`DataFrame.min`, and :meth:`DataFrame.max` on :class:`SparseDtype` columns forcing the result into the column's own dtype: ``count`` returned ``1`` for every sparse column, the sum of a narrow integer column silently wrapped around, the mean of an integer column was truncated to an integer, and a missing result (e.g. from ``min_count`` or an empty column) came back as a fill value or raised (:issue:`55123`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1125,6 +1125,7 @@ Reshaping
 
 Sparse
 ^^^^^^
+- Bug in :attr:`Series.sparse.density`, :attr:`DataFrame.sparse.density`, and :attr:`SparseArray.density` raising ``ZeroDivisionError`` on empty data instead of returning ``nan`` (:issue:`68422`)
 - Bug in :class:`SparseArray` with a datetime64 or timedelta64 subtype where a ``pd.NaT`` ``fill_value`` raised ``TypeError`` from :meth:`SparseArray.to_dense`, :meth:`SparseArray.unique`, :meth:`SparseArray.astype`, :meth:`SparseArray.take`, and arithmetic and comparison operations, and made ``np.asarray`` on a timedelta64 subtype return ``object`` dtype; all of these behaved correctly for an equivalent ``np.datetime64("NaT")`` fill value (:issue:`68449`)
 - Bug in :class:`SparseDtype` where two equal instances with an NA ``fill_value`` could hash differently, so a datetime64 or timedelta64 :class:`SparseDtype` could not be used as a dict key and identical sparse columns were counted separately by :meth:`Series.value_counts` on :attr:`DataFrame.dtypes` (:issue:`68449`)
 - Bug in :meth:`DataFrame.count`, :meth:`DataFrame.sum`, :meth:`DataFrame.mean`, :meth:`DataFrame.min`, and :meth:`DataFrame.max` on :class:`SparseDtype` columns forcing the result into the column's own dtype: ``count`` returned ``1`` for every sparse column, the sum of a narrow integer column silently wrapped around, the mean of an integer column was truncated to an integer, and a missing result (e.g. from ``min_count`` or an empty column) came back as a fill value or raised (:issue:`55123`)

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -465,7 +465,8 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
         Ratio of non-sparse points to total (dense) data points.
 
         This property returns the proportion of the data that is not sparse
-        (i.e., not equal to the fill value), as a value between 0 and 1.
+        (i.e., not equal to the fill value), as a value between 0 and 1. An
+        empty DataFrame has no density and returns ``nan``.
 
         See Also
         --------

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -811,7 +811,8 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         This is calculated as the number of non-fill-value points divided by
         the total length of the array. A density of 1.0 means no values are
-        the fill value, while 0.0 means all values are the fill value.
+        the fill value, while 0.0 means all values are the fill value. An
+        empty array has no density and returns ``nan``.
 
         See Also
         --------
@@ -825,6 +826,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         >>> s.density
         0.6
         """
+        if self.sp_index.length == 0:
+            # 0 / 0 is undefined
+            return np.nan
         return self.sp_index.npoints / self.sp_index.length
 
     @property

--- a/pandas/tests/arrays/sparse/test_accessor.py
+++ b/pandas/tests/arrays/sparse/test_accessor.py
@@ -91,7 +91,7 @@ class TestSeriesAccessor:
         assert cols == expected_cols
 
     def test_density_empty(self):
-        # GH#68422
+        # GH#68468
         ser = pd.Series(SparseArray(np.array([], dtype="float64")))
         assert np.isnan(ser.sparse.density)
 
@@ -222,7 +222,7 @@ class TestFrameAccessor:
         assert res == expected
 
     def test_density_empty(self):
-        # GH#68422
+        # GH#68468
         df = pd.DataFrame({"A": SparseArray(np.array([], dtype="float64"))})
         assert np.isnan(df.sparse.density)
 

--- a/pandas/tests/arrays/sparse/test_accessor.py
+++ b/pandas/tests/arrays/sparse/test_accessor.py
@@ -90,6 +90,11 @@ class TestSeriesAccessor:
         assert rows == expected_rows
         assert cols == expected_cols
 
+    def test_density_empty(self):
+        # GH#68422
+        ser = pd.Series(SparseArray(np.array([], dtype="float64")))
+        assert np.isnan(ser.sparse.density)
+
     def test_non_sparse_raises(self):
         ser = pd.Series([1, 2, 3])
         with pytest.raises(AttributeError, match=".sparse"):
@@ -215,6 +220,11 @@ class TestFrameAccessor:
         res = df.sparse.density
         expected = 0.75
         assert res == expected
+
+    def test_density_empty(self):
+        # GH#68422
+        df = pd.DataFrame({"A": SparseArray(np.array([], dtype="float64"))})
+        assert np.isnan(df.sparse.density)
 
     @pytest.mark.parametrize("dtype", ["int64", "float64"])
     @pytest.mark.parametrize("dense_index", [True, False])

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -339,6 +339,11 @@ class TestSparseArrayAnalytics:
         arr = SparseArray([0, 1])
         assert arr.density == 0.5
 
+    def test_density_empty(self):
+        # GH#68422
+        arr = SparseArray(np.array([], dtype="float64"))
+        assert np.isnan(arr.density)
+
     def test_npoints(self):
         arr = SparseArray([0, 1])
         assert arr.npoints == 1

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -340,7 +340,7 @@ class TestSparseArrayAnalytics:
         assert arr.density == 0.5
 
     def test_density_empty(self):
-        # GH#68422
+        # GH#68468
         arr = SparseArray(np.array([], dtype="float64"))
         assert np.isnan(arr.density)
 


### PR DESCRIPTION
`SparseArray.density` divides the non-fill point count by the array length with no zero
guard, so a length-zero sparse array raises instead of reporting a density:

```python
>>> pd.arrays.SparseArray(np.array([], dtype="float64")).density
ZeroDivisionError: division by zero
```

`Series.sparse.density` delegates to it and `DataFrame.sparse.density` averages the
per-column densities, so both inherit the raise. An empty frame is an ordinary state to
reach — a filter that matched no rows — and `density` is a diagnostic you would print on
whatever frame you have.

Empty now returns `nan`. `0 / 0` is undefined, and both of the anchors the docstring gives
hold vacuously on an empty array ("no values are the fill value" and "all values are the
fill value" are each true of nothing), so neither `1.0` nor `0.0` is principled. `nan` also
matches the neighbouring empty-input reductions — `mean`, `min`, `max`, `var`, `std` all
return `nan` — and it is what `DataFrame.sparse.density` already returned for a frame with
no columns, so the whole empty surface now answers with one value.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and
tests and ran a multi-round review of the branch.
