### PR TITLE
BUG: SparseArray.shift raised for a boolean or datetimelike subtype

### DIFF
--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1560,6 +1560,7 @@ Sparse
 - Bug in :meth:`DataFrame.sparse.from_spmatrix` which hard coded an invalid ``fill_value`` for certain subtypes. (:issue:`59063`)
 - Bug in :meth:`DataFrame.sparse.to_dense` which ignored subclassing and always returned an instance of :class:`DataFrame` (:issue:`59913`)
 - Bug in :meth:`SparseArray.cumsum` with integer data caused max recursion depth error. (:issue:`62669`)
+- Bug in :meth:`SparseArray.shift` raising for a datetimelike subtype or a boolean subtype with the default ``fill_value``, and otherwise choosing a result dtype from ``fill_value`` that disagreed with :meth:`Series.shift` (:issue:`68506`)
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/doc/source/whatsnew/v3.0.0.rst
+++ b/doc/source/whatsnew/v3.0.0.rst
@@ -1560,7 +1560,7 @@ Sparse
 - Bug in :meth:`DataFrame.sparse.from_spmatrix` which hard coded an invalid ``fill_value`` for certain subtypes. (:issue:`59063`)
 - Bug in :meth:`DataFrame.sparse.to_dense` which ignored subclassing and always returned an instance of :class:`DataFrame` (:issue:`59913`)
 - Bug in :meth:`SparseArray.cumsum` with integer data caused max recursion depth error. (:issue:`62669`)
-- Bug in :meth:`SparseArray.shift` raising for a datetimelike subtype or a boolean subtype with the default ``fill_value``, and otherwise choosing a result dtype from ``fill_value`` that disagreed with :meth:`Series.shift` (:issue:`68506`)
+- Bug in :meth:`SparseArray.shift` raising for a datetimelike subtype or a boolean subtype with the default ``fill_value``, and otherwise choosing a result dtype from ``fill_value`` that disagreed with :meth:`Series.shift` (:issue:`68580`)
 
 ExtensionArray
 ^^^^^^^^^^^^^^

--- a/pandas/core/arrays/sparse/array.py
+++ b/pandas/core/arrays/sparse/array.py
@@ -1018,7 +1018,7 @@ class SparseArray(OpsMixin, PandasObject, ExtensionArray):
         if isna(fill_value):
             fill_value = self.dtype.na_value
 
-        subtype = np.result_type(fill_value, self.dtype.subtype)
+        subtype, fill_value = _promote_for_fill(self.dtype.subtype, fill_value)
 
         if subtype != self.dtype.subtype:
             # just coerce up front

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -710,7 +710,7 @@ def test_array_interface(arr_data, arr):
 
 
 def test_shift_bool_subtype():
-    # GH#68506 np.result_type promoted the NA fill to float64, which the array's
+    # GH#68580 np.result_type promoted the NA fill to float64, which the array's
     #  own False fill_value is not valid for
     arr = SparseArray(np.array([True, False]))
     result = arr.shift(1)
@@ -724,7 +724,7 @@ def test_shift_bool_subtype():
 
 
 def test_shift_fill_value_promotion():
-    # GH#68506 np.result_type is not value-aware, so an int64 subtype both cast a
+    # GH#68580 np.result_type is not value-aware, so an int64 subtype both cast a
     #  bool fill to 1 and widened for a float fill it could hold exactly
     arr = SparseArray(np.array([1, 2, 3]))
 
@@ -739,7 +739,7 @@ def test_shift_fill_value_promotion():
 @pytest.mark.parametrize("kind", ["M8", "m8"])
 @pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
 def test_shift_datetimelike_subtype(kind, unit):
-    # GH#68506 np.result_type cannot promote a datetimelike dtype against the
+    # GH#68580 np.result_type cannot promote a datetimelike dtype against the
     #  NA fill value at all, so this raised
     dtype = f"{kind}[{unit}]"
     values = np.array([1, 2, 3], dtype="i8").astype(dtype)

