### PR TITLE
BUG: date_range emitted dates past end for non-Tick offsets

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -680,7 +680,6 @@ Datetimelike
 - Bug in :func:`date_range` where ``inclusive="left"`` and ``inclusive="right"`` returned a single-element result instead of empty when ``start`` equals ``end`` (:issue:`55293`)
 - Bug in :func:`date_range` where ``inclusive`` parameter failed to filter endpoints when only ``start`` and ``periods`` or ``end`` and ``periods`` were specified (:issue:`46331`)
 - Bug in :func:`date_range` where ``periods=1`` with offsets that disallow ``n=0`` (e.g. :class:`offsets.LastWeekOfMonth`, :class:`offsets.FY5253`) raised ``ValueError`` (:issue:`41563`)
-- Bug in :func:`date_range` where offsets that preserve ``start``'s time-of-day (e.g. ``MS``, ``ME``, ``QS``, ``YS``, ``B``, ``C``) could exclude the last offset boundary when ``end``'s time-of-day was earlier than ``start``'s (:issue:`35342`)
 - Bug in :func:`date_range` where passing ``end`` off the offset together with ``periods`` and an anchored offset (e.g. ``W-SUN``, ``ME``, ``MS``, ``QS``) silently returned fewer than ``periods`` dates (:issue:`64834`)
 - Bug in :func:`to_datetime` and :class:`Timestamp` where a datetime near the implementation bounds with a fixed UTC offset silently wrapped when shifted to UTC instead of raising ``OutOfBoundsDatetime`` (:issue:`65353`)
 - Bug in :func:`to_datetime` and :func:`read_csv` with ``parse_dates`` returning timezone-naive results for datetime strings whose timezone is spelled ``"GMT"``, such as RFC 1123 / HTTP dates, and in :func:`tseries.api.guess_datetime_format` guessing such a timezone as a literal instead of ``%Z`` (:issue:`68193`)

