### PR TITLE
BUG: astype to a big-endian datetime64/timedelta64 dtype byteswapped the values

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -692,6 +692,7 @@ Datetimelike
 - Bug in :func:`to_datetime` when passed a :class:`DataFrame` of date/time field columns with ``errors="coerce"`` returning ``datetime64[s]`` dtype instead of ``datetime64[us]`` when all rows were invalid (:issue:`65195`)
 - Bug in :func:`to_datetime` when using a low time resolution ``unit``, higher resolution in ``origin`` is now preserved instead of silently dropped (e.g. ``unit="D"`` with microsecond precision origin) (:issue:`63419`)
 - Bug in :func:`to_datetime` with string input silently ignoring ``dayfirst`` and ``yearfirst`` when ``unit`` was also passed (:issue:`63472`)
+- Bug in :meth:`DataFrame.astype`, :meth:`Series.astype` and :meth:`Index.astype` to a big-endian ``datetime64``/``timedelta64`` dtype, e.g. ``astype(">M8[s]")``, silently returning byteswapped values when the cast also changed the resolution; the result now has the equivalent native-byteorder dtype (:issue:`68565`)
 - Bug in :meth:`DataFrame.replace` and :meth:`Series.replace` raising ``AssertionError`` instead of ``OutOfBoundsDatetime`` when replacing with a ``datetime`` value outside the ``datetime64[ns]`` range (:issue:`61671`)
 - Bug in :meth:`DataFrame.to_string` and :meth:`Series.to_string` where ``na_rep`` was ignored for datetime and timedelta columns, always displaying ``NaT`` (:issue:`55426`)
 - Bug in :meth:`DatetimeArray.isin` and :meth:`TimedeltaArray.isin` where mismatched resolutions could silently truncate finer-resolution values, leading to false matches (:issue:`64545`)

--- a/pandas/_libs/tslibs/np_datetime.pyx
+++ b/pandas/_libs/tslibs/np_datetime.pyx
@@ -450,6 +450,12 @@ cpdef ndarray astype_overflowsafe(
             "both-datetime64 or both-timedelta64."
         )
 
+    if not cnp.PyDataType_ISNOTSWAPPED(dtype):
+        # GH#68565 the conversions below view their natively-written results as
+        #  `dtype`, so a non-native target would read back byteswapped; pandas
+        #  stores datetimelike data natively in any case
+        dtype = (<object>dtype).newbyteorder("=")
+
     raise_if_unit_multiplier(values.dtype)
     raise_if_unit_multiplier(dtype)
 

--- a/pandas/tests/frame/methods/test_select_dtypes.py
+++ b/pandas/tests/frame/methods/test_select_dtypes.py
@@ -708,21 +708,22 @@ def test_select_dtypes_dt64_td64_string_byteorder_unitless(kind):
 
 def test_select_dtypes_td64_non_native_column():
     # GH#40234 a string spec matches by resolution, an instance spec stays exact.
-    # Construction no longer yields a non-native column (GH#68342); the fixture
-    # leans on a unit-changing astype, itself a bug, so the assert is a tripwire
+    # Construction normalizes byteorder and GH#68565 stopped astype producing a
+    # non-native column, so ``view`` plus setitem is the route left -- the
+    # byteorder assert is a tripwire for that becoming unreachable too
     df = pd.DataFrame(
         {
-            "be": pd.Series(np.array([1, 2], dtype="<m8[ms]")),
-            "le": pd.Series(np.array([1, 2], dtype="<m8[s]")),
-            "ms": pd.Series(np.array([1, 2], dtype="<m8[ms]")),
+            "le": pd.Series(np.array([1, 2], dtype="m8[s]")),
+            "ms": pd.Series(np.array([1, 2], dtype="m8[ms]")),
         }
-    ).astype({"be": ">m8[s]"})
+    )
+    df["be"] = pd.Series(np.array([1, 2], dtype="m8[s]")).array.view(">m8[s]")
     assert df["be"].dtype.byteorder == ">"
 
     # a string spec is byteorder-agnostic on both sides
     for spec in ("timedelta64[s]", ">timedelta64[s]", "<timedelta64[s]"):
         result = df.select_dtypes(include=[spec])
