### PR TITLE
BUG: DataFrame.sparse.density warned for a frame with no columns

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1140,6 +1140,7 @@ Reshaping
 
 Sparse
 ^^^^^^
+- Bug in :attr:`DataFrame.sparse.density` emitting ``RuntimeWarning`` for a :class:`DataFrame` with no columns (:issue:`68564`)
 - Bug in :attr:`Series.sparse.density`, :attr:`DataFrame.sparse.density`, and :attr:`SparseArray.density` raising ``ZeroDivisionError`` on empty data instead of returning ``nan`` (:issue:`68468`)
 - Bug in :class:`SparseArray` with a datetime64 or timedelta64 subtype where a ``pd.NaT`` ``fill_value`` raised ``TypeError`` from :meth:`SparseArray.to_dense`, :meth:`SparseArray.unique`, :meth:`SparseArray.astype`, :meth:`SparseArray.take`, and arithmetic and comparison operations, and made ``np.asarray`` on a timedelta64 subtype return ``object`` dtype; all of these behaved correctly for an equivalent ``np.datetime64("NaT")`` fill value (:issue:`68449`)
 - Bug in :class:`SparseDtype` where two equal instances with an NA ``fill_value`` could hash differently, so a datetime64 or timedelta64 :class:`SparseDtype` could not be used as a dict key and identical sparse columns were counted separately by :meth:`Series.value_counts` on :attr:`DataFrame.dtypes` (:issue:`68449`)

--- a/pandas/core/arrays/sparse/accessor.py
+++ b/pandas/core/arrays/sparse/accessor.py
@@ -479,8 +479,10 @@ class SparseFrameAccessor(BaseAccessor, PandasDelegate):
         >>> df.sparse.density
         np.float64(0.5)
         """
-        tmp = np.mean([column.array.density for _, column in self._parent.items()])
-        return tmp
+        if len(self._parent.columns) == 0:
+            # mean of an empty list is undefined
+            return np.nan
+        return np.mean([column.array.density for _, column in self._parent.items()])
 
     @staticmethod
     def _prep_index(data, index, columns):

--- a/pandas/tests/arrays/sparse/test_accessor.py
+++ b/pandas/tests/arrays/sparse/test_accessor.py
@@ -226,6 +226,13 @@ class TestFrameAccessor:
         df = pd.DataFrame({"A": SparseArray(np.array([], dtype="float64"))})
         assert np.isnan(df.sparse.density)
 
+    def test_density_no_columns(self):
+        # GH#68564 - np.mean of an empty list warns; the nan result was already correct
+        df = pd.DataFrame(index=[0, 1])
+        with tm.assert_produces_warning(None):
+            result = df.sparse.density
+        assert np.isnan(result)
+
     @pytest.mark.parametrize("dtype", ["int64", "float64"])
     @pytest.mark.parametrize("dense_index", [True, False])
     def test_series_from_coo(self, dtype, dense_index):


### PR DESCRIPTION
A `DataFrame` with no columns passes the sparse accessor's validation vacuously, so `DataFrame.sparse.density` is reachable on one. It then averages an empty list of per-column densities, and `np.mean([])` emits `RuntimeWarning: Mean of empty slice` and `RuntimeWarning: invalid value encountered in scalar divide` from inside a public property. The returned value was already correct (`nan`); only the warnings were wrong.

Guard the zero-column case and return `nan` directly, mirroring the zero-*length* guard GH-68468 added to `SparseArray.density`. Zero-row frames that do have columns are unaffected — their per-column `nan` densities already go through `np.mean` without warning.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the warnings, wrote the guard, test and whatsnew entry, and ran a multi-round review of the diff.