--- a/pandas/core/arrays/_ranges.py
+++ b/pandas/core/arrays/_ranges.py
@@ -158,20 +158,6 @@ def generate_daily_offset_range(
         if periods is not None:
             # start + periods.
             end = (anchor + (periods - 1) * freq + tod).as_unit(unit)
-        elif (
-            # start + end. GH#64790: align end's time-of-day to start's so the
-            # last on-offset date isn't dropped when end's is earlier. Mask
-            # offsets preserve time-of-day unless ``freq.normalize``; testing
-            # that attribute rather than probing ``freq._add_datetime(start)`` avoids
-            # raising near Timestamp.max (GH#64648).
-            tod and not freq.normalize and end >= start  # type: ignore[operator]
-        ):
-            try:
-                end = (end.normalize() + tod).as_unit(unit)  # type: ignore[union-attr]
-            except OutOfBoundsDatetime:
-                # the boundary element this alignment would admit is beyond
-                # Timestamp.max, so keeping the raw end excludes it correctly
-                pass
 
     i8values = generate_regular_range(start, end, None, Day(), unit=unit)
     dt64 = i8values.view(f"datetime64[{unit}]")

--- a/pandas/core/arrays/datetimes.py
+++ b/pandas/core/arrays/datetimes.py
@@ -3200,20 +3200,6 @@ def _generate_range(
         else:
             start = offset.rollback(start)  # type: ignore[assignment]
 
-    # GH#35342: For offsets that preserve start's time-of-day (e.g. MonthBegin,
-    # QuarterBegin), adjust end to use the same time so that the boundary
-    # comparison doesn't incorrectly exclude the last offset boundary.
-    if start is not None and end is not None:
-        start_tod: Timedelta = start - start.normalize()
-        if (
-            start_tod
-            # Check if the offset preserves start's time-of-day
-            and (offset._add_datetime(start) - offset._add_datetime(start).normalize())
-            == start_tod
-        ):
-            if (offset.n >= 0 and end >= start) or (offset.n < 0 and end <= start):
-                end = end.normalize() + start_tod
-
     # Unsupported operand types for < ("Timestamp" and "None")
     if periods is None and end < start and offset.n >= 0:  # type: ignore[operator]
         end = None

--- a/pandas/tests/indexes/datetimes/test_date_range.py
+++ b/pandas/tests/indexes/datetimes/test_date_range.py
@@ -1247,29 +1247,34 @@ class TestBusinessDateRange:
         expected = pd.DatetimeIndex(["2026-03-12", "2026-03-17", "2026-03-20"])
         tm.assert_index_equal(result, expected, check_freq=False)
 
-    @pytest.mark.parametrize("freq", ["B", "C", "2B", "2C"])
-    def test_date_range_business_freq_start_end_time_of_day(self, freq):
-        # GH#64648 (post-merge): the business-day fast path must apply the
-        # GH#35342/GH#64790 time-of-day fix -- when end's time-of-day is
-        # earlier than start's, the last on-offset date must not be excluded.
+    @pytest.mark.parametrize(
+        "freq, last",
+        [
+            ("B", "2024-01-08 09:00"),
+            ("C", "2024-01-08 09:00"),
+            ("2B", "2024-01-05 09:00"),
+            ("2C", "2024-01-05 09:00"),
+        ],
+    )
+    def test_date_range_business_freq_start_end_time_of_day(self, freq, last):
+        # GH#64790: the business-day fast path must not stretch end to start's
+        # time-of-day, so an end earlier in the day than start drops that boundary
         result = pd.date_range("2024-01-01 09:00", "2024-01-09 08:00", freq=freq)
-        # identical to giving end the same time-of-day as start (no boundary lost)
-        expected = pd.date_range("2024-01-01 09:00", "2024-01-09 09:00", freq=freq)
+        expected = pd.date_range("2024-01-01 09:00", last, freq=freq)
         tm.assert_index_equal(result, expected)
-        assert result[-1] == pd.Timestamp("2024-01-09 09:00")
+        assert result[-1] == pd.Timestamp(last)
 
     def test_date_range_business_start_end_near_timestamp_max(self):
-        # GH#64648 (post-merge): the GH#64790 time-of-day fix must not raise
-        # OutOfBoundsDatetime when start is a business day with time-of-day
-        # within one offset step of Timestamp.max (2262-04-11 is a Friday)
+        # GH#64648 (post-merge): endpoint arithmetic must not overflow when
+        # start and end sit within one offset step of Timestamp.max
+        # (2262-04-11 is a Friday)
         start = pd.Timestamp("2262-04-11 10:00").as_unit("ns")
         end = pd.Timestamp("2262-04-11 15:00").as_unit("ns")
         result = pd.date_range(start, end, freq="B")
         expected = pd.DatetimeIndex([start], freq="B")
         tm.assert_index_equal(result, expected)
 
-        # aligning end to start's time-of-day would exceed Timestamp.max; the
-        # unrepresentable boundary element is excluded, not raised on
+        # one daily step past this start is unrepresentable
         start = pd.Timestamp("2262-04-10 23:59:59.999999").as_unit("ns")
         end = pd.Timestamp("2262-04-11 01:00").as_unit("ns")
         result = pd.date_range(start, end, freq="B")
@@ -2023,6 +2028,12 @@ class TestDateRangeNonTickFreq:
                 "MS",
                 "2020-02-01 15:00",
                 "2020-05-01 01:00",
+                ["2020-02-01 15:00", "2020-03-01 15:00", "2020-04-01 15:00"],
+            ),
+            (
+                "MS",
+                "2020-02-01 15:00",
+                "2020-05-01 23:00",
                 [
                     "2020-02-01 15:00",
                     "2020-03-01 15:00",
@@ -2034,36 +2045,23 @@ class TestDateRangeNonTickFreq:
                 "ME",
                 "2020-01-31 15:00",
                 "2020-04-30 01:00",
-                [
-                    "2020-01-31 15:00",
-                    "2020-02-29 15:00",
-                    "2020-03-31 15:00",
-                    "2020-04-30 15:00",
-                ],
+                ["2020-01-31 15:00", "2020-02-29 15:00", "2020-03-31 15:00"],
             ),
             (
                 "QS",
                 "2020-01-01 15:00",
                 "2020-10-01 01:00",
-                [
-                    "2020-01-01 15:00",
-                    "2020-04-01 15:00",
-                    "2020-07-01 15:00",
-                    "2020-10-01 15:00",
-                ],
+                ["2020-01-01 15:00", "2020-04-01 15:00", "2020-07-01 15:00"],
             ),
             (
                 "YS",
                 "2020-01-01 15:00",
                 "2023-01-01 01:00",
-                [
-                    "2020-01-01 15:00",
-                    "2021-01-01 15:00",
-                    "2022-01-01 15:00",
-                    "2023-01-01 15:00",
-                ],
+                ["2020-01-01 15:00", "2021-01-01 15:00", "2022-01-01 15:00"],
             ),
             (
+                # negative freq: end is the lower bound, so the 15:00 boundary
+                # on end's date is inside [end, start] and is kept
                 "-1MS",
                 "2020-05-01 15:00",
                 "2020-02-01 01:00",
@@ -2074,16 +2072,34 @@ class TestDateRangeNonTickFreq:
                     "2020-02-01 15:00",
                 ],
             ),
+            (
+                "-1MS",
+                "2020-05-01 15:00",
+                "2020-02-01 16:00",
+                ["2020-05-01 15:00", "2020-04-01 15:00", "2020-03-01 15:00"],
+            ),
         ],
     )
     def test_date_range_end_time_earlier_than_start_time(
         self, unit, freq, start, end, expected_dates
     ):
