### PR TITLE
BUG: HDF5 append silently mixed a CategoricalIndex with an integer Index (GH#65576)

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2918,9 +2918,24 @@ class IndexCol:
         # check for backwards incompatibility
         if append:
             existing_kind = getattr(self.attrs, self.kind_attr, None)
-            if existing_kind is not None and existing_kind != self.kind:
+            if existing_kind is None:
+                # brand new table, nothing to be incompatible with
+                return
+            if existing_kind != self.kind:
                 raise TypeError(
                     f"incompatible kind in col [{existing_kind} - {self.kind}]"
+                )
+            existing_meta = getattr(self.attrs, self.meta_attr, None)
+            if existing_meta != self.meta:
+                # A CategoricalIndex stores its codes, so both sides are kind
+                # "integer" and the check above passes; without this the append
+                # silently reinterprets codes as labels or vice versa. GH#65576
+                if self.meta == "category":
+                    raise TypeError(
+                        "cannot append a categorical index to a non-categorical index"
+                    )
+                raise TypeError(
+                    "cannot append a non-categorical index to a categorical index"
                 )
 
     def update_info(self, info) -> None:

--- a/pandas/tests/io/pytables/test_categorical.py
+++ b/pandas/tests/io/pytables/test_categorical.py
@@ -479,3 +479,32 @@ def test_categorical_where_ordering_op_unrecorded_ordered(temp_h5_path):
 
     result = pd.read_hdf(temp_h5_path, "df", where='col < "b"')
     tm.assert_frame_equal(result, df.iloc[:1])
+
+
+@pytest.mark.parametrize(
+    "first, second, msg",
+    [
+        (
+            pd.Index([0, 1]),
+            pd.CategoricalIndex(["a", "b"]),
+            "cannot append a categorical index to a non-categorical index",
+        ),
+        (
+            pd.CategoricalIndex(["a", "b"]),
+            pd.Index([0, 1]),
+            "cannot append a non-categorical index to a categorical index",
+        ),
+    ],
+)
+def test_categorical_index_append_mismatch_raises(first, second, msg, temp_h5_path):
+    # GH#65576 - the append used to be accepted, silently reinterpreting the
+    # already-stored index values on read.
+    df = pd.DataFrame({"v": [1.0, 2.0]}, index=first)
+    df.to_hdf(temp_h5_path, key="df", format="table")
+
+    other = pd.DataFrame({"v": [3.0, 4.0]}, index=second)
+    with pytest.raises(TypeError, match=msg):
+        other.to_hdf(temp_h5_path, key="df", format="table", append=True)
+
+    # the rejected append leaves the stored rows intact and readable
+    tm.assert_frame_equal(pd.read_hdf(temp_h5_path, key="df"), df)


### PR DESCRIPTION
`HDFStore.append` to a `format="table"` key accepted an index whose type did not match the stored one when a `CategoricalIndex` met a plain integer `Index`. A `CategoricalIndex` is stored as its integer codes, so `IndexCol.validate_attr`'s `kind` comparison saw `"integer"` on both sides and let the append through:

```python
store.put("k", DataFrame({"v": [1.0, 2.0]}, index=Index([0, 1])), format="table")
store.append("k", DataFrame({"v": [3.0]}, index=CategoricalIndex(["a", "b"])[:1]))

store.select("k").index                 # ['a', 'b', 'a'] -- the stored 0 and 1 relabelled
store.select("k", where="index=='a'")   # 2 rows, one of them the old int-0 row
```

The reverse order reads raw integers back as categories, and a one-category variant leaves the key permanently unreadable (`IndexError: out of bounds value in 'indices'`). `validate_attr` now compares the persisted `meta` attribute as well and raises `TypeError` in both directions, matching the loud raise a float-vs-int index mismatch already gives.

Follow-up to GH-65576, which first made a `CategoricalIndex` writable to HDF5 and so opened this path. No whatsnew entry: GH-65576 is unreleased, so its existing 3.1.0 entry covers this — as with GH-66165, the earlier follow-up to the same PR.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the `kind` collision, wrote the fix and the regression tests, and ran the review loop over the result.
