### PR TITLE
BUG: SparseArray.take promoted the subtype for a taken fill position

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1136,6 +1136,7 @@ Sparse
 - Bug in :meth:`Series.mean` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`Series.mode` and :meth:`DataFrame.mode` raising ``AttributeError: 'SparseDtype' object has no attribute 'itemsize'`` on a float :class:`SparseDtype` column (:issue:`68421`)
 - Bug in :meth:`Series.reindex` and alignment raising when extending a boolean :class:`SparseDtype`-backed :class:`Series`; missing entries now upcast to ``object`` to match the dense behavior (:issue:`32119`)
+- Bug in :meth:`Series.reindex`, :meth:`DataFrame.reindex`, :meth:`GroupBy.first`, :meth:`GroupBy.last`, and :meth:`SparseArray.take` returning the wrong subtype for :class:`SparseDtype` data: ``uint64`` values above ``2**53`` were silently rounded, and a datetime64 or timedelta64 subtype changed unit, became ``object`` holding raw integers, or raised ``DTypePromotionError`` (:issue:`68469`)
 - Bug in :meth:`Series.sum`, :meth:`Series.min`, and :meth:`Series.max` with ``skipna=False`` ignoring missing values for :class:`SparseDtype`-backed :class:`Series` (:issue:`65478`)
 - Bug in :meth:`SparseArray.astype` where converting a datetime64 :class:`SparseArray` with ``NaT`` fill value to ``"Sparse[int64]"`` silently replaced the fill value with ``0`` instead of ``iNaT`` (:issue:`49631`)
 - Bug in :meth:`SparseArray.mean` raising a ``TypeError`` when called with the ``skipna`` argument (:issue:`65478`)

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -48,6 +48,7 @@ from pandas.util._validators import (
 
 from pandas.core.dtypes.astype import astype_array
 from pandas.core.dtypes.cast import (
+    can_hold_element,
     construct_1d_object_array_from_listlike,
     find_common_type,
     maybe_box_datetimelike,
@@ -336,6 +337,28 @@ def _wrap_result(
 
 _BOOL_SPARSE_DTYPE_FALSE_FILL = SparseDtype(bool, False)
 _BOOL_SPARSE_DTYPE_TRUE_FILL = SparseDtype(bool, True)
+
+
+def _promote_for_fill(dtype: np.dtype, fill_value) -> tuple[np.dtype, Any]:
+    """
+    Dense dtype wide enough to hold ``fill_value``, and ``fill_value`` unboxed.
+
+    ``maybe_promote`` is no good on its own: its datetime64 arm widens to ``M8[ns]``
+    whenever the fill value's unit differs, so a ``Timestamp`` would pull a
+    ``Sparse[M8[s]]`` up to nanoseconds.  A ``Timestamp``/``Timedelta`` is unboxed
+    because ``np.full`` would otherwise truncate it to microseconds.
+    """
+    dummy = ensure_wrapped_if_datetimelike(np.empty(0, dtype=dtype))
+    if can_hold_element(dummy, fill_value):
+        if dtype.kind in "mM":
+            # an object dtype holds these as-is; only a datetimelike array needs
+            #  the numpy scalar, and only it rejects np.nan in place of NaT
+            if isna(fill_value):
+                fill_value = dtype.type("NaT")
+            elif isinstance(fill_value, (Timestamp, Timedelta)):
+                fill_value = fill_value.asm8
+        return dtype, fill_value
+    return maybe_promote(dtype, fill_value)
 
 
 @set_module("pandas.arrays")
@@ -1233,9 +1256,9 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if len(self) == 0:
             # Empty... Allow taking only if all empty
             if (indices == -1).all():
-                dtype = np.result_type(self.sp_values, type(fill_value))
+                dtype, new_fill = _promote_for_fill(self.sp_values.dtype, fill_value)
                 taken = np.empty_like(indices, dtype=dtype)
-                taken.fill(fill_value)
+                taken.fill(new_fill)
                 return taken
             else:
                 raise IndexError("cannot do a non-empty take from an empty axes.")
@@ -1249,19 +1272,15 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         if self.sp_index.npoints == 0 and old_fill_indices.all():
             # We've looked up all valid points on an all-sparse array.
-            taken = np.full(
-                sp_indexer.shape, fill_value=self.fill_value, dtype=self.dtype.subtype
-            )
+            _dtype, old_fill = _promote_for_fill(self.dtype.subtype, self.fill_value)
+            taken = np.full(sp_indexer.shape, old_fill, dtype=_dtype)
 
         elif self.sp_index.npoints == 0:
             # Use the old fill_value unless we took for an index of -1
-            _dtype = np.result_type(self.dtype.subtype, type(fill_value))
-            if self.dtype.subtype.kind == "b" and _dtype.kind != "b":
-                # GH#32119 numpy bool can't hold a non-bool (e.g. NA) fill;
-                #  match the dense reindex behavior and upcast to object
-                _dtype = np.dtype(object)
-            taken = np.full(sp_indexer.shape, fill_value=fill_value, dtype=_dtype)
-            taken[old_fill_indices] = self.fill_value
+            _dtype, new_fill = _promote_for_fill(self.dtype.subtype, fill_value)
+            _dtype, old_fill = _promote_for_fill(_dtype, self.fill_value)
+            taken = np.full(sp_indexer.shape, new_fill, dtype=_dtype)
+            taken[old_fill_indices] = old_fill
         else:
             taken = self.sp_values.take(sp_indexer)
 
@@ -1276,18 +1295,14 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             result_type = taken.dtype
 
             if m0.any():
-                result_type = np.result_type(result_type, type(self.fill_value))
-                taken = taken.astype(result_type)
-                taken[old_fill_indices] = self.fill_value
+                result_type, old_fill = _promote_for_fill(result_type, self.fill_value)
+                taken = taken.astype(result_type, copy=False)
+                taken[old_fill_indices] = old_fill
 
             if m1.any():
-                result_type = np.result_type(result_type, type(fill_value))
-                if taken.dtype.kind == "b" and result_type.kind != "b":
-                    # GH#32119 numpy bool can't hold a non-bool (e.g. NA)
-                    #  fill; match the dense reindex behavior (bool -> object)
-                    result_type = np.dtype(object)
-                taken = taken.astype(result_type)
-                taken[new_fill_indices] = fill_value
+                result_type, new_fill = _promote_for_fill(result_type, fill_value)
+                taken = taken.astype(result_type, copy=False)
+                taken[new_fill_indices] = new_fill
 
         return taken
 

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -354,7 +354,8 @@ def _promote_for_fill(dtype: np.dtype, fill_value) -> tuple[np.dtype, Any]:
             # an object dtype holds these as-is; only a datetimelike array needs
             #  the numpy scalar, and only it rejects np.nan in place of NaT
             if isna(fill_value):
-                fill_value = dtype.type("NaT")
+                # a unitless NaT is deprecated as of numpy 2.5
+                fill_value = dtype.type("NaT", np.datetime_data(dtype)[0])
             elif isinstance(fill_value, (Timestamp, Timedelta)):
                 fill_value = fill_value.asm8
         return dtype, fill_value

--- a/pandas/tests/arrays/sparse/test_indexing.py
+++ b/pandas/tests/arrays/sparse/test_indexing.py
@@ -194,6 +194,97 @@ class TestTake:
         assert result.dtype == pd.SparseDtype(object, False)
         tm.assert_sp_array_equal(result, expected)
 
+    @pytest.mark.parametrize(
+        "subtype", ["int8", "int32", "uint16", "uint64", "float32"]
+    )
+    def test_take_fill_preserves_subtype(self, subtype):
+        # GH#68469 an old fill position holds self.fill_value, which
+        #  SparseDtype._check_fill_value guarantees fits the subtype, so it must
+        #  not promote; widening uint64 to float64 would round above 2**53
+        big = 2**63 + 12345 if subtype == "uint64" else 3
+        sparse = SparseArray(np.array([1, 0, big], dtype=subtype), fill_value=0)
+        result = sparse.take(np.array([0, 1, 2]), allow_fill=True)
+        tm.assert_sp_array_equal(result, sparse)
+
+    def test_take_fill_all_fill_preserves_subtype(self):
+        # GH#68469 same for the all-fill (sp_index.npoints == 0) path, which
+        #  promoted whenever an index of -1 came along
+        sparse = SparseArray(np.array([0, 0, 0], dtype="int8"), fill_value=0)
+        result = sparse.take(np.array([0, 1, -1]), allow_fill=True, fill_value=0)
+        assert result.dtype == pd.SparseDtype("int8", 0)
+        tm.assert_sp_array_equal(result, sparse)
+
+    @pytest.mark.parametrize("unit", ["M8[s]", "M8[ns]", "m8[s]", "m8[ns]"])
+    def test_take_fill_datetimelike_subtype(self, unit):
+        # GH#68469 a datetimelike subtype was promoted on type(fill_value):
+        #  to object for a nanosecond unit, which numpy renders as raw
+        #  integers, and to microseconds for a coarser one
+        data = np.array([1, 3, 5], dtype=unit)
+        fill = pd.Timestamp(data[1]) if unit[0] == "M" else pd.Timedelta(data[1])
+        sparse = SparseArray(data, fill_value=fill)
+        result = sparse.take(np.array([0, 1, 2]), allow_fill=True)
+        tm.assert_sp_array_equal(result, sparse)
+
+    @pytest.mark.parametrize("unit", ["M8[s]", "M8[ns]", "m8[s]", "m8[ns]"])
+    def test_take_fill_datetimelike_new_fill_is_nat(self, unit):
+        # GH#68469 a new fill position takes NaT in the subtype, as dense
+        #  reindex does, rather than promoting the array
+        data = np.array([1, 3, 5], dtype=unit)
+        fill = pd.Timestamp(data[1]) if unit[0] == "M" else pd.Timedelta(data[1])
+        sparse = SparseArray(data, fill_value=fill)
+        result = sparse.take(np.array([0, 1, -1]), allow_fill=True)
+        expected = SparseArray(np.array([1, 3, "NaT"], dtype=unit), fill_value=fill)
+        tm.assert_sp_array_equal(result, expected)
+
+    @pytest.mark.parametrize("subtype", ["int8", "uint64", "float32"])
+    def test_take_fill_empty_preserves_subtype(self, subtype):
+        # GH#68469 the len(self) == 0 arm promoted on type(fill_value) too, so an
+        #  empty array disagreed with a non-empty one on the same input
+        sparse = SparseArray(np.array([], dtype=subtype), fill_value=0)
+        result = sparse.take(np.array([-1, -1]), allow_fill=True, fill_value=0)
+        assert result.dtype == pd.SparseDtype(subtype, 0)
+
+    @pytest.mark.parametrize("unit", ["M8[s]", "M8[ns]", "m8[s]", "m8[ns]"])
+    def test_take_fill_empty_datetimelike(self, unit):
+        # GH#68469 the same arm raised DTypePromotionError for a datetimelike
+        #  subtype, since it promoted against type(np.nan)
+        sparse = SparseArray(np.array([], dtype=unit), fill_value=pd.NaT)
+        result = sparse.take(np.array([-1, -1]), allow_fill=True)
+        assert result.dtype.subtype == np.dtype(unit)
+
+    def test_take_fill_all_fill_all_new(self):
+        # an all-fill array taken entirely at -1 has no old fill position at
+        #  all; pins that the promotion stays well defined, see GH#68469
+        sparse = SparseArray(np.array([0, 0, 0], dtype="int8"), fill_value=0)
+        result = sparse.take(np.array([-1, -1]), allow_fill=True)
+        expected = SparseArray(np.array([np.nan, np.nan]), fill_value=0)
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_take_fill_object_subtype_keeps_boxed_scalar(self):
+        # only a datetimelike subtype needs the numpy scalar; pins that an
+        #  object subtype keeps the Timestamp boxed, cf GH#68073
+        sparse = SparseArray(np.array(["a", "x", "b"], dtype=object), fill_value="x")
+        ts = pd.Timestamp("2000-01-01")
+        result = sparse.take(np.array([0, -1]), allow_fill=True, fill_value=ts)
+        assert result.dtype == pd.SparseDtype(object, "x")
+        assert result[1] == ts and isinstance(result[1], pd.Timestamp)
+
+    @pytest.mark.parametrize("unit", ["M8[s]", "M8[ns]", "m8[s]", "m8[ns]"])
+    def test_take_fill_datetimelike_no_gaps(self, unit):
+        # GH#68469 with no gaps only the new fill promotes, and promoting a
+        #  datetimelike subtype against type(np.nan) raised outright
+        data = np.array([1, 3, 5], dtype=unit)
+        fill = (
+            pd.Timestamp(99, unit=unit[3:-1])
+            if unit[0] == "M"
+            else pd.Timedelta(99, unit[3:-1])
+        )
+        sparse = SparseArray(data, fill_value=fill)
+        assert sparse.sp_index.ngaps == 0
+        result = sparse.take(np.array([0, 1, 2, -1]), allow_fill=True)
+        assert result.dtype.subtype == np.dtype(unit)
+        assert result[3] is pd.NaT
+
     def test_take_fill_value(self):
         data = np.array([1, np.nan, 0, 3, 0])
         sparse = SparseArray(data, fill_value=0)

--- a/pandas/tests/groupby/test_sparse.py
+++ b/pandas/tests/groupby/test_sparse.py
@@ -163,6 +163,41 @@ class TestSparseGroupby:
         expected = getattr(dense_ser.groupby(keys), op)()
         tm.assert_series_equal(result, expected)
 
+    @pytest.mark.parametrize("op", ["first", "last"])
+    @pytest.mark.parametrize(
+        "subtype", ["int8", "int32", "uint16", "uint64", "float32"]
+    )
+    def test_sparse_groupby_first_last_preserves_subtype(self, subtype, op):
+        # GH#68469 first/last keep the SparseDtype rather than densifying, so
+        #  they reach the gaps through take
+        keys = ["a", "a", "b", "b", "a", "b"]
+        big = 2**63 + 12345 if subtype == "uint64" else 3
+        dense_ser = pd.Series(np.array([0, 1, big, 0, big, 0], dtype=subtype))
+        sparse_ser = dense_ser.astype(pd.SparseDtype(subtype, 0))
+        assert sparse_ser.array.sp_index.ngaps == 3
+
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        expected = expected.astype(pd.SparseDtype(subtype, 0))
+        tm.assert_series_equal(result, expected)
+
+    @pytest.mark.parametrize("op", ["first", "last"])
+    @pytest.mark.parametrize("unit", ["M8[s]", "M8[ns]", "m8[s]", "m8[ns]"])
+    def test_sparse_groupby_first_last_datetimelike(self, unit, op):
+        # GH#68469 same for a datetimelike subtype: a nanosecond unit was
+        #  promoted to object and read back as raw integers, a coarser one
+        #  was widened
+        keys = ["a", "a", "b", "b", "a", "b"]
+        dense_ser = pd.Series(np.array([3, 1, 5, 3, 5, 3], dtype=unit))
+        fill = dense_ser[0] if unit[0] == "M" else pd.Timedelta(dense_ser[0])
+        sparse_ser = dense_ser.astype(pd.SparseDtype(unit, fill))
+        assert sparse_ser.array.sp_index.ngaps == 3
+
+        result = getattr(sparse_ser.groupby(keys), op)()
+        expected = getattr(dense_ser.groupby(keys), op)()
+        expected = expected.astype(pd.SparseDtype(unit, fill))
+        tm.assert_series_equal(result, expected)
+
     @pytest.mark.parametrize("nat_fill", [None, pd.NaT])
     @pytest.mark.parametrize(
         "unit",


### PR DESCRIPTION
Every arm of `SparseArray._take_with_fill` chose its result dtype with a *type*-based promotion, `np.result_type(dtype, type(fill_value))`, which fires whenever a taken position lands on a gap or on a `-1` index. `SparseDtype._check_fill_value` already guarantees a non-NA fill value fits the subtype, so for a gap the promotion is never needed, and for a `-1` it should follow the value rather than its type.

The result was that `arr.take([0, 1, 2], allow_fill=True)` — an identity take, no `-1` at all — did not round-trip:

| `self.dtype` | result |
|---|---|
| `Sparse[int8, 0]` | `Sparse[int64, 0]` |
| `Sparse[uint64, 0]` | `Sparse[float64, 0]`, rounding values above `2**53` |
| `Sparse[datetime64[ns], Timestamp(...)]` | `Sparse[object]` holding raw integers |
| `Sparse[datetime64[s], Timestamp(...)]` | `Sparse[datetime64[us]]` |
| `Sparse[datetime64[ns]]`, no gaps | `DTypePromotionError` |

`Series.reindex`, `DataFrame.reindex`, `.loc[list]`, alignment and `GroupBy.first`/`last` all reach this, so a sparse column silently widened — or lost precision — on ordinary indexing. `first`/`last` are the groupby path because they preserve the `SparseDtype` and so take the gaps through `take` rather than densifying.

Replaced all four promotions with a `_promote_for_fill` helper that keeps the dtype when `can_hold_element` says it already holds the value and defers to `maybe_promote` otherwise. `maybe_promote` cannot be used alone here: its datetime64 arm widens to `M8[ns]` whenever the fill value's unit differs, which would pull `Sparse[M8[s]]` up to nanoseconds. The helper subsumes the two open-coded `GH-32119` bool-upcast guards, which are removed.

The defect is long-standing — the promotion dates to the ExtensionArray refactor in 56d8e789155 (2018). Found while auditing GH-66690, which fixed the neighbouring densify path but did not touch `take`.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which investigated the defect, wrote the fix and tests, and ran a multi-round review loop over the branch; reviewed by me before opening.