### PR TITLE
BUG: read_hdf read a missing value in a string Index of a pandas 3.0 file back as "nan" (GH#9604)

### DIFF
--- a/pandas/io/pytables.py
+++ b/pandas/io/pytables.py
@@ -2968,10 +2968,11 @@ class IndexCol:
             # empty categories cannot be written as metadata, still round-trips
             # as categorical rather than as raw integer codes. GH#65576
             _set_attr_if_changed(self.attrs, self.meta_attr, self.meta)
-        if self.nan_rep is not None:
-            # GH#9604: persist the string-Index NaN sentinel so select() can
-            # restore missing values on read (see IndexCol.convert).
-            _set_attr_if_changed(self.attrs, self.nan_rep_attr, self.nan_rep)
+        if self.kind == "string":
+            # GH#9604: the NaN sentinel, empty when the index has no missing
+            # value, so that its absence marks an older file. Table.indexables
+            # reads it back through _read_index_nan_rep.
+            _set_attr_if_changed(self.attrs, self.nan_rep_attr, self.nan_rep or "")
 
     def validate_metadata(self, handler: AppendableTable) -> None:
         """validate that kind=category does not change the categories"""
@@ -3738,10 +3739,9 @@ class GenericFixed(Fixed):
             node._v_attrs.kind = converted.kind
             node._v_attrs.name = index.name
 
-            if converted.nan_rep is not None:
-                # GH#9604: persist the string-Index NaN sentinel so read_index
-                # can restore missing values (see read_index_node).
-                node._v_attrs.nan_rep = converted.nan_rep
+            if converted.kind == "string":
+                # GH#9604: the NaN sentinel, as in IndexCol.set_attr
+                node._v_attrs.nan_rep = converted.nan_rep or ""
 
             if isinstance(index, (DatetimeIndex, PeriodIndex)):
                 node._v_attrs.index_class = self._class_to_alias(type(index))
@@ -3772,8 +3772,9 @@ class GenericFixed(Fixed):
             node._v_attrs.kind = conv_level.kind
             node._v_attrs.name = name
 
-            if conv_level.nan_rep is not None:
-                node._v_attrs.nan_rep = conv_level.nan_rep
+            if conv_level.kind == "string":
+                # GH#9604: the NaN sentinel, as in IndexCol.set_attr
+                node._v_attrs.nan_rep = conv_level.nan_rep or ""
 
             # write the name
             setattr(node._v_attrs, f"{key}_name{name}", name)
@@ -3834,8 +3835,7 @@ class GenericFixed(Fixed):
         attrs = node._v_attrs
         factory, kwargs = self._get_index_factory(attrs)
 
-        # GH#9604: per-index string NaN sentinel (absent for old files)
-        nan_rep = getattr(node._v_attrs, "nan_rep", None)
+        nan_rep = _read_index_nan_rep(attrs) if kind == "string" else None
 
         if kind == "string" and using_string_dtype():
             # GH#9604: once the sentinel is substituted back to NaN, dtype
@@ -4529,8 +4529,11 @@ class Table(Fixed):
 
             kind_attr = f"{name}_kind"
             kind = getattr(table_attrs, kind_attr, None)
-            # GH#9604: per-index string NaN sentinel (absent for old files)
-            nan_rep = getattr(table_attrs, f"{name}_nan_rep", None)
+            nan_rep = (
+                _read_index_nan_rep(table_attrs, f"{name}_nan_rep")
+                if kind == "string"
+                else None
+            )
 
             index_col = IndexCol(
                 name=name,
@@ -4898,6 +4901,17 @@ class Table(Fixed):
         if table_exists:
             existing_index_col = self.index_axes[0]
             existing_nan_rep = existing_index_col.nan_rep
+            if existing_index_col.kind == "string" and not hasattr(
+                self.table.attrs, existing_index_col.nan_rep_attr
+            ):
+                # _read_index_nan_rep assumes "nan" is the sentinel of a file
+                # written before one was persisted, which only holds if such a
+                # value is stored. Without one the column has no sentinel to
+                # protect, so a literal "nan" may still be appended to it. Test
+                # the raw bytes rather than decoding a possibly large column.
+                stored = getattr(self.table.cols, existing_index_col.cname)[:]
+                if not (stored == existing_nan_rep.encode(self.encoding)).any():
+                    existing_nan_rep = None
             if (
                 existing_nan_rep is None
                 and existing_index_col.kind == "string"
@@ -5942,6 +5956,19 @@ def _set_tz(
     dtype = tz_to_dtype(tz=tz, unit=unit)  # type: ignore[arg-type]
     dta = DatetimeArray._from_sequence(values, dtype=dtype)
     return dta
+
+
+def _read_index_nan_rep(attrs, name: str = "nan_rep") -> str | None:
+    """
+    Read back the NaN sentinel persisted for a string Index column (GH#9604).
+
+    The writer records the attribute for every string Index, empty when the
+    index had no missing value, so its absence means the file predates the
+    sentinel. Such a file stored a NaN as the bare string "nan", which is how
+    pandas read it back before the sentinel existed.
+    """
+    nan_rep = getattr(attrs, name, "nan")
+    return nan_rep or None
 
 
 def _make_index_nan_rep(

--- a/pandas/tests/io/pytables/test_round_trip.py
+++ b/pandas/tests/io/pytables/test_round_trip.py
@@ -134,6 +134,116 @@ def test_string_index_real_na_roundtrips_table(temp_hdfstore):
     not using_string_dtype(),
     reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
 )
+def test_string_index_na_read_from_file_without_sentinel_fixed(temp_hdfstore):
+    # GH#9604 — pandas 3.0 stored a NaN in a string Index as the bare string
+    # "nan" and read it back as missing. Those files carry no sentinel
+    # attribute, so the reader has to keep substituting "nan" for them.
+    ser = pd.Series(range(3), index=pd.Index(["aaa", np.nan, "bbb"], dtype=str))
+
+    temp_hdfstore.put("s", ser, track_times=False)
+    assert temp_hdfstore.get_storer("s").group.index[:].tolist() == [
+        b"aaa",
+        b"nan",
+        b"bbb",
+    ]
+    del temp_hdfstore.get_storer("s").group.index._v_attrs.nan_rep
+
+    tm.assert_series_equal(temp_hdfstore.get("s"), ser)
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_index_na_read_from_file_without_sentinel_table(temp_hdfstore):
+    # GH#9604 — same, table format.
+    ser = pd.Series(range(3), index=pd.Index(["aaa", np.nan, "bbb"], dtype=str))
+
+    temp_hdfstore.append("s", ser)
+    del temp_hdfstore.get_storer("s").table.attrs.index_nan_rep
+
+    tm.assert_series_equal(temp_hdfstore.select("s"), ser)
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_index_append_to_file_without_sentinel(temp_hdfstore):
+    # GH#9604 — appending to such a file adopts "nan" as the sentinel, so the
+    # rows already stored and the appended missing values agree.
+    ser1 = pd.Series(range(2), index=pd.Index(["aaa", np.nan], dtype=str))
+    temp_hdfstore.append("s", ser1)
+    del temp_hdfstore.get_storer("s").table.attrs.index_nan_rep
+
+    ser2 = pd.Series(range(2, 4), index=pd.Index(["bbb", np.nan], dtype=str))
+    temp_hdfstore.append("s", ser2)
+
+    expected = pd.Series(
+        range(4), index=pd.Index(["aaa", np.nan, "bbb", np.nan], dtype=str)
+    )
+    tm.assert_series_equal(temp_hdfstore.select("s"), expected)
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_index_append_literal_nan_to_file_without_sentinel_raises(temp_hdfstore):
+    # GH#9604 — a file written before the sentinel was persisted stores a NaN
+    # as "nan", so a row labelled "nan" can no longer be appended to one: it
+    # would be indistinguishable from those.
+    temp_hdfstore.append(
+        "s", pd.Series([0, 1], index=pd.Index(["aaa", np.nan], dtype=str))
+    )
+    del temp_hdfstore.get_storer("s").table.attrs.index_nan_rep
+
+    ser2 = pd.Series([2], index=pd.Index(["nan"], dtype=str))
+    with pytest.raises(ValueError, match="collides with the sentinel"):
+        temp_hdfstore.append("s", ser2)
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
+def test_string_index_append_na_to_file_without_missing_values(temp_hdfstore):
+    # GH#9604 — the sentinel minted for the first missing value appended to such
+    # a file has to dodge the values already stored, not just the ones in the
+    # appended chunk: here "nan" and "_nan_" are both taken.
+    temp_hdfstore.append(
+        "s", pd.Series([0, 1], index=pd.Index(["_nan_", "bbbbbbbbbb"], dtype=str))
+    )
+    del temp_hdfstore.get_storer("s").table.attrs.index_nan_rep
+
+    ser2 = pd.Series([2, 3], index=pd.Index(["nan", np.nan], dtype=str))
+    temp_hdfstore.append("s", ser2)
+
+    expected = pd.Series(
+        range(4),
+        index=pd.Index(["_nan_", "bbbbbbbbbb", "nan", np.nan], dtype=str),
+    )
+    tm.assert_series_equal(temp_hdfstore.select("s"), expected)
+
+
+def test_string_index_append_literal_nan_to_file_without_missing_values(temp_hdfstore):
+    # GH#9604 — but a pre-sentinel file that stores no "nan" at all has no
+    # sentinel to protect, so appending that label still works as it did.
+    temp_hdfstore.append(
+        "s", pd.Series([0, 1], index=pd.Index(["aaa", "bbb"], dtype=str))
+    )
+    del temp_hdfstore.get_storer("s").table.attrs.index_nan_rep
+
+    temp_hdfstore.append("s", pd.Series([2], index=pd.Index(["nan"], dtype=str)))
+
+    expected = pd.Series(range(3), index=pd.Index(["aaa", "bbb", "nan"], dtype=str))
+    tm.assert_series_equal(temp_hdfstore.select("s"), expected)
+
+
+@pytest.mark.skipif(
+    not using_string_dtype(),
+    reason="a real NaN in dtype=str is an object/mixed Index under infer_string=0",
+)
 def test_string_index_real_na_and_literal_nan_roundtrip(temp_h5_path):
     # GH#9604 — a real NA and the literal string "nan" coexist in one string
     # Index and both round-trip: the NaN sentinel is chosen to avoid colliding
@@ -315,16 +425,17 @@ def test_string_index_literal_nan_multichunk_append_no_na(temp_hdfstore):
     tm.assert_series_equal(temp_hdfstore.select("s"), expected)
 
 
-def test_string_multiindex_level_literal_nan(temp_h5_path):
-    # GH#9604 — a literal "nan" string in a MultiIndex level round-trips in the
-    # table format. Levels are stored as data columns, which previously read a
-    # literal "nan" back as a missing value via the global NaN sentinel.
+@pytest.mark.parametrize("fmt", ["fixed", "table"])
+def test_string_multiindex_level_literal_nan(temp_h5_path, fmt):
+    # GH#9604 — a literal "nan" in a MultiIndex level round-trips in both
+    # formats. In the fixed format the empty sentinel attribute is what keeps it
+    # a string: an absent one marks a pre-3.1 file and means substitute.
     mi = pd.MultiIndex.from_arrays(
         [pd.Index(["nan", "a", "b"], dtype=str), [1, 2, 3]], names=["s", "i"]
     )
     ser = pd.Series(range(3), index=mi)
 
-    ser.to_hdf(temp_h5_path, key="t", format="table")
+    ser.to_hdf(temp_h5_path, key="t", format=fmt)
     tm.assert_series_equal(pd.read_hdf(temp_h5_path, "t"), ser)
 
 


### PR DESCRIPTION
Follow-up to GH-65603 (GH-9604). No issue to close — the regression is on `main` only, so no released version is affected.

GH-65603 made `nan_rep=None` mean "skip substitution" in `_unconvert_string_array`, on the premise that "the write path for indices never substitutes a NaN sentinel". That premise is only true syntactically: `_convert_string_array` ends in `np.asarray(data, dtype=f"S{itemsize}")`, and numpy stringifies a float NaN to `b"nan"`. So files written by earlier pandas *do* contain a de-facto sentinel with no persisted `nan_rep` attribute, and the reader they were written for substituted it back.

The result is a silent backward-compatibility corruption: a missing value in a string `Index` of any HDF5 file written by pandas 3.0 reads back on `main` as the three-character string `"nan"`, with `isna()` all `False`. Verified against a real 3.0.1 build — it writes `[b'alpha', b'nan', b'gamma']` and reads back `['alpha', nan, 'gamma']`; `main` reads the same bytes as three strings. Both storage formats and fixed-format `columns` are affected. MultiIndex levels are not (a level never holds the NA — it is code `-1`), nor is table-format `columns` (pickled in `non_index_axes`).

The fix persists the `nan_rep` attribute for every string `Index` — empty when there is no sentinel — so that the attribute's *absence* identifies such a file, which is then read exactly as it always was. On the append path the legacy sentinel is only inherited when the stored column actually contains that value, so a file with no sentinel to protect still accepts a row labelled `"nan"`, as 3.0 did.

Two consequences worth calling out, both inherent to bytes that are genuinely ambiguous:

- A pre-existing file whose string `Index` holds a *literal* `"nan"` reads back as `NaN` again. That is what every released pandas does with those files, and the alternative silently destroys real missing values. Newly written files round-trip both, which is what GH-9604 asked for.
- pandas 3.0 sized the column from the non-missing strings, so an index whose longest value was under 3 characters stored a truncated sentinel (`Index(["a", nan])` → `[b"a", b"n"]`). Those missing values are unrecoverable; 3.0 itself read them back as `"n"`, and this matches that exactly.

No whatsnew entry: GH-65603 merged after v3.0.0, so the regression never shipped, and the 3.0 → 3.1 delta is still exactly the two existing `:issue:`9604`` entries.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the regression against a local pandas 3.0.1 build, wrote the fix and tests, and ran a multi-agent review of the branch; reviewed by me before opening.
