### PR TITLE
BUG: select_dtypes did not match Sparse[object] columns for an object spec

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5561,11 +5561,13 @@ class DataFrame(NDFrame, OpsMixin):
             raise ValueError("at least one of include or exclude must be nonempty")
 
         def matches_object(dtype_obj: DtypeObj) -> bool:
-            # backwards compat for the default `str` dtype being
-            # selected by object. ``is_handled`` is defined below, after both
-            # sides are resolved; nothing calls this until ``predicate`` runs.
-            if dtype_obj == np.dtype(np.object_):
+            # ``is_handled`` is defined below, after both sides are resolved;
+            # nothing calls this until ``predicate`` runs.
+            # GH#68494: Sparse[object] has an object scalar type but does not
+            # compare equal to np.dtype(object)
+            if issubclass(dtype_obj.type, np.object_):
                 return True
+            # backwards compat for the default `str` dtype being selected by object
             return (
                 isinstance(dtype_obj, StringDtype)
                 and dtype_obj.na_value is np.nan

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -1435,3 +1435,18 @@ def test_select_dtypes_include_object_with_explicit_str_no_warning(
     with tm.assert_produces_warning(None):
         result = df.select_dtypes(include=["object", str_spec])
     tm.assert_frame_equal(result, df[["a", "b"]])
+
+
+@pytest.mark.parametrize("object_spec", [object, "object", np.object_])
+def test_select_dtypes_sparse_object_subtype(object_spec):
+    # GH#68494: a Sparse[object] column is an object column, but SparseDtype
+    # does not compare equal to np.dtype(object)
+    df = pd.DataFrame(
+        {
+            "a": pd.arrays.SparseArray(["x", "y"], dtype=object),
+            "b": pd.arrays.SparseArray([1, 2], dtype="int64"),
+            "c": pd.Series([1, "z"], dtype=object),
+        }
+    )
+    tm.assert_frame_equal(df.select_dtypes(include=object_spec), df[["a", "c"]])
+    tm.assert_frame_equal(df.select_dtypes(exclude=object_spec), df[["b"]])


### PR DESCRIPTION
`DataFrame.select_dtypes(include=[object])` silently dropped `Sparse[object]` columns, and `exclude=[object]` silently kept them.

Regression from GH-66112. That PR was billed as a pure refactor, but it rewrote the object arm of the dtype predicate from `issubclass(dtype.type, np.object_)` to an equality test against `np.dtype(object)`. `SparseDtype("object").type is np.object_`, but `SparseDtype("object") == np.dtype("O")` is `False`, so the column stopped matching. Every other type spec in the same function still goes through `issubclass` on `.type` — which is why `include="number"` still picks up `Sparse[int64]` — so `object` was the only spec left inconsistent.

Restoring the `issubclass` test moves exactly one dtype. A sweep over every constructible pandas/numpy/pyarrow dtype shows `SparseDtype` with an object subtype is the only one on which the two predicates disagree; `matches_object` sees an `ArrowDtype` only after the `numpy_dtype` normalization, so the arrow surface is untouched.

No whatsnew entry — GH-66112 is unreleased (3.1.0.dev), so the regression never reached users.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the regression against GH-66112's diff, wrote the fix and the regression test, and ran a blind review round plus a maintainer-lens settle review over the branch.
