### PR TITLE
BUG: out-of-range Timedelta strings raise OutOfBoundsTimedelta

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1319,6 +1319,7 @@ Datetimelike
 Timedelta
 ^^^^^^^^^
 - Accuracy improvement in :meth:`Timedelta.to_pytimedelta` to round microseconds consistently for large nanosecond based Timedelta (:issue:`57841`)
+- Bug in :class:`Timedelta` and :func:`to_timedelta` with a string outside the representable range returning a wrong value, or raising ``OutOfBoundsDatetime`` or ``OverflowError`` instead of ``OutOfBoundsTimedelta`` (:issue:`68560`)
 - Bug in :class:`Timedelta` constructor failing to raise when passed an invalid keyword (:issue:`53801`)
 - Bug in :meth:`DataFrame.cumsum` which was raising ``IndexError`` if dtype is ``timedelta64[ns]`` (:issue:`57956`)
 - Bug in adding or subtracting a :class:`Timedelta` object with non-nanosecond unit to a python ``datetime.datetime`` object giving incorrect results; this now works correctly for Timedeltas inside the ``datetime.timedelta`` implementation bounds (:issue:`53643`)

--- a/pandas/_libs/tslibs/timedeltas.pyx
+++ b/pandas/_libs/tslibs/timedeltas.pyx
@@ -607,6 +607,20 @@ def array_to_timedelta64(
     return result
 
 
+cdef int64_t _check_td_ns(object total, str ts) except? -1:
+    """
+    Range-check a timedelta string's parsed nanosecond total (GH#68560).
+
+    The parsers sum Python ints, so a running total that overshoots can be
+    brought back by a later term; only the total has to fit. The lower bound is
+    exclusive because INT64_MIN is NPY_NAT, and a parse landing there is a
+    value, not NaT.
+    """
+    if not (-(2**63) < total < 2**63):
+        raise OutOfBoundsTimedelta(f"Out of bounds nanosecond timedelta: '{ts}'")
+    return total
+
+
 @cython.cpow(True)
 cdef int64_t parse_timedelta_string(
     str ts, c_Resolution* out_reso=NULL
@@ -625,7 +639,8 @@ cdef int64_t parse_timedelta_string(
         str c
         bint neg = 0, have_dot = 0, have_value = 0, have_hhmmss = 0
         str current_unit = None
-        int64_t result = 0, m = 0, r
+        int64_t m = 0
+        object result = 0, r
         list number = [], frac = [], unit = []
         # finest reso seen; RESO_DAY is the coarsest a timedelta string reaches.
         #  spec_ptr is NULL (skipping all reso work) unless a caller wants it.
@@ -701,7 +716,7 @@ cdef int64_t parse_timedelta_string(
                 elif current_unit == "m":
                     current_unit = "s"
                     m = 1000000000
-                r = <int64_t>int("".join(number)) * m
+                r = int("".join(number)) * m
                 result += timedelta_as_neg(r, neg)
                 have_hhmmss = 1
             else:
@@ -720,7 +735,7 @@ cdef int64_t parse_timedelta_string(
                 if current_unit != "m":
                     raise ValueError("expected hh:mm:ss format before .")
                 m = 1000000000
-                r = <int64_t>int("".join(number)) * m
+                r = int("".join(number)) * m
                 result += timedelta_as_neg(r, neg)
                 have_value = 1
                 unit, number, frac = [], [], []
@@ -763,7 +778,7 @@ cdef int64_t parse_timedelta_string(
         else:
             m = 1
             frac = frac[:9]
-        r = <int64_t>int("".join(frac)) * m
+        r = int("".join(frac)) * m
         result += timedelta_as_neg(r, neg)
 
     # we have a regular format
@@ -781,7 +796,7 @@ cdef int64_t parse_timedelta_string(
                 f"received: {ts}"
             )
         m = 1000000000
-        r = <int64_t>int("".join(number)) * m
+        r = int("".join(number)) * m
         result += timedelta_as_neg(r, neg)
         if c_Resolution.RESO_SEC < reso:
             reso = c_Resolution.RESO_SEC
@@ -813,15 +828,15 @@ cdef int64_t parse_timedelta_string(
 
     if out_reso is not NULL:
         out_reso[0] = reso
-    return result
+    return _check_td_ns(result, ts)
 
 
-cdef int64_t timedelta_as_neg(int64_t value, bint neg):
+cdef object timedelta_as_neg(object value, bint neg):
     """
 
     Parameters
     ----------
-    value : int64_t of the timedelta value
+    value : the timedelta value in nanoseconds
     neg : bool if the a negative value
     """
     if neg:
@@ -857,7 +872,12 @@ cdef timedelta_from_spec(object number, object frac, object unit,
         out_reso[0] = _timedelta_unit_to_reso(unit)
 
     n = "".join(number) + "." + "".join(frac)
-    return cast_from_unit(float(n), unit)
+    try:
+        return cast_from_unit(float(n), unit)
+    except OutOfBoundsDatetime as err:
+        # GH#68560 cast_from_unit is shared with the Timestamp path and raises
+        #  the datetime-named class; there is no datetime in this one.
+        raise OutOfBoundsTimedelta(*err.args) from err
 
 
 cdef c_Resolution _timedelta_unit_to_reso(str abbrev):
@@ -1257,11 +1277,12 @@ cdef int64_t parse_iso_format_string(
 
     cdef:
         unicode c
-        int64_t result = 0, r
+        object result = 0, r
         int p = 0, sign = 1
         object dec_unit = "ms", err_msg
         bint have_dot = 0, have_value = 0, neg = 0
         list number = [], unit = []
+        str body
         c_Resolution reso = c_Resolution.RESO_DAY
         c_Resolution spec_reso = c_Resolution.RESO_DAY
         c_Resolution* spec_ptr = &spec_reso if out_reso is not NULL else NULL
@@ -1270,9 +1291,11 @@ cdef int64_t parse_iso_format_string(
 
     if ts[0] == "-":
         sign = -1
-        ts = ts[1:]
+        body = ts[1:]
+    else:
+        body = ts
 
-    for c in ts:
+    for c in body:
         # number (ascii codes)
         if 48 <= ord(c) <= 57:
 
@@ -1356,7 +1379,7 @@ cdef int64_t parse_iso_format_string(
 
     if out_reso is not NULL:
         out_reso[0] = reso
-    return sign*result
+    return _check_td_ns(sign*result, ts)
 
 
 def parse_timedelta_string_reso(str ts):

--- a/pandas/tests/scalar/timedelta/test_constructors.py
+++ b/pandas/tests/scalar/timedelta/test_constructors.py
@@ -904,3 +904,68 @@ def test_construction_trailing_characters_raises(value, leftover):
 
     result = pd.to_timedelta([value], errors="coerce")
     tm.assert_index_equal(result, pd.TimedeltaIndex([pd.NaT]))
+
+
+@pytest.mark.parametrize(
+    "value, msg",
+    [
+        # a single term is out of range, so no later term can bring it back
+        ("1000000 days", "cannot convert input 1000000.0 with the unit 'D'"),
+        ("99999999999999999999ns", "cannot convert input 1e+20 with the unit 'ns'"),
+        ("P106752D", "cannot convert input 106752.0 with the unit 'D'"),
+        ("-P200000D", "cannot convert input 200000.0 with the unit 'D'"),
+        # the total is out of range
+        (
+            "99999999999999999999:00:00",
+            "Out of bounds nanosecond timedelta: '99999999999999999999:00:00'",
+        ),
+        (
+            "106751 days 106751 days",
+            "Out of bounds nanosecond timedelta: '106751 days 106751 days'",
+        ),
+        (
+            "2562047:47:16.854775808",
+            "Out of bounds nanosecond timedelta: '2562047:47:16.854775808'",
+        ),
+        # the total is exactly NPY_NAT, one below the representable range
+        (
+            "-2562047:47:16.854775808",
+            "Out of bounds nanosecond timedelta: '-2562047:47:16.854775808'",
+        ),
+        (
+            "-P106751DT23H47M16.854775808S",
+            "Out of bounds nanosecond timedelta: '-P106751DT23H47M16.854775808S'",
+        ),
+    ],
+)
+def test_construction_string_out_of_bounds(value, msg):
+    # GH#68560 these used to raise OutOfBoundsDatetime or a bare OverflowError,
+    #  or silently wrap the int64 nanosecond total and return a wrong value
+    with pytest.raises(OutOfBoundsTimedelta, match=re.escape(msg)):
+        pd.Timedelta(value)
+
+    with pytest.raises(OutOfBoundsTimedelta, match=re.escape(msg)):
+        pd.to_timedelta([value])
+
+    result = pd.to_timedelta([value], errors="coerce")
+    tm.assert_index_equal(result, pd.TimedeltaIndex([pd.NaT]))
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("2562047:47:16.854775807", pd.Timedelta(2**63 - 1, "ns")),
+        ("-2562047:47:16.854775807", pd.Timedelta(-(2**63) + 1, "ns")),
+        ("106751 days 23:47:16.854775807", pd.Timedelta(2**63 - 1, "ns")),
+        ("P106751DT23H47M16.854775807S", pd.Timedelta(2**63 - 1, "ns")),
+        # GH#68560 the leading "-" applies to every term until the first ":",
+        #  so the running total can leave the range and be brought back
+        (
+            "-106751 days 106751 days 2562001:00:00",
+            pd.Timedelta(-9223369200000000000, "ns"),
+        ),
+    ],
+)
+def test_construction_string_at_bounds(value, expected):
+    # GH#68560 the total's range check must not reject a representable value
+    assert pd.Timedelta(value) == expected


### PR DESCRIPTION
The two timedelta string parsers in `pandas/_libs/tslibs/timedeltas.pyx` — `parse_timedelta_string` for the `"1 days 02:30:00"` form and `parse_iso_format_string` for the `"P1DT2H"` form — accumulated an `int64_t` running total in nanoseconds. A string outside that range failed three different ways:

```python
pd.Timedelta("1000000 days")
# OutOfBoundsDatetime: cannot convert input 1000000.0 with the unit 'D'

pd.Timedelta("99999999999999999999:00:00")
# OverflowError: Python int too large to convert to C long

pd.Timedelta("106751 days 106751 days")
# Timedelta('-2 days +00:25:26.290448384')   <- silent wraparound, wrong value
```

The third reaches every string entry point: `to_timedelta`, `TimedeltaIndex` and `astype("m8[ns]")` all return the wrapped value, and a parse landing exactly on the `NaT` sentinel returned `NaT`. The numeric constructor already got this right — `pd.Timedelta(10**20, "ns")` raises `OutOfBoundsTimedelta`.

Both parsers now accumulate as exact Python ints and range-check the total once at each return. Checking the total rather than each partial sum matters: the leading `-` in `parse_timedelta_string` applies to every term until the first `:`, so a running total can leave the range and be brought back, and `"-106751 days 106751 days 2562001:00:00"` is representable. `timedelta_from_spec` also translates `cast_from_unit`'s `OutOfBoundsDatetime`, the last timedelta caller of it that did not already do so.

This does not widen what the string path accepts — `pd.Timedelta("1000000 days")` still fails where `pd.Timedelta(1000000, "D")` succeeds.

Accumulating Python ints costs some speed in `parse_timedelta_string`: each term is now a Python allocation rather than a C multiply-and-add. Measured per element over 10k strings through `array_to_timedelta64`, alternating build order:

| case | main | this PR | |
|---|---|---|---|
| `"1 days 02:30:00"` | 1280 ns | 1463 ns | +14% |
| `"00:00:01"` | 692 ns | 810 ns | +17% |
| `"P1DT2H30M"` | 2242 ns | 2309 ns | +3% |

The ISO path barely moves because it already routed every term through `timedelta_from_spec`. Keeping the C accumulator and promoting to a Python int only on overflow would recover most of this, at the cost of a second accumulator threaded through all five accumulation sites — happy to do that if reviewers prefer.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and reviewed the branch across several rounds; all output was reviewed before submission.