--- a/pandas/tests/arrays/sparse/test_array.py
+++ b/pandas/tests/arrays/sparse/test_array.py
@@ -707,3 +707,51 @@ def test_array_interface(arr_data, arr):
     result_nocopy1 = np.array(arr2, copy=False)
     result_nocopy2 = np.array(arr2, copy=False)
     assert np.may_share_memory(result_nocopy1, result_nocopy2)
+
+
+def test_shift_bool_subtype():
+    # GH#68506 np.result_type promoted the NA fill to float64, which the array's
+    #  own False fill_value is not valid for
+    arr = SparseArray(np.array([True, False]))
+    result = arr.shift(1)
+    expected = SparseArray(np.array([np.nan, True], dtype=object), fill_value=False)
+    tm.assert_sp_array_equal(result, expected)
+
+    # an explicit bool fill needs no promotion
+    tm.assert_sp_array_equal(
+        arr.shift(1, fill_value=True), SparseArray(np.array([True, True]))
+    )
+
+
+def test_shift_fill_value_promotion():
+    # GH#68506 np.result_type is not value-aware, so an int64 subtype both cast a
+    #  bool fill to 1 and widened for a float fill it could hold exactly
+    arr = SparseArray(np.array([1, 2, 3]))
+
+    result = arr.shift(1, fill_value=True)
+    assert result.dtype == pd.SparseDtype(object, 0)
+    assert result[0] is True
+
+    result = arr.shift(1, fill_value=2.0)
+    tm.assert_sp_array_equal(result, SparseArray(np.array([2, 1, 2])))
+
+
+@pytest.mark.parametrize("kind", ["M8", "m8"])
+@pytest.mark.parametrize("unit", ["s", "ms", "us", "ns"])
+def test_shift_datetimelike_subtype(kind, unit):
+    # GH#68506 np.result_type cannot promote a datetimelike dtype against the
+    #  NA fill value at all, so this raised
+    dtype = f"{kind}[{unit}]"
+    values = np.array([1, 2, 3], dtype="i8").astype(dtype)
+    arr = SparseArray(values)
+
+    result = arr.shift(1)
+    expected = SparseArray(np.array(["NaT", values[0], values[1]], dtype=dtype))
+    tm.assert_sp_array_equal(result, expected)
+
+    # an explicit fill is a Timestamp/Timedelta, which np.result_type rejects
+    #  as a dtype
+    box = pd.Timestamp if kind == "M8" else pd.Timedelta
+    result = arr.shift(1, fill_value=box(values[2]))
+    expected = SparseArray(np.array([values[2], values[0], values[1]], dtype=dtype))
+    tm.assert_sp_array_equal(result, expected)


### PR DESCRIPTION
Noticed while looking at sparse fill-value handling; no existing issue.

`SparseArray.shift` decided its result subtype with `np.result_type(fill_value, self.dtype.subtype)`, which is neither value-aware nor dtype-safe:

- a boolean subtype with the default fill raised `ValueError: fill_value must be a valid value for the SparseDtype.subtype`, because `np.result_type(nan, bool)` is `float64` and `SparseDtype(float64, False)` fails validation;
- every datetimelike subtype raised `numpy.exceptions.DTypePromotionError` with the default fill, and `TypeError: Cannot interpret 'Timestamp(...)' as a data type` with an explicit `Timestamp`/`Timedelta` fill, since `np.result_type` was being handed a *value* where it wants a dtype;
- for other subtypes the result dtype disagreed with `Series.shift` in both directions — `fill_value=True` on an `int64` subtype was stored as `1`, and `fill_value=2.0` widened `int64` to `float64` where dense keeps `int64`.

Dense `Series.shift` handles all of these. The fix routes that one line through `_promote_for_fill`, the helper in the same module that `take`/`_take_with_fill` already use for exactly this computation (added in GH-68469).

Pre-existing rather than a recent regression: the `np.result_type` line dates to 823adcfff88 (GH-23947).

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which wrote the fix and tests and ran a multi-round review of the branch; reviewed by me before opening.