### PR TITLE
PERF: assert_almost_equal on exactly-equal integer/float arrays above 2**53

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -557,6 +557,7 @@ Performance improvements
 - Performance improvement in :func:`read_sas` for compressed SAS7BDAT files with many rows per page, up to ~1.7x faster (:issue:`47339`)
 - Performance improvement in :func:`read_sas` when decoding strings (:issue:`47339`)
 - Performance improvement in :func:`read_sql` with ADBC connections by requesting only table metadata when checking whether an input string names a table (:issue:`65652`)
+- Performance improvement in :func:`testing.assert_frame_equal`, :func:`testing.assert_series_equal` and :func:`testing.assert_index_equal` with ``check_exact=False`` and ``check_dtype=False`` (``exact=False`` for :func:`testing.assert_index_equal`) when integer and floating values above ``2**53`` are exactly equal, which fell back to an element-by-element comparison (:issue:`68568`)
 - Performance improvement in :func:`to_datetime` and the :class:`Timestamp` constructor when parsing strings with timezone offsets (:issue:`66123`)
 - Performance improvement in :func:`to_datetime` when passed a :class:`DataFrame` of date/time field columns (:issue:`65195`)
 - Performance improvement in :func:`to_datetime` with the default ``cache=True`` for inputs that are already datetime-typed or use a ``unit`` (:issue:`65380`)

--- a/pandas/_libs/testing.pyx
+++ b/pandas/_libs/testing.pyx
@@ -165,8 +165,18 @@ cpdef assert_almost_equal(a, b,
                 ):
                     return True
 
+                # array_equivalent compared after a lossy cast to float64; redo
+                #  it at full integer precision so only a genuine difference pays
+                #  for the loop below. A float outside the integer dtype's range
+                #  has no exact cast, so leave that case to the loop.
+                flt_arr = b if int_arr is a else a
+                info = np.iinfo(int_arr.dtype)
+                if ((flt_arr >= info.min) & (flt_arr < info.max + 1)).all():
+                    if np.array_equal(int_arr, flt_arr.astype(int_arr.dtype)):
+                        return True
+
             # flatten so the loop compares values, not rows; see GH#68366 and
-            #  test_assert_almost_equal_2d_large_mixed_integer_float
+            #  test_assert_almost_equal_value_mismatch_2d_percentage
             a = a.ravel()
             b = b.ravel()
 

--- a/pandas/tests/util/test_assert_almost_equal.py
+++ b/pandas/tests/util/test_assert_almost_equal.py
@@ -217,8 +217,27 @@ def test_assert_almost_equal_large_mixed_integer_float_rtol():
 )
 def test_assert_almost_equal_large_mixed_integer_float_equal(left, right):
     # GH#66699 magnitudes above 2**53 bypass the array_equivalent fast path, so
-    #  the equal case has to survive the elementwise comparison too.
+    #  the equal case has to be settled at full integer precision instead.
     _assert_almost_equal_both(left, right, check_dtype=False, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "left,right",
+    [
+        (
+            np.array([2**63 - 1], dtype="int64"),
+            np.array([float(2**63)], dtype="float64"),
+        ),
+        (
+            np.array([2**64 - 1], dtype="uint64"),
+            np.array([float(2**64)], dtype="float64"),
+        ),
+    ],
+)
+def test_assert_almost_equal_mixed_integer_float_out_of_range(left, right):
+    # GH#68568 the float rounds past the end of the integer dtype, so it has no
+    #  exact integer cast and the one-integer difference must still be reported
+    _assert_not_almost_equal_both(left, right, check_dtype=False, rtol=0, atol=0)
 
 
 def test_assert_almost_equal_large_mixed_integer_float_message():
@@ -235,8 +254,7 @@ def test_assert_almost_equal_large_mixed_integer_float_message():
 
 
 def test_assert_almost_equal_2d_large_mixed_integer_float():
-    # GH#68366 the GH#66699 magnitude guard sends exactly-equal large integers
-    #  through the element loop, which must honour check_dtype like the 1-D case
+    # GH#68366 check_dtype=False must hold in 2-D as well as 1-D
     big = np.array([[2**60, 1], [2, 3]], dtype="int64")
 
     _assert_almost_equal_both(


### PR DESCRIPTION
Follow-up to GH-66722, which made `assert_almost_equal` stop trusting `array_equivalent` for mixed integer/float arrays above float64's exactly-representable range — correct, since `array_equivalent` compares them after a lossy cast. But its only exit was to fall through to the generic per-element loop, so an exactly-equal 1M-element int64/float64 pair went from ~0.7ms to ~300ms.

Before falling through, redo the comparison at full integer precision with `np.array_equal(int_arr, flt_arr.astype(int_arr.dtype))`. Only an exact match returns early; everything else still takes the loop, so GH-66722's correctness behavior is unchanged.

The `np.iinfo` range check is load-bearing rather than defensive: a float that rounds past the end of the integer dtype (`int64` `2**63 - 1` against `float(2**63)`) has no exact cast, and numpy saturates it with a `RuntimeWarning`. `test_assert_almost_equal_mixed_integer_float_out_of_range` covers both signed and unsigned.

The new early exit short-circuits `test_assert_almost_equal_2d_large_mixed_integer_float` (GH-68366), so that test's integer is offset by one to keep it on the element-loop path it was written to guard.

Arrays that are equal only within tolerance are unaffected — they still take the loop.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the change and its tests and ran a multi-round review loop over the diff.
