### PR TITLE
PERF: skip to_datetime caching for ISO 8601 formats handled by the C parser

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -558,7 +558,7 @@ Performance improvements
 - Performance improvement in :func:`read_sql` with ADBC connections by requesting only table metadata when checking whether an input string names a table (:issue:`65652`)
 - Performance improvement in :func:`to_datetime` and the :class:`Timestamp` constructor when parsing strings with timezone offsets (:issue:`66123`)
 - Performance improvement in :func:`to_datetime` when passed a :class:`DataFrame` of date/time field columns (:issue:`65195`)
-- Performance improvement in :func:`to_datetime` with the default ``cache=True`` for inputs that are already datetime-typed or use a ``unit`` (:issue:`65380`)
+- Performance improvement in :func:`to_datetime` with the default ``cache=True`` for inputs that are already datetime-typed, use a ``unit``, or use an ISO 8601 ``format`` (:issue:`65380`)
 - Performance improvement in :func:`tseries.frequencies.to_offset` parsing of frequency strings, especially for tick-resolution offsets (e.g. ``"h"``, ``"5min"``, ``"3s"``) and compound expressions (e.g. ``"1D1h"``) (:issue:`65395`)
 - Performance improvement in :func:`util.hash_pandas_object` for PyArrow-backed string and binary types by using PyArrow's ``dictionary_encode`` instead of converting to NumPy for factorization (:issue:`48964`)
 - Performance improvement in :meth:`.DataFrameGroupBy.agg` and :meth:`.SeriesGroupBy.agg` with user-defined functions (:issue:`46505`)

--- a/pandas/_libs/tslibs/strptime.pyi
+++ b/pandas/_libs/tslibs/strptime.pyi
@@ -4,6 +4,7 @@ import numpy as np
 
 from pandas._typing import npt
 
