### PR TITLE
DOC: document the extension-dtype behavior change from GH#61828

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -344,6 +344,7 @@ See :ref:`install.dependencies` and :ref:`install.optional_dependencies` for mor
 Other API changes
 ^^^^^^^^^^^^^^^^^
 - :attr:`Index.values` and :attr:`Index.array` now return read-only arrays for all dtypes, so an :class:`Index` can no longer be silently corrupted by mutating the returned array in place (previously this left the Index displaying the new value while lookups still used the old one) (:issue:`38547`)
+- :class:`DataFrame` arithmetic, comparison, and logical operations with an extension-dtype :class:`Series`, :class:`Index`, or array along the default ``axis="columns"`` now follow the same rules as the operation between two :class:`Series` (``axis=0`` already did). The result keeps the extension dtype instead of falling back to NumPy -- ``Int64`` rather than ``int64``, ``boolean`` rather than ``bool`` -- so a comparison involving a missing value now yields ``NA`` instead of ``True`` or ``False``. An operation the dtype declines now raises instead of silently succeeding: arithmetic and ordering comparisons against a ``category`` Series previously operated on the categories as if they were plain scalars and now raise ``TypeError``, while equality against one is unchanged. Conversely, operations that previously raised a spurious error now succeed, such as adding an integer :class:`DataFrame` to a ``period`` Series (:issue:`61828`)
 - :class:`Timedelta` and :func:`to_timedelta` now raise on strings with trailing characters after an ``hh:mm:ss`` field, such as the AM/PM marker in ``"3:25:00 PM"``. Previously those characters were silently discarded, so ``"3:25:00 PM"`` parsed as three hours rather than fifteen (:issue:`18793`)
 - :class:`Timestamp`, :func:`to_datetime`, and :func:`read_csv` with ``parse_dates`` now return the standard library ``datetime.timezone.utc`` rather than ``dateutil.tz.tzutc()`` when a non-ISO-8601 string carries a zero UTC offset (e.g. ``"Jan 15 2004 03:00 GMT"``), so such results now repr as ``tz='UTC'`` and match what the ISO-8601 and ``format``-based paths already returned (:issue:`66827`)
 - :func:`infer_freq` on quarter-start data now reports the equivalent anchor from the first calendar quarter, e.g. ``QS-JAN`` instead of ``QS-OCT`` (:issue:`36939`)
@@ -797,7 +798,7 @@ Numeric
 - Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) for :class:`ArrowDtype` returning the biased (population) statistic instead of the bias-corrected sample statistic returned by other dtypes; :meth:`Series.kurt` also raised ``TypeError`` instead of computing a result (:issue:`66336`)
 - Fixed bug in :meth:`Series.skew` and :meth:`Series.kurt` (and their :class:`DataFrame` counterparts) returning ``0.0`` for degenerate distributions; these now return ``NaN`` (:issue:`62864`)
 - Fixed bug in complex-dtype :meth:`Series.duplicated` and :meth:`Series.unique` (and related hashtable-backed methods) raising ``TypeError`` when backed by a :class:`NumpyExtensionArray` (:issue:`54761`)
-- Fixed bug where :class:`DataFrame` arithmetic operations with :class:`Series` did not support the fill_value parameter(:issue:`61581`)
+- Fixed bug where :class:`DataFrame` arithmetic operations with :class:`Series` did not support the ``fill_value`` parameter (:issue:`61581`)
 
 Conversion
 ^^^^^^^^^^

--- a/pandas/tests/frame/test_arithmetic.py
+++ b/pandas/tests/frame/test_arithmetic.py
@@ -2391,3 +2391,93 @@ def test_sum_mixed_empty(any_string_dtype):
     )
     result = empty_df.sum()
     tm.assert_series_equal(result, expected)
