### PR TITLE
BUG: unstack added a column for a level value no row used (GH#68588)

### DIFF
--- a/doc/source/whatsnew/v3.1.0.rst
+++ b/doc/source/whatsnew/v3.1.0.rst
@@ -1133,6 +1133,7 @@ Reshaping
 - Bug in :meth:`Series.combine` passing a :class:`Series` instead of a scalar to ``func`` when the index contained duplicated labels; occurrences of a duplicated label are now paired in order (:issue:`67446`)
 - Bug in :meth:`Series.combine` using ``fill_value`` instead of the value from ``other`` when the two indexes had labels that compare equal but differ in dtype, e.g. ``True`` and ``1`` (:issue:`67446`)
 - Bug in :meth:`Series.combine` with :class:`MultiIndex` inputs of different numbers of levels returning incorrect results or raising ``AssertionError``; now raises ``ValueError`` (:issue:`67446`)
+- Bug in :meth:`Series.unstack` adding a spurious all-NaN column when the unstacked level held a value that no row used, and in :meth:`Series.unstack` and :meth:`DataFrame.unstack` raising on such an index when ``sort=False`` (:issue:`68588`)
 - Bug in :meth:`Series.unstack` with ``sort=False`` always placing a ``NaN`` column first without reordering the corresponding values (:issue:`66672`)
 - Fixed bug in :meth:`DataFrame.pivot_table` with ``margins=True`` and a dictionary ``aggfunc`` raising ``KeyError`` when a column in the data is missing from the dictionary (:issue:`66151`)
 - Fixed bug in :meth:`Series.sort_values` where ``ignore_index=True`` had no effect on an already-sorted Series (:issue:`65833`)

--- a/pandas/core/reshape/reshape.py
+++ b/pandas/core/reshape/reshape.py
@@ -124,10 +124,6 @@ class _Unstacker:
         self.constructor = constructor
         self.sort = sort
 
-        # remove_unused_levels ensures every value in the unstacked level
-        # has at least one entry, which guarantees that the mask returned by
-        # get_new_values satisfies mask.any(0).all() i.e. no column in the
-        # unstacked result is entirely empty.
         self.index = index.remove_unused_levels()
 
         self.level = self.index._get_level_number(level)
@@ -146,6 +142,7 @@ class _Unstacker:
         self.removed_level = self.new_index_levels.pop(self.level)
         self.removed_level_full = index.levels[self.level]
         self.unique_nan_index: int = -1
+        self._level_code_map: npt.NDArray[np.intp] | None = None
         if not self.sort:
             unique_codes: np.ndarray = unique(self.index.codes[self.level])
             if self.has_nan:
@@ -157,6 +154,17 @@ class _Unstacker:
 
             self.removed_level = self.removed_level.take(unique_codes)
             self.removed_level_full = self.removed_level_full.take(unique_codes)
+        elif any(lev.hasnans for lev in self.index.levels):
+            # remove_unused_levels returns the index unpruned when a level holds
+            #  NaN as a value (GH#37510) -- and only then -- so the unstacked
+            #  level can keep a value no row uses, which would get a column of
+            #  its own below.
+            level_codes = self.index.codes[self.level]
+            used = np.zeros(len(self.removed_level), dtype=bool)
+            used[level_codes[level_codes != -1]] = True
+            if not used.all():
+                self.removed_level = self.removed_level[used]
+                self._level_code_map = np.cumsum(used, dtype=np.intp) - 1
 
         if config["mode"]["performance_warnings"]:
             # Bug fix GH 20601
@@ -212,7 +220,10 @@ class _Unstacker:
         level_codes = self.index.codes[self.level]
         if self.sort:
             # -1 for NaN; self.lift shifts those into position 0.
-            return level_codes
+            if self._level_code_map is None:
+                return level_codes
+            # renumber past the dropped entries, keeping -1 for NaN
+            return np.where(level_codes == -1, -1, self._level_code_map[level_codes])
         # removed_level is in order of first appearance, and so is this, with
         #  NaN numbered wherever it first appeared (see unique_nan_index).
         return factorize(level_codes)[0]
@@ -222,7 +233,7 @@ class _Unstacker:
         # libreshape.unstack walks the values in the order they occupy in the
         #  result, so sort the rows by (result row, result column).
         comp_index, ngroups = self._comp_index_and_ngroups
-        stride = self.index.levshape[self.level] + self.has_nan
+        stride = len(self.removed_level) + self.has_nan
         keys = [comp_index, self._unstacked_level_codes]
 
         # xnull=False shifts a -1 code to 0, which is where _make_selectors puts
@@ -246,7 +257,7 @@ class _Unstacker:
     def _make_selectors(self) -> None:
         comp_index, ngroups = self._comp_index_and_ngroups
 
-        stride = self.index.levshape[self.level] + self.has_nan
+        stride = len(self.removed_level) + self.has_nan
         self.full_shape = ngroups, stride
 
         # make the mask

--- a/pandas/tests/frame/test_stack_unstack.py
+++ b/pandas/tests/frame/test_stack_unstack.py
@@ -1603,6 +1603,80 @@ def test_unstack_monotonic_values_unsorted_codes():
     assert result.loc["a", 1] == 10
 
 
+@pytest.mark.parametrize("sort", [True, False])
+@pytest.mark.parametrize("dtype", ["int64", "Int64", "mixed"])
+@pytest.mark.parametrize(
+    "level, level_codes",
+    [(["x", np.nan], [0, -1]), ([np.nan, "x"], [1, -1])],
+    ids=["unused-last", "unused-first"],
+)
+def test_unstack_level_with_unused_entry(sort, dtype, level, level_codes):
+    # GH#68588 remove_unused_levels returns the index unpruned when a level holds
+    #  NaN as a value (GH#37510), so the unstacked level can keep a value no row
+    #  uses. That entry used to get a column of its own, duplicating the NaN
+    #  column under sort=True and leaving the blocks out of step with the columns
+    #  under sort=False.
+    index = pd.MultiIndex(
+        levels=[["a", "b"], level], codes=[[0, 1], level_codes], names=["i", "j"]
+    )
+    if dtype == "mixed":
+        # two numpy blocks: the one shape that used to corrupt silently rather
+        #  than raise, so the to_numpy check below has something to catch
+        df = pd.DataFrame({"A": [1, 2], "B": [3.0, 4.0]}, index=index)
+    else:
+        df = pd.DataFrame({"A": [1, 2], "B": [3, 4]}, index=index, dtype=dtype)
+
+    result = df.unstack("j", sort=sort)
+
+    if sort:
+        # the unused entry stays in the level, but no code points at it
+        col_level, x_pos = level, level.index("x")
+        codes = [-1, x_pos, -1, x_pos]
+        values = [[np.nan, 1.0, np.nan, 3.0], [2.0, np.nan, 4.0, np.nan]]
+    else:
+        col_level = ["x"]
+        codes = [0, -1, 0, -1]
+        values = [[1.0, np.nan, 3.0, np.nan], [np.nan, 2.0, np.nan, 4.0]]
+    expected = pd.DataFrame(
+        values,
+        index=pd.Index(["a", "b"], name="i"),
+        columns=pd.MultiIndex(
+            levels=[["A", "B"], col_level],
+            codes=[[0, 0, 1, 1], codes],
+            names=[None, "j"],
+        ),
+    )
+    if dtype == "Int64":
+        # an EA column keeps its dtype, and unstacks through ExtensionBlock
+        expected = expected.astype(dtype)
+    tm.assert_frame_equal(result, expected)
+    # assert_frame_equal reads the columns one at a time, so it does not notice
+    #  blocks that are wider than the placement they were given
+    tm.assert_numpy_array_equal(result.to_numpy(), expected.to_numpy())
+
+
+@pytest.mark.parametrize("sort", [True, False])
+def test_unstack_unused_entry_from_nan_in_other_level(sort):
+    # GH#68588 The NaN that stops remove_unused_levels can sit in a different
+    #  level, leaving the unstacked level holding an ordinary unused value.
+    index = pd.MultiIndex(
+        levels=[["x", np.nan], ["a", "b", "c"]],
+        codes=[[0, -1, 0], [0, 1, 1]],
+        names=["i", "j"],
+    )
+    ser = pd.Series([1.0, 2.0, 3.0], index=index)
+
+    result = ser.unstack("j", sort=sort)
+
+    order = [np.nan, "x"] if sort else ["x", np.nan]
+    expected = pd.DataFrame(
+        [[np.nan, 2.0], [1.0, 3.0]] if sort else [[1.0, 3.0], [np.nan, 2.0]],
+        index=pd.Index(order, name="i"),
+        columns=pd.Index(["a", "b"], name="j"),
+    )
+    tm.assert_frame_equal(result, expected)
+
+
 def test_unstack_fill_frame_object():
     # GH12815 Test unstacking with object.
     data = pd.Series(["a", "b", "c", "a"], dtype="object")


### PR DESCRIPTION
`_Unstacker` assumed that after `remove_unused_levels()` every value of the unstacked level is used by some row. That is false by design — `remove_unused_levels` returns the index unpruned when a level holds NaN as a value, so the level keeps its unused NaN entry (GH-37510). That entry then got a column of its own: a duplicate NaN column under `sort=True`, and under `sort=False` a width disagreement between `get_new_values` and `get_new_columns` that raised, or on a mixed-dtype frame left blocks wider than the placements they were given.

Fix: narrow `removed_level` to the used entries under `sort=True`, renumber the level codes to match, and use one `stride` expression at all four sites (two used `levshape[level] + has_nan`, which agrees only when nothing is unused). The narrowing is gated on `any(lev.hasnans for lev in self.index.levels)`, since the GH-37510 bail-out is the only way `remove_unused_levels` returns unpruned; without the gate it cost ~7% of a 1M-row `Series.unstack`.

Found while auditing GH-64516, which removed the mask-based empty-column filtering on the strength of that assumption. That PR's Cython simplification is untouched here.

AI disclosure: drafted with Claude Code (`claude opus 5 (high)`), which reproduced the bug, wrote the fix and tests, and ran a multi-round blind review of the branch.
