### PR TITLE
BUG: select_dtypes deprecation warning leaked a numpy repr for an ndarray spec

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5804,9 +5804,10 @@ class DataFrame(NDFrame, OpsMixin):
                                 raise
                             # strings accepted here but not by pandas_dtype
                             if dtype in ("datetimetz", "datetime64tz"):
-                                # GH#24558
+                                # GH#24558; str() so an ndarray spec reprs as
+                                # 'datetimetz', not np.str_('datetimetz')
                                 warnings.warn(
-                                    f"Passing {dtype!r} to select_dtypes is "
+                                    f"Passing {str(dtype)!r} to select_dtypes is "
                                     "deprecated and will raise in a future "
                                     "version. Pass pd.DatetimeTZDtype instead.",
                                     Pandas4Warning,

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -942,6 +942,17 @@ def test_select_dtypes_datetimetz_string_deprecated(spec, arg):
     tm.assert_frame_equal(alt, expected)
 
 
+@pytest.mark.parametrize("spec", ["datetimetz", "datetime64tz"])
+def test_select_dtypes_datetimetz_string_deprecated_ndarray_message(spec):
+    # GH#24558: an ndarray spec yields np.str_ elements, which must not reach
+    # the warning as np.str_('datetimetz')
+    df = pd.DataFrame({"a": pd.date_range("2016-01-01", periods=2, tz="UTC")})
+    msg = f"Passing {spec!r} to select_dtypes is deprecated"
+    with tm.assert_produces_warning(Pandas4Warning, match=msg):
+        result = df.select_dtypes(include=np.array([spec]))
+    tm.assert_frame_equal(result, df)
+
+
 def test_select_dtypes_datetimetz_string_overlaps_class():
     # GH#24558: the deprecated string and its replacement resolve to the same
     # spec, so contradictory include/exclude is caught rather than silently


### PR DESCRIPTION
The `"datetimetz"` / `"datetime64tz"` deprecation warning added in GH-66666 interpolates the caller's spec element with `{dtype!r}`. A raw numpy `<U` array yields `np.str_` elements, which satisfy the `isinstance(dtype, str)` guard just above but repr as `np.str_('datetimetz')`, so the same spec produced two different warning texts depending on the container it arrived in:

```python
df = pd.DataFrame({"a": pd.date_range("2016-01-01", periods=2, tz="UTC")})

df.select_dtypes(include=["datetimetz"])
# Passing 'datetimetz' to select_dtypes is deprecated ...

df.select_dtypes(include=np.array(["datetimetz"]))
# Passing np.str_('datetimetz') to select_dtypes is deprecated ...
```

Interpolate `str(dtype)` instead, which is what the sibling "is not a supported datetime64/timedelta64 resolution" messages in the same function already do via `.name`. `DataFrame.describe` forwards `include`/`exclude` verbatim, so it picks up the same fix.

No whatsnew entry: the deprecation itself is unreleased, so the divergent message has never shipped, and this changes only the warning's text.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`) — the fix, the regression test, and a multi-round review of the branch.
