### PR TITLE
PERF: Avoid generator overhead in select_dtypes

### DIFF
--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5904,7 +5904,7 @@ class DataFrame(NDFrame, OpsMixin):
                 # and EA-subclass specs (GH#65366) are all checked against the
                 # raw dtype before the ArrowDtype -> numpy_dtype normalization
                 # below.
-                # GH#??? - dont use generators for these checks; too much overhead.
+                # GH#68501 - dont use generators for these checks; too much overhead.
                 for instance in instances:
                     if dtype_obj == instance:
                         return True

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5904,11 +5904,17 @@ class DataFrame(NDFrame, OpsMixin):
                 # and EA-subclass specs (GH#65366) are all checked against the
                 # raw dtype before the ArrowDtype -> numpy_dtype normalization
                 # below.
-                if any(dtype_obj == instance for instance in instances):
-                    return True
-                if any(func(dtype_obj) for func in ea_funcs):
-                    return True
-                if isinstance(dtype_obj, klass_tuple):
+                # This runs once per block, so plain loops are used instead of
+                # any(...) over a generator: most calls have only one or two
+                # non-empty lists, and constructing a generator for each empty
+                # one dominated the per-block cost.
+                for instance in instances:
+                    if dtype_obj == instance:
+                        return True
+                for ea_func in ea_funcs:
+                    if ea_func(dtype_obj):
+                        return True
+                if klass_tuple and isinstance(dtype_obj, klass_tuple):
                     return True
                 if isinstance(dtype_obj, ArrowDtype):
                     pa_type = dtype_obj.pyarrow_dtype
@@ -5927,7 +5933,10 @@ class DataFrame(NDFrame, OpsMixin):
                         # invents varies by pyarrow version), so only a unitless
                         # spec may match it
                         dtype_obj = np.dtype(f"{dtype_obj.kind}8")
-                return any(func(dtype_obj) for func in funcs)
+                for func in funcs:
+                    if func(dtype_obj):
+                        return True
+                return False
 
             return matches_any, frozenset(resolved)
 

--- a/pandas/core/frame.py
+++ b/pandas/core/frame.py
@@ -5904,10 +5904,7 @@ class DataFrame(NDFrame, OpsMixin):
                 # and EA-subclass specs (GH#65366) are all checked against the
                 # raw dtype before the ArrowDtype -> numpy_dtype normalization
                 # below.
-                # This runs once per block, so plain loops are used instead of
-                # any(...) over a generator: most calls have only one or two
-                # non-empty lists, and constructing a generator for each empty
-                # one dominated the per-block cost.
+                # GH#??? - dont use generators for these checks; too much overhead.
                 for instance in instances:
                     if dtype_obj == instance:
                         return True


### PR DESCRIPTION
Written using Claude Fable 5.1.
Ref: 
- https://github.com/pandas-dev/asv-runner/issues/153
- https://github.com/pandas-dev/asv-runner/issues/154
- https://github.com/pandas-dev/asv-runner/issues/158
- Much of https://github.com/pandas-dev/asv-runner/issues/156, but not all

Replaces the generators with plain loops and skips the `isinstance` check when no `ExtensionDtype` classes were given. On the benchmarks my timing goes from 87us to 48us locally, back to the pre-regression 52us.