-        # GH#35342 - end's time-of-day should not cause the last offset
-        # boundary to be excluded
+        # GH#64790: end's time-of-day is not stretched to start's, so every
+        # entry satisfies start <= date <= end -- GH#35342 wanted a point outside it
         result = pd.date_range(start, end, freq=freq, unit=unit)
         expected = pd.DatetimeIndex(expected_dates, dtype=f"M8[{unit}]", freq=freq)
         tm.assert_index_equal(result, expected)
+
+
+@pytest.mark.parametrize("inclusive", ["both", "left", "right", "neither"])
+@pytest.mark.parametrize("freq", ["MS", "ME", "QS", "YS", "B", "C", "D", "12h"])
+def test_date_range_never_exceeds_end(freq, inclusive):
+    # GH#64790: every offset family obeys the same closed-interval contract;
+    # the non-Tick paths used to overshoot end, escaping the inclusive= trim
+    start = pd.Timestamp("2021-01-01 09:00")
+    end = pd.Timestamp("2022-03-01 08:00")
+    result = pd.date_range(start, end, freq=freq, inclusive=inclusive)
+    assert result[0] >= start
+    assert result[-1] <= end
 
 
 class TestDateRangeUnitInference:


### PR DESCRIPTION
Removes the end-extension added by GH-64790 and carried into the `B`/`C` mask fast path by GH-64648. `_generate_range` rewrote `end` as `end.normalize() + start_tod` whenever the offset preserves `start`'s time-of-day, pushing the caller's `end` up to ~24h later. Anchored offsets therefore emitted a trailing date strictly outside the requested interval, while Tick offsets — which take the vectorized path and never reach that block — did not:

```python
pd.date_range("2021-01-01 09:00", "2021-03-01 08:00", freq="MS")[-1]
# Timestamp('2021-03-01 09:00:00')    > end

pd.date_range("2021-01-01 09:00", "2021-01-05 08:00", freq="D")[-1]
# Timestamp('2021-01-04 09:00:00')    no overshoot
```

`start <= date <= end` now holds for every offset, which is what `_generate_range`'s docstring has always promised. That also repairs `inclusive=`, whose endpoint filter compares against the caller's `end` and so never matched the stretched grid: `inclusive="left"` returned an index *ending* past `end`, and `inclusive="right"` returned one not containing `end` at all.

The alternative — extending the Tick path to match — is incoherent: among Ticks only `Day` multiples preserve time-of-day, so `freq="D"` would extend while `freq="12h"` would not, turning the Tick/non-Tick split into a `Day`/sub-daily split.

The `n < 0` arm was wrong in the other direction as well: for a negative offset `end` is the *lower* bound, so the rewrite lowered it whenever end's time-of-day was later than start's, admitting a point below the caller's `end`. Both directions are covered by the rewritten `test_date_range_end_time_earlier_than_start_time`, and a new `test_date_range_never_exceeds_end` asserts the contract across `MS/ME/QS/YS/B/C/D/12h` and all four `inclusive=` values.

No whatsnew entry, and GH-64790's bullet is deleted rather than reworded: it is unreleased, so there is no net 3.0 → 3.1 change to announce.

One thing reviewers should weigh in on: GH-35342 was closed by GH-64790, and this PR reverses that behavior. Of the six `MS` cases and three `ME` cases in that report, only case 4 (`'2020-02-01 15:00'` → `'2020-05-01 01:00'`, expecting `2020-05-01 15:00`) changes; its expected point lies strictly outside the requested interval, so under closed-interval semantics that part of the report looks incorrect. The genuinely broken cases there were repaired by other work and still pass. GH-35342 likely wants reopening with that explanation.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the diff and tests and ran a recursive blind-review loop over them.