+def format_is_iso(f: str) -> bool: ...
 def array_strptime(
     values: npt.NDArray[np.object_],
     fmt: str | None,

--- a/pandas/_libs/tslibs/strptime.pyx
+++ b/pandas/_libs/tslibs/strptime.pyx
@@ -113,18 +113,13 @@ _iso_format_re = re.compile(
 )
 
 
-cdef bint format_is_iso(f: str):
+cpdef bint format_is_iso(str f):
     """
     Does format match the iso8601 set that can be handled by the C parser?
     Generally of form YYYY-MM-DDTHH:MM:SS - date separator can be different
     but must be consistent.  Leading 0s in dates and times are optional.
     """
     return _iso_format_re.match(f) is not None and f != "%Y%m"
-
-
-def _test_format_is_iso(f: str) -> bool:
-    """Only used in testing."""
-    return format_is_iso(f)
 
 
 cdef bint parse_today_now(

--- a/pandas/core/tools/datetimes.py
+++ b/pandas/core/tools/datetimes.py
@@ -41,7 +41,10 @@ from pandas._libs.tslibs.parsing import (
     DateParseError,
     guess_datetime_format,
 )
-from pandas._libs.tslibs.strptime import array_strptime
+from pandas._libs.tslibs.strptime import (
+    array_strptime,
+    format_is_iso,
+)
 from pandas._typing import (
     AnyArrayLike,
     ArrayLike,
@@ -168,6 +171,7 @@ def should_cache(
     arg: ArrayConvertible,
     unique_share: float = 0.7,
     check_count: int | None = None,
+    format: str | None = None,
     unit: str | None = None,
 ) -> bool:
     """
@@ -183,6 +187,8 @@ def should_cache(
         0 < unique_share < 1
     check_count: int, optional
         0 <= check_count <= len(arg)
+    format : str or None, default None
+        Strftime format to parse time.
     unit : str or None, default None
         The unit of the arg (e.g. 's', 'ms').
 
@@ -199,12 +205,15 @@ def should_cache(
     All constants were chosen empirically by.
     """
     # GH#65380 O(1) bail for input shapes where caching cannot help: a
-    # numeric+unit cast or an already-datetime dtype is a vectorized
+    # numeric+unit cast, an already-datetime dtype, or an ISO 8601 format
+    # (parsed by the C parser rather than strptime) is a vectorized
     # conversion, so deduplicating the input only adds overhead.
-    # NB: an explicit ``format`` is intentionally *not* a bail condition --
+    # NB: a non-ISO ``format`` is intentionally *not* a bail condition --
     # strptime parsing of highly-duplicated strings is exactly where caching
-    # pays off (GH#65380 originally bailed here and regressed those inputs).
+    # pays off (GH#65380 originally bailed on any format and regressed those).
     if unit is not None:
+        return False
+    if format is not None and format_is_iso(format):
         return False
     arg_dtype = getattr(arg, "dtype", None)
     if (
@@ -278,7 +287,7 @@ def _maybe_cache(
 
     if cache:
         # Perform a quicker unique check
-        if not should_cache(arg, unit=unit):
+        if not should_cache(arg, format=format, unit=unit):
             return cache_array
 
         if not isinstance(arg, (np.ndarray, ExtensionArray, Index, ABCSeries)):

--- a/pandas/tests/tools/test_to_datetime.py
+++ b/pandas/tests/tools/test_to_datetime.py
@@ -4154,6 +4154,10 @@ class TestShouldCacheEarlyBail:
                 pd.date_range("2020-01-01", periods=100, freq="s", tz="US/Eastern"),
                 {},
             ),
+            # ISO 8601 format, handled by the vectorized C parser
+            (["2020-01-01"] * 100, {"format": "%Y-%m-%d"}),
+            (["20200101"] * 100, {"format": "%Y%m%d"}),
+            (["2020-01-01T00:00:00-0800"] * 100, {"format": "%Y-%m-%dT%H:%M:%S%z"}),
         ],
     )
     def test_should_cache_returns_false(self, arg, kwargs):
@@ -4173,12 +4177,19 @@ class TestShouldCacheEarlyBail:
         idx = pd.Index(arr)
         assert tools.should_cache(idx) is False
 
-    def test_should_cache_explicit_format_not_skipped(self):
-        # GH#65380, asv-runner#137: an explicit ``format`` must NOT disable
-        # caching. Highly-duplicated strings still benefit from caching even
-        # with a (slow-parsing) strptime format, so should_cache returns True.
-        arg = pd.Index(["19MAY11"] * 100)
-        assert tools.should_cache(arg) is True
+    @pytest.mark.parametrize(
+        "arg, fmt",
+        [
+            (["19MAY11"] * 100, "%d%b%y"),
+            (["10/11/2018 00:00:00.045-07:00"] * 100, "%m/%d/%Y %H:%M:%S.%f%z"),
+            (["2020-01-01", "01/02/2020"] * 50, "mixed"),
+        ],
+    )
+    def test_should_cache_non_iso_format_not_skipped(self, arg, fmt):
+        # GH#65380, asv-runner#137: a non-ISO ``format`` must NOT disable
+        # caching. Highly-duplicated strings still benefit from caching with
+        # a (slow-parsing) strptime format, so should_cache returns True.
+        assert tools.should_cache(pd.Index(arg), format=fmt) is True
 
 
 def test_nullable_integer_to_datetime():

--- a/pandas/tests/tslibs/test_parsing.py
+++ b/pandas/tests/tslibs/test_parsing.py
@@ -476,7 +476,7 @@ def test_parse_datetime_string_with_reso_check_instance_type_raise_exception():
 )
 def test_is_iso_format(fmt, expected):
     # see gh-41047
-    result = strptime._test_format_is_iso(fmt)
+    result = strptime.format_is_iso(fmt)
     assert result == expected
 
 


### PR DESCRIPTION
Ref: https://github.com/pandas-dev/asv-runner/issues/149
Written with Claude Fable 5.1.

#65754 removed the #65380 disabling of `to_datetime` caching for any explicit `format`, because that regressed slow strptime formats (https://github.com/pandas-dev/asv-runner/issues/#137). But for formats the C ISO 8601 parser handles, the vectorized parse is already cheaper than the cache path (`unique` + parse + reindex), so caching those inputs only adds overhead.

This restores disabling the cache only for ISO formats using the existing `format_is_iso`.

| Benchmark | main | this PR |
|---|---|---|
| `ToDatetimeCache.time_dup_string_dates_and_format(cache=True)` | 5.46 ms | 2.11 ms |
| `ToDatetimeYYYYMMDD.time_format_YYYYMMDD` | 3.57 ms | 2.57 ms |
| `ToDatetimeFormat.time_exact` (must stay cached) | 30 ms | 30 ms |

Every format matched by `format_is_iso`, including `%z` variants with and without `utc=True`, was 1.8x–3.2x faster uncached at 10k and 100k rows.