### PR TITLE
BUG: sparse logical ops raised on a masked boolean operand (GH#66306)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1084,7 +1084,7 @@ Sparse
 - Bug in ``np.std`` and ``np.var`` on a :class:`SparseArray` returning ``NaN`` when the array held missing values, inconsistently with ``np.sum`` and ``np.mean``, which skip them (:issue:`68194`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
 - Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a differently-indexed :class:`Series` raising an uninformative error instead of aligning and returning the expected result (:issue:`32119`)
-- Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a nullable ``boolean`` :class:`Series` raising ``TypeError: boolean value of NA is ambiguous``, or silently resolving the missing values to ``False``; the result now matches the non-sparse equivalent and has ``boolean`` dtype (:issue:`68422`)
+- Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a nullable ``boolean`` :class:`Series` raising ``TypeError: boolean value of NA is ambiguous``, or silently resolving the missing values to ``False``; the result now matches the non-sparse equivalent and has ``boolean`` dtype (:issue:`68483`)
 - Bug in the repr of a datetime64 or timedelta64 :class:`SparseDtype`-backed :class:`Series`, and in casting such an array to ``object`` dtype, showing raw integers such as ``1577836800000000000`` instead of :class:`Timestamp`/:class:`Timedelta` values (:issue:`68073`)
 
 ExtensionArray

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1084,6 +1084,7 @@ Sparse
 - Bug in ``np.std`` and ``np.var`` on a :class:`SparseArray` returning ``NaN`` when the array held missing values, inconsistently with ``np.sum`` and ``np.mean``, which skip them (:issue:`68194`)
 - Bug in indexing a :class:`SparseArray` with an out-of-bounds integer with the value of the length of the array returning the fill value instead of raising an ``IndexError`` (:issue:`64183`).
 - Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a differently-indexed :class:`Series` raising an uninformative error instead of aligning and returning the expected result (:issue:`32119`)
+- Bug in logical operators (``&``, ``|``, ``^``) between a :class:`SparseDtype`-backed :class:`Series` and a nullable ``boolean`` :class:`Series` raising ``TypeError: boolean value of NA is ambiguous``, or silently resolving the missing values to ``False``; the result now matches the non-sparse equivalent and has ``boolean`` dtype (:issue:`68422`)
 - Bug in the repr of a datetime64 or timedelta64 :class:`SparseDtype`-backed :class:`Series`, and in casting such an array to ``object`` dtype, showing raw integers such as ``1577836800000000000`` instead of :class:`Timestamp`/:class:`Timedelta` values (:issue:`68073`)
 
 ExtensionArray

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -63,6 +63,7 @@ from pandas.core.dtypes.common import (
     pandas_dtype,
 )
 from pandas.core.dtypes.dtypes import (
+    BaseMaskedDtype,
     DatetimeTZDtype,
     SparseDtype,
 )
@@ -192,6 +193,16 @@ def _get_fill(arr: SparseArray) -> np.ndarray:
         return np.asarray(arr.fill_value, dtype=arr.dtype.subtype)
     except ValueError:
         return np.asarray(arr.fill_value)
+
+
+def _maybe_object_for_bool_fill(
+    from_dtype: np.dtype, result_dtype: np.dtype
+) -> np.dtype:
+    # GH#32119 numpy bool cannot hold a non-bool (e.g. NA) fill value, so a take
+    #  that introduces one upcasts to object like the dense path, never to float.
+    if from_dtype.kind == "b" and result_dtype.kind != "b":
+        return np.dtype(object)
+    return result_dtype
 
 
 def _sparse_array_op(
@@ -1224,7 +1235,10 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if len(self) == 0:
             # Empty... Allow taking only if all empty
             if (indices == -1).all():
-                dtype = np.result_type(self.sp_values, type(fill_value))
+                dtype = _maybe_object_for_bool_fill(
+                    self.dtype.subtype,
+                    np.result_type(self.sp_values, type(fill_value)),
+                )
                 taken = np.empty_like(indices, dtype=dtype)
                 taken.fill(fill_value)
                 return taken
@@ -1240,17 +1254,20 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
 
         if self.sp_index.npoints == 0 and old_fill_indices.all():
             # We've looked up all valid points on an all-sparse array.
-            taken = np.full(
-                sp_indexer.shape, fill_value=self.fill_value, dtype=self.dtype.subtype
-            )
+            # GH#32119 the fill is the array's own, so don't promote; the bool
+            #  subtype is the exception, where np.full would quietly turn an NA
+            #  fill into True
+            _dtype = self.dtype.subtype
+            if _dtype.kind == "b" and not lib.is_bool(self.fill_value):
+                _dtype = np.dtype(object)
+            taken = np.full(sp_indexer.shape, fill_value=self.fill_value, dtype=_dtype)
 
         elif self.sp_index.npoints == 0:
             # Use the old fill_value unless we took for an index of -1
-            _dtype = np.result_type(self.dtype.subtype, type(fill_value))
-            if self.dtype.subtype.kind == "b" and _dtype.kind != "b":
-                # GH#32119 numpy bool can't hold a non-bool (e.g. NA) fill;
-                #  match the dense reindex behavior and upcast to object
-                _dtype = np.dtype(object)
+            _dtype = _maybe_object_for_bool_fill(
+                self.dtype.subtype,
+                np.result_type(self.dtype.subtype, type(fill_value)),
+            )
             taken = np.full(sp_indexer.shape, fill_value=fill_value, dtype=_dtype)
             taken[old_fill_indices] = self.fill_value
         else:
@@ -1267,16 +1284,16 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             result_type = taken.dtype
 
             if m0.any():
-                result_type = np.result_type(result_type, type(self.fill_value))
+                result_type = _maybe_object_for_bool_fill(
+                    taken.dtype, np.result_type(result_type, type(self.fill_value))
+                )
                 taken = taken.astype(result_type)
                 taken[old_fill_indices] = self.fill_value
 
             if m1.any():
-                result_type = np.result_type(result_type, type(fill_value))
-                if taken.dtype.kind == "b" and result_type.kind != "b":
-                    # GH#32119 numpy bool can't hold a non-bool (e.g. NA)
-                    #  fill; match the dense reindex behavior (bool -> object)
-                    result_type = np.dtype(object)
+                result_type = _maybe_object_for_bool_fill(
+                    taken.dtype, np.result_type(result_type, type(fill_value))
+                )
                 taken = taken.astype(result_type)
                 taken[new_fill_indices] = fill_value
 
@@ -2479,7 +2496,15 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
                 dtype=np.bool_,
             )
 
-    def _logical_method(self, other, op) -> SparseArray:
+    def _logical_method(self, other, op):
+        other_dtype = getattr(other, "dtype", None)
+        if isinstance(other_dtype, BaseMaskedDtype) and other_dtype.kind == "b":
+            # GH#68422 defer to the masked operand's reflected op, which keeps
+            #  its Kleene NA semantics; densifying here loses them.
+            #  Boolean only -- the other masked dtypes reach _arith_method,
+            #  which cannot consume a SparseArray.
+            return NotImplemented
+
         # GH#32119 the sparse fast path (see _sparse_array_op / splib) only
         #  implements and/or/xor for boolean and integer subtypes. When
         #  alignment upcasts an operand to object/float -- e.g. NA introduced

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -2499,7 +2499,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
     def _logical_method(self, other, op):
         other_dtype = getattr(other, "dtype", None)
         if isinstance(other_dtype, BaseMaskedDtype) and other_dtype.kind == "b":
-            # GH#68422 defer to the masked operand's reflected op, which keeps
+            # GH#68483 defer to the masked operand's reflected op, which keeps
             #  its Kleene NA semantics; densifying here loses them.
             #  Boolean only -- the other masked dtypes reach _arith_method,
             #  which cannot consume a SparseArray.

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -485,7 +485,7 @@ def test_logical_op_uneven_length_series(op):
 @pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
 @pytest.mark.parametrize("subtype", [bool, object])
 def test_logical_op_masked_other(op, subtype):
-    # GH#68422 a masked operand keeps its own Kleene semantics; densifying it
+    # GH#68483 a masked operand keeps its own Kleene semantics; densifying it
     #  lost them -- raising on the NA for a bool subtype, silently resolving it
     #  to False for an object one
     values = np.array([True, True, False, False], dtype=subtype)
@@ -498,7 +498,7 @@ def test_logical_op_masked_other(op, subtype):
 
 @pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
 def test_logical_op_masked_other_without_na(op):
-    # GH#68422 the operand's dtype decides, not whether it holds NA, so the
+    # GH#68483 the operand's dtype decides, not whether it holds NA, so the
     #  result is the masked dtype either way -- as it is for the dense operand
     values = np.array([True, True, False, False])
     other = pd.array([True, False, True, False], dtype="boolean")
@@ -511,7 +511,7 @@ def test_logical_op_masked_other_without_na(op):
 
 @pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
 def test_logical_op_non_boolean_masked_other(op):
-    # GH#68422 only a masked *boolean* operand is deferred to; the other masked
+    # GH#68483 only a masked *boolean* operand is deferred to; the other masked
     #  dtypes reach _arith_method, which cannot consume a SparseArray
     values = np.array([1, 0, 3, 0])
     other = pd.array([1, 2, 3, 4], dtype="Int64")
@@ -525,7 +525,7 @@ def test_logical_op_non_boolean_masked_other(op):
 @pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
 @pytest.mark.parametrize("n_sparse, n_other", [(11, 10), (10, 11)])
 def test_logical_op_masked_other_uneven_length_series(op, n_sparse, n_other):
-    # GH#68422 the alignment path onto the above; either operand can be the one
+    # GH#68483 the alignment path onto the above; either operand can be the one
     #  that gains the NA, and only the shorter-sparse case upcasts it to object
     sparse = pd.Series(SparseArray(np.arange(n_sparse)))
     other = pd.Series(np.arange(n_other) == 5, dtype="boolean")

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -482,6 +482,59 @@ def test_logical_op_uneven_length_series(op):
     tm.assert_series_equal(result.astype(bool), expected)
 
 
+@pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
+@pytest.mark.parametrize("subtype", [bool, object])
+def test_logical_op_masked_other(op, subtype):
+    # GH#68422 a masked operand keeps its own Kleene semantics; densifying it
+    #  lost them -- raising on the NA for a bool subtype, silently resolving it
+    #  to False for an object one
+    values = np.array([True, True, False, False], dtype=subtype)
+    other = pd.array([True, pd.NA, True, False], dtype="boolean")
+
+    result = op(SparseArray(values), other)
+    expected = op(values, other)
+    tm.assert_extension_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
+def test_logical_op_masked_other_without_na(op):
+    # GH#68422 the operand's dtype decides, not whether it holds NA, so the
+    #  result is the masked dtype either way -- as it is for the dense operand
+    values = np.array([True, True, False, False])
+    other = pd.array([True, False, True, False], dtype="boolean")
+
+    result = op(SparseArray(values), other)
+    expected = op(values, other)
+    assert result.dtype == pd.BooleanDtype()
+    tm.assert_extension_array_equal(result, expected)
+
+
+@pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
+def test_logical_op_non_boolean_masked_other(op):
+    # GH#68422 only a masked *boolean* operand is deferred to; the other masked
+    #  dtypes reach _arith_method, which cannot consume a SparseArray
+    values = np.array([1, 0, 3, 0])
+    other = pd.array([1, 2, 3, 4], dtype="Int64")
+
+    result = op(SparseArray(values), other)
+    expected = op(values, np.array([1, 2, 3, 4]))
+    assert isinstance(result.dtype, pd.SparseDtype)
+    tm.assert_numpy_array_equal(result.to_dense(), expected)
+
+
+@pytest.mark.parametrize("op", [operator.and_, operator.or_, operator.xor])
+@pytest.mark.parametrize("n_sparse, n_other", [(11, 10), (10, 11)])
+def test_logical_op_masked_other_uneven_length_series(op, n_sparse, n_other):
+    # GH#68422 the alignment path onto the above; either operand can be the one
+    #  that gains the NA, and only the shorter-sparse case upcasts it to object
+    sparse = pd.Series(SparseArray(np.arange(n_sparse)))
+    other = pd.Series(np.arange(n_other) == 5, dtype="boolean")
+
+    result = op(sparse == 5, other)
+    expected = op(pd.Series(np.arange(n_sparse)) == 5, other)
+    tm.assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     "a, b",
     [

--- a/pandas/tests/arrays/sparse/test_arithmetics.py
+++ b/pandas/tests/arrays/sparse/test_arithmetics.py
@@ -513,11 +513,12 @@ def test_logical_op_masked_other_without_na(op):
 def test_logical_op_non_boolean_masked_other(op):
     # GH#68483 only a masked *boolean* operand is deferred to; the other masked
     #  dtypes reach _arith_method, which cannot consume a SparseArray
-    values = np.array([1, 0, 3, 0])
+    # int64 explicitly: on 32-bit the default int would not match the int64 result
+    values = np.array([1, 0, 3, 0], dtype="int64")
     other = pd.array([1, 2, 3, 4], dtype="Int64")
 
     result = op(SparseArray(values), other)
-    expected = op(values, np.array([1, 2, 3, 4]))
+    expected = op(values, other.to_numpy(dtype="int64"))
     assert isinstance(result.dtype, pd.SparseDtype)
     tm.assert_numpy_array_equal(result.to_dense(), expected)
 

--- a/pandas/tests/arrays/sparse/test_indexing.py
+++ b/pandas/tests/arrays/sparse/test_indexing.py
@@ -195,8 +195,8 @@ class TestTake:
         tm.assert_sp_array_equal(result, expected)
 
     def test_take_fill_bool_empty_upcasts_to_object(self):
-        # GH#68483 same as above for a length-zero array, which takes a
-        #  separate branch and kept upcasting to float
+        # GH#32119 same as above for a length-zero array, which takes a
+        #  separate branch
         sparse = SparseArray(np.array([], dtype=bool))
         result = sparse.take([-1, -1], allow_fill=True)
         expected = SparseArray([np.nan, np.nan], dtype=pd.SparseDtype(object, False))
@@ -204,8 +204,8 @@ class TestTake:
         tm.assert_sp_array_equal(result, expected)
 
     def test_take_fill_bool_old_fill_upcasts_to_object(self):
-        # GH#68483 same for the old-fill arm, reached when the array's own
-        #  fill value is NA; it kept upcasting True to 1.0
+        # GH#32119 same for the old-fill arm, reached when the array's own
+        #  fill value is NA
         sparse = SparseArray(
             np.array([True, np.nan], dtype=object),
             dtype=pd.SparseDtype(bool, np.nan),
@@ -216,8 +216,8 @@ class TestTake:
         tm.assert_sp_array_equal(result, expected)
 
     def test_take_fill_bool_all_sparse_na_fill_upcasts_to_object(self):
-        # GH#68483 the all-sparse arm took the subtype straight, so np.full
-        #  wrote the NA fill into a bool array and resolved it to True
+        # GH#32119 same for the all-sparse arm, where np.full would otherwise
+        #  write the NA into a bool array and quietly resolve it to True
         sparse = SparseArray(
             np.array([np.nan, np.nan], dtype=object),
             dtype=pd.SparseDtype(bool, np.nan),
@@ -229,14 +229,14 @@ class TestTake:
 
     @pytest.mark.parametrize("dtype", ["uint8", "int8", "int16", "float32"])
     def test_take_all_sparse_preserves_narrow_subtype(self, dtype):
-        # GH#68483 the all-sparse arm writes a fill its own subtype already
+        # GH#68469 the all-sparse arm writes a fill its own subtype already
         #  holds, so it must not promote
         sparse = SparseArray(np.zeros(3, dtype=dtype), fill_value=0)
         result = sparse.take([2, 1, 0], allow_fill=True)
         assert result.dtype == sparse.dtype
 
     def test_reindex_empty_bool_upcasts_to_object(self):
-        # GH#68483 the user-visible path onto the branch above
+        # GH#32119 the user-visible path onto the branch above
         ser = pd.Series(SparseArray(np.array([], dtype=bool)))
         result = ser.reindex([0, 1])
         expected = pd.Series(

--- a/pandas/tests/arrays/sparse/test_indexing.py
+++ b/pandas/tests/arrays/sparse/test_indexing.py
@@ -194,6 +194,56 @@ class TestTake:
         assert result.dtype == pd.SparseDtype(object, False)
         tm.assert_sp_array_equal(result, expected)
 
+    def test_take_fill_bool_empty_upcasts_to_object(self):
+        # GH#68422 same as above for a length-zero array, which takes a
+        #  separate branch and kept upcasting to float
+        sparse = SparseArray(np.array([], dtype=bool))
+        result = sparse.take([-1, -1], allow_fill=True)
+        expected = SparseArray([np.nan, np.nan], dtype=pd.SparseDtype(object, False))
+        assert result.dtype == pd.SparseDtype(object, False)
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_take_fill_bool_old_fill_upcasts_to_object(self):
+        # GH#68422 same for the old-fill arm, reached when the array's own
+        #  fill value is NA; it kept upcasting True to 1.0
+        sparse = SparseArray(
+            np.array([True, np.nan], dtype=object),
+            dtype=pd.SparseDtype(bool, np.nan),
+        )
+        result = sparse.take([0, 1], allow_fill=True)
+        expected = SparseArray([True, np.nan], dtype=pd.SparseDtype(object, np.nan))
+        assert result.dtype == pd.SparseDtype(object, np.nan)
+        tm.assert_sp_array_equal(result, expected)
+
+    def test_take_fill_bool_all_sparse_na_fill_upcasts_to_object(self):
+        # GH#68422 the all-sparse arm took the subtype straight, so np.full
+        #  wrote the NA fill into a bool array and resolved it to True
+        sparse = SparseArray(
+            np.array([np.nan, np.nan], dtype=object),
+            dtype=pd.SparseDtype(bool, np.nan),
+        )
+        result = sparse.take([1, 0], allow_fill=True)
+        expected = SparseArray([np.nan, np.nan], dtype=pd.SparseDtype(object, np.nan))
+        assert result.dtype == pd.SparseDtype(object, np.nan)
+        tm.assert_sp_array_equal(result, expected)
+
+    @pytest.mark.parametrize("dtype", ["uint8", "int8", "int16", "float32"])
+    def test_take_all_sparse_preserves_narrow_subtype(self, dtype):
+        # GH#68422 the all-sparse arm writes a fill its own subtype already
+        #  holds, so it must not promote
+        sparse = SparseArray(np.zeros(3, dtype=dtype), fill_value=0)
+        result = sparse.take([2, 1, 0], allow_fill=True)
+        assert result.dtype == sparse.dtype
+
+    def test_reindex_empty_bool_upcasts_to_object(self):
+        # GH#68422 the user-visible path onto the branch above
+        ser = pd.Series(SparseArray(np.array([], dtype=bool)))
+        result = ser.reindex([0, 1])
+        expected = pd.Series(
+            SparseArray([np.nan, np.nan], dtype=pd.SparseDtype(object, False))
+        )
+        tm.assert_series_equal(result, expected)
+
     def test_take_fill_value(self):
         data = np.array([1, np.nan, 0, 3, 0])
         sparse = SparseArray(data, fill_value=0)

--- a/pandas/tests/arrays/sparse/test_indexing.py
+++ b/pandas/tests/arrays/sparse/test_indexing.py
@@ -195,7 +195,7 @@ class TestTake:
         tm.assert_sp_array_equal(result, expected)
 
     def test_take_fill_bool_empty_upcasts_to_object(self):
-        # GH#68422 same as above for a length-zero array, which takes a
+        # GH#68483 same as above for a length-zero array, which takes a
         #  separate branch and kept upcasting to float
         sparse = SparseArray(np.array([], dtype=bool))
         result = sparse.take([-1, -1], allow_fill=True)
@@ -204,7 +204,7 @@ class TestTake:
         tm.assert_sp_array_equal(result, expected)
 
     def test_take_fill_bool_old_fill_upcasts_to_object(self):
-        # GH#68422 same for the old-fill arm, reached when the array's own
+        # GH#68483 same for the old-fill arm, reached when the array's own
         #  fill value is NA; it kept upcasting True to 1.0
         sparse = SparseArray(
             np.array([True, np.nan], dtype=object),
@@ -216,7 +216,7 @@ class TestTake:
         tm.assert_sp_array_equal(result, expected)
 
     def test_take_fill_bool_all_sparse_na_fill_upcasts_to_object(self):
-        # GH#68422 the all-sparse arm took the subtype straight, so np.full
+        # GH#68483 the all-sparse arm took the subtype straight, so np.full
         #  wrote the NA fill into a bool array and resolved it to True
         sparse = SparseArray(
             np.array([np.nan, np.nan], dtype=object),
@@ -229,14 +229,14 @@ class TestTake:
 
     @pytest.mark.parametrize("dtype", ["uint8", "int8", "int16", "float32"])
     def test_take_all_sparse_preserves_narrow_subtype(self, dtype):
-        # GH#68422 the all-sparse arm writes a fill its own subtype already
+        # GH#68483 the all-sparse arm writes a fill its own subtype already
         #  holds, so it must not promote
         sparse = SparseArray(np.zeros(3, dtype=dtype), fill_value=0)
         result = sparse.take([2, 1, 0], allow_fill=True)
         assert result.dtype == sparse.dtype
 
     def test_reindex_empty_bool_upcasts_to_object(self):
-        # GH#68422 the user-visible path onto the branch above
+        # GH#68483 the user-visible path onto the branch above
         ser = pd.Series(SparseArray(np.array([], dtype=bool)))
         result = ser.reindex([0, 1])
         expected = pd.Series(


### PR DESCRIPTION
Follow-up to GH-66306, which fixed both of its bugs incompletely. The `_take_with_fill` half has since been superseded upstream by GH-68469, so what remains here is the logical-op half.

**Masked boolean operands in logical ops.** `_logical_needs_dense` read a masked `BooleanDtype` operand as safe for the sparse and/or/xor kernels because its `kind` is `"b"`. `_cmp_method` then densified it with `np.asarray`, whose `pd.NA` raised — or, for an object subtype, was silently resolved to `False`:

```python
sp = pd.Series(SparseArray(np.arange(11))) == 5
other = pd.Series(np.arange(10) == 5, dtype="boolean")
sp & other      # TypeError: boolean value of NA is ambiguous
other & sp      # boolean -- correct, and matches the dense left-hand side
```

`_logical_method` now returns `NotImplemented` for a masked boolean operand, so the operand's reflected op runs and its Kleene semantics survive. The result takes the operand's `boolean` dtype, matching both the dense equivalent and the reflected order. The deferral is deliberately boolean-only: the other masked dtypes inherit `_logical_method = _arith_method`, which cannot consume a `SparseArray`.

Verified with a dense-vs-sparse differential over subtype × operand-dtype × operator.

**On the take tests.** GH-68469 rewrote every dtype-selection site in `_take_with_fill` behind a shared `_promote_for_fill`, which fixes the bool-NA-fill cases this PR originally also targeted; that code is gone from the diff. None of GH-68469's tests use a `bool` subtype with an NA fill, so the take tests here are kept as regression coverage — they pass against its implementation unchanged.

`SparseArray._cmp_method` has the same densification bug (`Sp[int] < Int64(NA)` silently answers `False` where dense gives `<NA>`) and `shift()` the same bool-fill shape; both predate GH-66306, still reproduce on current main, and are left for separate PRs.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests under my direction and ran a multi-round blind review of the branch.
