### PR TITLE
ERR: Report dtype mismatch for NaT arrays with different units in assert_numpy_array_equal

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1180,6 +1180,7 @@ Styler
 Other
 ^^^^^
 
+- Bug in :func:`testing.assert_numpy_array_equal` where comparing datetime64 or timedelta64 arrays with different units, such as ``NaT`` arrays, gave a confusing "values are different" message; the mismatching dtype is now reported instead (:issue:`68459`)
 - Bug in :class:`DataFrame` constructor where passing the same :class:`Index` object as both ``index`` and ``columns`` shared a single object between the two axes, so mutating metadata such as ``names`` on one would also change the other (:issue:`42934`)
 - Bug in :func:`eval` and :meth:`DataFrame.eval` where passing a :class:`Series` or :class:`DataFrame` as ``expr`` silently parsed its (possibly truncated) repr instead of raising, producing a confusing error (:issue:`16289`)
 - Bug in :func:`option_context` where deprecation warnings pointed to ``contextlib.__enter__`` instead of user code (:issue:`63235`)

--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1180,11 +1180,11 @@ Styler
 Other
 ^^^^^
 
-- Bug in :func:`testing.assert_numpy_array_equal` where comparing datetime64 or timedelta64 arrays with different units, such as ``NaT`` arrays, gave a confusing "values are different" message; the mismatching dtype is now reported instead (:issue:`68459`)
 - Bug in :class:`DataFrame` constructor where passing the same :class:`Index` object as both ``index`` and ``columns`` shared a single object between the two axes, so mutating metadata such as ``names`` on one would also change the other (:issue:`42934`)
 - Bug in :func:`eval` and :meth:`DataFrame.eval` where passing a :class:`Series` or :class:`DataFrame` as ``expr`` silently parsed its (possibly truncated) repr instead of raising, producing a confusing error (:issue:`16289`)
 - Bug in :func:`option_context` where deprecation warnings pointed to ``contextlib.__enter__`` instead of user code (:issue:`63235`)
 - Bug in :func:`testing.assert_frame_equal`, :func:`testing.assert_series_equal` and :func:`testing.assert_index_equal` where the ``first diff`` line of the failure message did not quote strings, so a string-vs-number mismatch such as ``"1"`` against ``1`` was reported as ``1 != 1`` (:issue:`37488`)
+- Bug in :func:`testing.assert_numpy_array_equal` where comparing datetime64 or timedelta64 arrays with different units, such as ``NaT`` arrays, gave a confusing "values are different" message; the mismatching dtype is now reported instead (:issue:`68459`)
 - Bug in :func:`testing.assert_series_equal` with ``check_category_order=False`` raising for equal :class:`Categorical` values when missing values were present and the two objects stored their categories in a different order (:issue:`62008`)
 - Bug in :func:`testing.assert_series_equal`, :func:`testing.assert_frame_equal` and :func:`testing.assert_extension_array_equal` raising ``TypeError`` instead of reporting the difference when comparing unequal :class:`~pandas.api.extensions.ExtensionArray` objects whose scalars define ``__len__``, such as ``pint``'s ``Quantity`` (:issue:`45240`)
 - Bug in :func:`util.hash_array` and :func:`util.hash_pandas_object` with float and complex dtypes returning different hashes for ``0.0`` and ``-0.0``, and for ``NaN`` values whose sign or payload bits differ (:issue:`28363`)

--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -844,6 +844,15 @@ def assert_numpy_array_equal(
                     obj, f"{obj} shapes are different", left.shape, right.shape
                 )
 
+            if (
+                left.dtype.kind in "mM"
+                and right.dtype.kind in "mM"
+                and left.dtype != right.dtype
+            ):
+                raise_assert_detail(
+                    obj, f"{obj} dtypes are different", left.dtype, right.dtype
+                )
+
             diff = 0.0
             # ravel so the count is over values, matching the `left.size` total
             for left_val, right_val in zip(left.ravel(), right.ravel(), strict=True):

--- a/pandas/tests/util/test_assert_numpy_array_equal.py
+++ b/pandas/tests/util/test_assert_numpy_array_equal.py
@@ -234,3 +234,16 @@ numpy array values are different \\(100.0 %\\)
 
     with pytest.raises(AssertionError, match=msg):
         tm.assert_numpy_array_equal(a, b)
+
+
+def test_assert_numpy_array_equal_nat_different_unit():
+    # GH#68459
+    arr1 = np.array(["NaT"], dtype="timedelta64[s]")
+    arr2 = np.array(["NaT"], dtype="timedelta64[us]")
+    msg = """numpy array are different
+
+numpy array dtypes are different
+\\[left\\]:  timedelta64\\[s\\]
+\\[right\\]: timedelta64\\[us\\]"""
+    with pytest.raises(AssertionError, match=msg):
+        tm.assert_numpy_array_equal(arr1, arr2)


### PR DESCRIPTION
- [x] closes #68459
- [x] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [x] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [x] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [x] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

When comparing datetime64/timedelta64 arrays with different units, assert_numpy_array_equal reports "values are different", which is misleading - for example two NaT arrays with dtypes timedelta64[s] and timedelta64[us] fail with a values message even though the real mismatch is the dtype unit. This adds a dtype check for datetime-like arrays before the elementwise value comparison so the failure names the actual mismatching dtypes.

Developed with help of Instinct in its standard task mode. I used it for code investigation, implementation, regression tests, edge-case analysis, and local verification, and I reviewed and understood every change. Instinct does not expose the underlying model version or a named effort setting in this environment, so I cannot provide those fields more specifically without guessing.

Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [x] I used AI to develop this pull request. I prompted it to follow `AGENTS.md`, I have reviewed and understood every change, and I have described above how I used it and exactly which tool, model version, and effort setting - e.g. `claude opus 4.8 (xhigh)`, not just `claude`.