-        tm.assert_frame_equal(result, df[["be", "le"]])
+        tm.assert_frame_equal(result, df[["le", "be"]])
 
     result = df.select_dtypes(exclude=["timedelta64[s]"])
     tm.assert_frame_equal(result, df[["ms"]])

--- a/pandas/tests/series/methods/test_astype.py
+++ b/pandas/tests/series/methods/test_astype.py
@@ -705,3 +705,34 @@ def test_astype_to_datetimelike_unit(arr_dtype, kind, unit):
         assert expected.dtype == f"{kind}8[s]"
 
     tm.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("kind", ["M", "m"])
+@pytest.mark.parametrize("values", [[10**9, "NaT"], [10**9, 2 * 10**9]])
+@pytest.mark.parametrize("from_unit, to_unit", [("ns", "s"), ("s", "ns")])
+def test_astype_to_datetimelike_bigendian(kind, values, from_unit, to_unit):
+    # GH#68565 the result was a big-endian-typed array of natively-written bits,
+    #  so every value read back byteswapped. The NaT-free case is what reaches
+    #  the vectorized branch, and to_numpy is what reads through the dtype
+    ser = pd.Series(np.array(values, dtype=f"{kind}8[{from_unit}]"))
+    result = ser.astype(f">{kind}8[{to_unit}]")
+
+    expected = ser.astype(f"{kind}8[{to_unit}]")
+    assert result.dtype.byteorder != ">"
+    tm.assert_series_equal(result, expected)
+    tm.assert_numpy_array_equal(result.to_numpy(), expected.to_numpy())
+
+
+@pytest.mark.parametrize("kind", ["M", "m"])
+def test_astype_object_to_datetimelike_bigendian(kind):
+    # GH#68565 a timedelta64 target additionally came back reporting a native
+    #  dtype, so nothing signaled the corruption. datetime64 takes only the unit
+    #  from the requested dtype and was already correct; it is here as a guard
+    values = ["2020-01-01", pd.NaT] if kind == "M" else ["1000s", pd.NaT]
+    ser = pd.Series(values, dtype=object)
+
+    result = ser.astype(f">{kind}8[s]")
+    expected = ser.astype(f"{kind}8[s]")
+    assert result.dtype.byteorder != ">"
+    tm.assert_series_equal(result, expected)
+    tm.assert_numpy_array_equal(result.to_numpy(), expected.to_numpy())


### PR DESCRIPTION
`Series.astype(">m8[s]")` and `.astype(">M8[s]")` returned garbage whenever the cast also changed the resolution:

```python
>>> pd.Series(pd.timedelta_range("1s", periods=2)).astype(">m8[s]")[0]
Timedelta('833999930994 days 12:52:16')     # expected 1 second
```

`astype_overflowsafe` builds its result as native `int64` and then hands it out with `.view(dtype)` — three branches do this, plus the `_via_dts` helper. With a non-native target the native bits get labelled big-endian, so every value reads back byteswapped. The function already normalized the *source* byteorder (GH-29684) but never the target. From object dtype the `timedelta64` result additionally came back reporting a *native* dtype while holding corrupt values, so nothing signalled it.

This normalizes the target byteorder there, so `astype` agrees with construction, which has stored datetimelike data natively since GH-30976 (`datetime64`) and GH-68342 (`timedelta64`). A user asking for `>m8[s]` now gets the equivalent native dtype back with correct values. A same-unit cast was never affected — that arm returns `values.copy()` and never reaches a `.view(dtype)`.

`test_select_dtypes_td64_non_native_column` built its non-native column with exactly the `astype` fixed here, so its fixture moves to `.view(">m8[s]")` plus setitem, which is the route that remains.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and ran a multi-round review loop over the branch; all findings were verified against the code before being acted on.
