### PR TITLE
BUG: sparse cumprod/cummin/cummax read the NA gaps of an int subtype as 0 (GH#68187)

### DIFF
--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1945,7 +1945,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
             return self.cumsum(**kwargs)
 
         result: ExtensionArray | np.ndarray
-        values = ensure_wrapped_if_datetimelike(self.to_dense())
+        values = ensure_wrapped_if_datetimelike(self._densify())
         if isinstance(values, ExtensionArray):
             # datetimelike subtypes have their own accumulations
             result = values._accumulate(name, skipna=skipna, **kwargs)

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -489,6 +489,38 @@ def test_accumulate_integer_subtype():
     tm.assert_series_equal(result, expected)
 
 
+@pytest.mark.parametrize("op_name", ["cumsum", "cumprod", "cummin", "cummax"])
+@pytest.mark.parametrize("skipna", [True, False])
+def test_accumulate_na_gaps_subtype_cannot_hold_na(op_name, skipna):
+    # GH#68187 the gaps of a Sparse[int64, nan] are NA, not 0. cumsum is affected
+    #  too: _accumulate's fast path for it is gated on skipna.
+    values = np.array([1.0, np.nan, 5.0, np.nan])
+    arr = SparseArray(values).astype(pd.SparseDtype("int64", np.nan))
+
+    result = getattr(pd.Series(arr), op_name)(skipna=skipna)
+    expected = getattr(pd.Series(values), op_name)(skipna=skipna)
+
+    # only that fast path keeps the subtype; the rest promote to hold the gaps
+    subtype = "int64" if (op_name == "cumsum" and skipna) else "float64"
+    assert result.dtype == pd.SparseDtype(subtype, np.nan)
+    # not sparse.to_dense(), which has the same cast-the-gaps bug this fixes
+    tm.assert_series_equal(result.astype("float64"), expected)
+
+
+@pytest.mark.parametrize("op_name", ["cumprod", "cummin", "cummax"])
+def test_accumulate_bool_subtype_promotes_to_object(op_name):
+    # GH#68187 a Sparse[bool, nan] has no wider numpy bool dtype to hold the gaps.
+    #  cumsum is excluded: its fast path returns Sparse[int64, nan] instead.
+    values = np.array([True, np.nan, False, np.nan], dtype=object)
+    arr = SparseArray([1.0, np.nan, 0.0, np.nan]).astype(pd.SparseDtype("bool", np.nan))
+
+    result = getattr(pd.Series(arr), op_name)()
+    expected = getattr(pd.Series(values), op_name)()
+
+    assert result.dtype == pd.SparseDtype(object, np.nan)
+    tm.assert_series_equal(result.sparse.to_dense(), expected)
+
+
 def test_accumulate_datetime64():
     # GH#68187 a datetimelike subtype accumulates through its own array
     dti = pd.to_datetime(["2020-01-02", "NaT", "2020-01-01"])


### PR DESCRIPTION
`SparseArray._accumulate`, added in GH-68187, densifies with `to_dense()`, which is
`np.asarray(self, dtype=self.sp_values.dtype)`. For a subtype that cannot hold NA —
`Sparse[int64, nan]`, `Sparse[uint8, nan]`, `Sparse[bool, nan]` — that casts the fill value into
the subtype, so the gaps reach `na_accum_func` as 0/False and get accumulated as real values:

```python
arr = pd.arrays.SparseArray([1.0, np.nan, 5.0, np.nan]).astype(pd.SparseDtype("int64", np.nan))
ser = pd.Series(arr)

list(ser.cumprod())            # [1, 0, 0, 0]   dense: [1.0, nan, 5.0, nan]
list(ser.cummin())             # [1, 0, 0, 0]   dense: [1.0, nan, 1.0, nan]
list(ser.cumsum(skipna=False)) # [1, 1, 6, 6]   dense: [1.0, nan, nan, nan]
# plus a leaked RuntimeWarning: invalid value encountered in cast
```

`cumsum(skipna=True)` escapes because the numeric fast path returns before densifying; the
`and skipna` on that gate is why `skipna=False` does not.

Use `_densify()`, added in GH-68449 for the reductions and `_groupby_op`, which promotes an NA
fill value with `maybe_promote` rather than casting it into the subtype.

No whatsnew entry: GH-68187 is unreleased, so the wrong values never shipped, and v3.1.0 already
carries that PR's entry.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which diagnosed the bug, wrote
the fix and tests, and ran a multi-round blind review of the branch.