+
+
+def test_frame_with_ea_series_keeps_dtype(any_numeric_ea_dtype):
+    # GH#61828 the Series used to be dispatched element-wise, so its dtype
+    # never reached the op and the result came back as numpy
+    df = pd.DataFrame([[10, 20], [30, 40]])
+    ser = pd.Series([1, 2], dtype=any_numeric_ea_dtype)
+
+    # the Series-with-Series result dtype is what the broadcast should give
+    dtype = (df[0] + ser).dtype
+    expected = pd.DataFrame([[11, 22], [31, 42]], dtype=dtype)
+    tm.assert_frame_equal(df + ser, expected)
+    tm.assert_frame_equal(df.add(ser), expected)
+
+    # comparisons keep it too, so the result is boolean rather than bool.
+    # the operand overlaps df so the result is not uniform, pinning the broadcast axis
+    overlapping = pd.Series([10, 40], dtype=any_numeric_ea_dtype)
+    dtype = (df[0] > overlapping).dtype
+    expected = pd.DataFrame([[False, False], [True, False]], dtype=dtype)
+    tm.assert_frame_equal(df > overlapping, expected)
+    expected = pd.DataFrame([[True, False], [False, True]], dtype=dtype)
+    tm.assert_frame_equal(df == overlapping, expected)
+
+
+def test_frame_with_categorical_series_raises_like_series():
+    # GH#61828 arithmetic against a Categorical used to operate on the
+    # categories as scalars instead of raising the way every other box does
+    df = pd.DataFrame([[10, 20], [30, 40]])
+    ser = pd.Series(pd.Categorical([10, 40]))
+
+    msg = "Object with dtype category cannot perform the numpy op add"
+    with pytest.raises(TypeError, match=msg):
+        df + ser
+    with pytest.raises(TypeError, match=msg):
+        df.add(ser)
+    with pytest.raises(TypeError, match=msg):
+        df[0] + ser
+
+    msg = "Unordered Categoricals can only compare equality or not"
+    with pytest.raises(TypeError, match=msg):
+        df.lt(ser)
+    with pytest.raises(TypeError, match=msg):
+        df[0].lt(ser)
+
+    # logical ops go through the same path (_logical_method is _arith_method)
+    bool_df = pd.DataFrame([[True, False], [False, True]])
+    with pytest.raises(TypeError, match="cannot perform the numpy op bitwise_and"):
+        bool_df & pd.Series(pd.Categorical([True, False]))
+
+    # an ordered Categorical is rejected as well, with its own message
+    ordered = pd.Series(pd.Categorical([1, 2], ordered=True))
+    msg = "Cannot compare a Categorical for op"
+    with pytest.raises(TypeError, match=msg):
+        df.lt(ordered)
+    with pytest.raises(TypeError, match=msg):
+        df[0].lt(ordered)
+
+    # equality is still defined for an unordered Categorical
+    expected = pd.DataFrame([[True, False], [False, True]])
+    tm.assert_frame_equal(df == ser, expected)
+
+
+def test_frame_with_ea_series_propagates_na():
+    # GH#61828 the Series used to be dispatched element-wise, so NA compared as
+    # an ordinary scalar instead of propagating
+    df = pd.DataFrame([[10, 20], [30, 40]])
+    ser = pd.Series([1, None], dtype="Int64")
+
+    result = df > ser
+    expected = pd.DataFrame([[True, None], [True, None]], dtype="boolean")
+    tm.assert_frame_equal(result, expected)
+
+    result = df == ser
+    expected = pd.DataFrame([[False, None], [False, None]], dtype="boolean")
+    tm.assert_frame_equal(result, expected)
+
+
+def test_frame_with_period_series():
+    # GH#61828 adding a period Series to an integer frame used to raise
+    df = pd.DataFrame([[10, 20], [30, 40]])
+    ser = pd.Series(pd.period_range("2020-01-01", periods=2, freq="D"))
+
+    result = df + ser
+    expected = pd.DataFrame(
+        {
+            0: pd.PeriodIndex(["2020-01-11", "2020-01-31"], freq="D"),
+            1: pd.PeriodIndex(["2020-01-22", "2020-02-11"], freq="D"),
+        }
+    )
+    tm.assert_frame_equal(result, expected)


### PR DESCRIPTION
GH-61828 enabled `fill_value` for `DataFrame`-with-`Series` flex ops by deleting the `else: return series` early-out in `_maybe_align_series_as_frame`. That has a much wider blast radius than its whatsnew entry (which mentions only `fill_value`) suggests: along the default `axis="columns"`, an extension-dtype right operand is now broadcast and run through the blockwise path instead of being dispatched element-by-element as scalars, which changed

- the result dtype (`Int64` rather than `int64`, `boolean` rather than `bool`),
- the result *values* wherever NA is involved — `df > Series([1, None], dtype="Int64")` used to give `False` in the NA column and now gives `NA`,
- and which operations raise: arithmetic and ordering comparisons against a `category` Series used to operate on the categories as if they were plain scalars, and now raise `TypeError` the way `Series`-with-`Series`, `DataFrame`-with-`DataFrame`, and `Categorical`-with-scalar always did. Conversely a few operations that raised spuriously, such as adding an integer frame to a `period` Series, now succeed.

Logical `&`/`|`/`^` travel the same path (`_logical_method is _arith_method`), as do `Index` and bare `ExtensionArray` right operands. `axis=0` was already behaving this way and is unchanged.

This adds an `Other API changes` entry for all of it, plus regression tests. No test covered a `DataFrame` operated against an extension-dtype `Series` at all, which is why the change shipped through green CI; all four new tests fail if GH-61828 is reverted.

No source change. This started as a follow-up to an audit finding that called the `category` works-to-raises a regression to be fixed before 3.1; on investigation the new behavior is the correct one — `DataFrame`-with-`Series` was the only box in which Categorical arithmetic succeeded, and only because the dtype never reached the operation — so the finding was closed as `wontfix` and the gap turned out to be documentation and test coverage.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which investigated the audit finding, wrote the entry and tests, and verified each documented claim by A/B-ing against the pre-GH-61828 helper.