### PR TITLE
ERR: improve assert_numpy_array_equal error message for dtype mismatch

### DIFF
--- a/pandas/_testing/asserters.py
+++ b/pandas/_testing/asserters.py
@@ -858,12 +858,13 @@ def assert_numpy_array_equal(
         raise AssertionError(err_msg)
 
     # compare shape and values
-    if not array_equivalent(left, right, strict_nan=strict_nan):
-        _raise(left, right, err_msg)
-
     if check_dtype:
         if isinstance(left, np.ndarray) and isinstance(right, np.ndarray):
             assert_attr_equal("dtype", left, right, obj=obj)
+    
+    if not array_equivalent(left, right, strict_nan=strict_nan):
+        _raise(left, right, err_msg)
+
 
 
 @set_module("pandas.testing")


### PR DESCRIPTION

What was the problem?

When comparing two numpy arrays of NaT values that have different timedelta64 (or datetime64) units — e.g. timedelta64[s] vs timedelta64[us] — assert_numpy_array_equal raised a confusing error. It reported "numpy array values are different (100.0%)" and showed [left]: [NaT] and [right]: [NaT], which look identical and give no indication that the actual problem is a unit/dtype mismatch, not a value mismatch.

Root cause

In assert_numpy_array_equal (pandas/_testing/asserters.py), the dtype check (check_dtype) ran after the value comparison (array_equivalent). Since the two NaT arrays compared as "not equivalent" internally due to the differing units, the function raised the generic values-differ error before it ever reached the dtype check that would have caught the real issue.

Fix

I moved the check_dtype block to run before the array_equivalent check. Now, when dtypes differ, the assertion clearly reports that mismatch (e.g. Attribute "dtype" are different: [left]: timedelta64[s] [right]: timedelta64[us]) instead of the misleading values-differ message.

closes #68459


- [ ] [Tests added and passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#writing-tests) if fixing a bug or adding a new feature
- [ ] All [code checks passed](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#pre-commit).
- [ ] Added [type annotations](https://pandas.pydata.org/pandas-docs/dev/development/contributing_codebase.html#type-hints) to new arguments/methods/functions.
- [ ] Added an entry in the latest `doc/source/whatsnew/vX.X.X.rst` file if fixing a bug or adding a new feature.
- [ ] I have reviewed and followed all the [contribution guidelines](https://pandas.pydata.org/docs/dev/development/contributing.html)

Check exactly one of the following, per the [automated contributions policy](https://pandas.pydata.org/docs/dev/development/contributing.html#automated-contributions-policy):

- [ ] I did **not** use AI to develop this pull request.
- [ ] I used AI to develop this pull request. I used Claude (Claude Sonnet 5) to help identify the root cause and draft the fix. I reviewed the change, understood why the dtype check needed to run before the value comparison, and verified locally that it produces the correct error message for the reported repro.




